### PR TITLE
Move push and PR creation from Claude to the agent

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -165,8 +165,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			CreatedAt:    time.Now(),
 		}
 
-		pushRemote := a.pushRemoteName()
-		prompt := buildImplementationPrompt(issue, a.cfg.SignedOffBy, a.cfg.Owner, a.cfg.Repo, pushRemote)
+		prompt := buildImplementationPrompt(issue, a.cfg.SignedOffBy)
 		_, err = runClaude(ctx, a.runner, worktreePath, prompt, a.cfg, a.logger, false)
 		if err != nil {
 			a.logger.Error("claude failed", "issue", issue.Number, "error", err)
@@ -180,23 +179,55 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			continue
 		}
 
-		_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
-
-		// Find the PR created by Claude
-		prs, err = a.gh.ListPRsByHead(ctx, a.cfg.Owner, a.cfg.Repo, a.cfg.GitHubHeadOwner, branchName)
-		if err != nil {
-			a.logger.Error("failed to list PRs", "issue", issue.Number, "error", err)
-		} else {
-			for _, p := range prs {
-				if p.State == "open" {
-					work.PRNumber = p.Number
-					work.Status = "pr-open"
-					a.logger.Info("found PR", "issue", issue.Number, "pr", work.PRNumber)
-					break
-				}
-			}
+		// Check if Claude produced any commits
+		logOut, _, _ := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--oneline")
+		if len(strings.TrimSpace(string(logOut))) == 0 {
+			a.logger.Warn("claude finished but produced no commits", "issue", issue.Number)
+			work.Status = "failed"
+			a.state.ActiveIssues[issue.Number] = work
+			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
+			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, "ai-failed")
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number,
+				fmt.Sprintf("AI agent finished but produced no commits for this issue.\n\n%s", botMarker))
+			continue
 		}
 
+		// Push the branch
+		if err := a.gitPush(ctx, worktreePath, false); err != nil {
+			a.logger.Error("failed to push branch", "issue", issue.Number, "error", err)
+			work.Status = "failed"
+			a.state.ActiveIssues[issue.Number] = work
+			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
+			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, "ai-failed")
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number,
+				fmt.Sprintf("AI agent failed to push branch: %v\n\n%s", err, botMarker))
+			continue
+		}
+
+		// Create PR
+		prHead := branchName
+		if a.cfg.GitHubHeadOwner != "" && a.cfg.GitHubHeadOwner != a.cfg.Owner {
+			prHead = a.cfg.GitHubHeadOwner + ":" + branchName
+		}
+		prTitle := issue.Title
+		prBody := a.buildPRBody(ctx, worktreePath, issue.Number)
+		prNumber, err := a.gh.CreatePR(ctx, a.cfg.Owner, a.cfg.Repo, prTitle, prBody, prHead, a.defaultBranch())
+		if err != nil {
+			a.logger.Error("failed to create PR", "issue", issue.Number, "error", err)
+			work.Status = "failed"
+			a.state.ActiveIssues[issue.Number] = work
+			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
+			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, "ai-failed")
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number,
+				fmt.Sprintf("AI agent failed to create PR: %v\n\n%s", err, botMarker))
+			continue
+		}
+
+		work.PRNumber = prNumber
+		work.Status = "pr-open"
+		a.logger.Info("created PR", "issue", issue.Number, "pr", prNumber)
+
+		_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
 		a.state.ActiveIssues[issue.Number] = work
 	}
 }
@@ -694,6 +725,14 @@ func (a *Agent) originDefaultBranch() string {
 		return wtm.OriginDefaultBranch()
 	}
 	return "origin/main"
+}
+
+// defaultBranch returns the default branch name (e.g. "main", "master").
+func (a *Agent) defaultBranch() string {
+	if wtm, ok := a.worktrees.(*GitWorktreeManager); ok {
+		return wtm.DefaultBranch()
+	}
+	return "main"
 }
 
 // buildPRBody constructs a PR description from the git log of the branch.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -252,9 +252,7 @@ func TestProcessNewIssues_RechecksForPR(t *testing.T) {
 func TestProcessNewIssues_HappyPath(t *testing.T) {
 	claudeResult := streamResultJSON(ClaudeResult{Result: "Fixed it"})
 	gh := &mockGitHubClient{
-		issues:         []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		prs:            []PR{{Number: 100, State: "open", Head: "ai/issue-42"}},
-		prsAfterNCalls: 1, // skip first call (early check), return PR on second (after Claude)
+		issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
 	}
 	runner := &mockCommandRunner{stdout: claudeResult}
 	wt := &mockWorktreeManager{}
@@ -270,6 +268,7 @@ func TestProcessNewIssues_HappyPath(t *testing.T) {
 	if !ok {
 		t.Fatal("issue 42 not in state")
 	}
+	// CreatePR mock returns 100
 	if work.PRNumber != 100 {
 		t.Errorf("expected PR 100, got %d", work.PRNumber)
 	}

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -2,10 +2,10 @@ package agent
 
 import "fmt"
 
-func buildImplementationPrompt(issue Issue, signedOffBy, owner, repo, pushRemote string) string {
+func buildImplementationPrompt(issue Issue, signedOffBy string) string {
 	signoff := ""
 	if signedOffBy != "" {
-		signoff = fmt.Sprintf("\n6. Add \"Signed-off-by: %s\" as a trailer in every commit message (do NOT use git commit -s, write it directly in the message)", signedOffBy)
+		signoff = fmt.Sprintf("\n5. Add \"Signed-off-by: %s\" as a trailer in every commit message (do NOT use git commit -s, write it directly in the message)", signedOffBy)
 	}
 
 	return fmt.Sprintf(`You are resolving GitHub issue #%d.
@@ -24,14 +24,10 @@ Instructions:
 1. Read CLAUDE.md for project conventions
 2. Implement the fix for this issue
 3. Run "make lint" and "make test" to verify your changes
-4. Commit your changes with a descriptive message (no trailing period, wrap body at 72 chars)
-5. Push to the remote using "git push %s HEAD --force"
-7. Create a PR using "gh pr create --repo %s/%s" with:
-   - "Fixes #%d" in the PR body
-   - If .github/PULL_REQUEST_TEMPLATE.md exists in the repo, follow its format for the PR body%s
+4. Commit your changes with a descriptive message (no trailing period, wrap body at 72 chars)%s
 
-Do not merge the PR. Only create it.`,
-		issue.Number, issue.Title, issue.Body, pushRemote, owner, repo, issue.Number, signoff)
+Do NOT push, create PRs, or amend — the agent handles that automatically.`,
+		issue.Number, issue.Title, issue.Body, signoff)
 }
 
 func buildReviewResponsePrompt(work IssueWork, comments []ReviewComment, reviews []PRReview, owner, repo string) string {

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -13,7 +13,7 @@ func TestBuildImplementationPrompt(t *testing.T) {
 		Labels: []string{"good-for-ai"},
 	}
 
-	prompt := buildImplementationPrompt(issue, "", "owner", "repo", "origin")
+	prompt := buildImplementationPrompt(issue, "")
 
 	checks := []string{
 		"#42",
@@ -22,10 +22,7 @@ func TestBuildImplementationPrompt(t *testing.T) {
 		"<user-provided-content>",
 		"</user-provided-content>",
 		"untrusted user input",
-		"Fixes #42",
-		"gh pr create",
-		"PULL_REQUEST_TEMPLATE",
-		"git push origin",
+		"Do NOT push",
 	}
 
 	for _, want := range checks {
@@ -34,8 +31,19 @@ func TestBuildImplementationPrompt(t *testing.T) {
 		}
 	}
 
+	// Must NOT contain push/PR instructions
+	forbidden := []string{
+		"gh pr create",
+		"git push",
+	}
+	for _, bad := range forbidden {
+		if strings.Contains(prompt, bad) {
+			t.Errorf("prompt should NOT contain %q", bad)
+		}
+	}
+
 	// With signed-off-by
-	prompt = buildImplementationPrompt(issue, "Test User <test@example.com>", "owner", "repo", "origin")
+	prompt = buildImplementationPrompt(issue, "Test User <test@example.com>")
 	if !strings.Contains(prompt, "Signed-off-by: Test User <test@example.com>") {
 		t.Error("prompt missing Signed-off-by when provided")
 	}

--- a/specs/loop.md
+++ b/specs/loop.md
@@ -16,7 +16,7 @@ type Agent struct {
 ## Methods
 
 - `(a *Agent) CleanupDone(ctx)` -- remove worktrees for merged/closed PRs
-- `(a *Agent) ProcessNewIssues(ctx)` -- find labeled issues, create worktrees, run Claude, create PRs
+- `(a *Agent) ProcessNewIssues(ctx)` -- find labeled issues, create worktrees, run Claude, push branch, create PR via GitHub API
 - `(a *Agent) ProcessReviewComments(ctx)` -- check for new review comments, run Claude to address them
 - `(a *Agent) isAllowedReviewer(user string) bool` -- checks if user is in reviewers whitelist (empty = allow all)
 - `(a *Agent) HasWatchedPRs() bool` -- returns true if `cfg.WatchPRs` is non-empty
@@ -31,6 +31,7 @@ When `--watch-prs` is set, `BootstrapWatchedPRs` runs instead of `ProcessNewIssu
 ### ProcessNewIssues behavior
 - Skips issues already in state (unless `prNumber == 0` and status is `implementing`, in which case it re-checks for the PR)
 - Cleans up stale worktrees/branches before creating new ones
+- After Claude finishes, the agent pushes the branch and creates the PR (Claude does NOT push or create PRs)
 
 ### ProcessReviewComments behavior
 - Filters comments through the reviewers whitelist
@@ -43,7 +44,7 @@ When `--watch-prs` is set, `BootstrapWatchedPRs` runs instead of `ProcessNewIssu
 All interfaces mocked:
 
 - `TestProcessNewIssues_SkipsAlreadyTracked` -- issue in state is not re-processed
-- `TestProcessNewIssues_HappyPath` -- creates worktree, runs claude, extracts PR, updates state
+- `TestProcessNewIssues_HappyPath` -- creates worktree, runs claude, agent pushes and creates PR, updates state
 - `TestProcessNewIssues_ClaudeFailure` -- adds `ai-failed` label, comments on issue
 - `TestProcessReviewComments_NoNewComments` -- no action taken
 - `TestProcessReviewComments_AddressesHumanComments` -- runs claude, updates lastCommentID

--- a/specs/prompts.md
+++ b/specs/prompts.md
@@ -6,8 +6,8 @@ Tells Claude to:
 - Read Claude.md for conventions
 - Implement the fix, run `make lint` and `make test`
 - Commit (no trailing period, 72 char body)
-- Create PR via `gh pr create` with `/kind`, `Fixes #N`, release-note block
 - If signedOffBy is non-empty, add `Signed-off-by:` to every commit message
+- Do NOT push, create PRs, or amend — the agent handles that automatically
 
 ## `buildReviewResponsePrompt(work IssueWork, comments []ReviewComment, signedOffBy string) string`
 
@@ -21,5 +21,5 @@ Tells Claude to:
 
 ## Tests (`prompt_test.go`)
 
-- `TestBuildImplementationPrompt` -- verifies issue number, title, body are interpolated; `/kind` and `release-note` instructions present
+- `TestBuildImplementationPrompt` -- verifies issue number, title, body are interpolated; verifies push/PR instructions are absent
 - `TestBuildReviewResponsePrompt` -- verifies each comment's file/line/body is included


### PR DESCRIPTION
## Summary

- Claude was instructed to `git push` and `gh pr create`, but it pushed the branch without creating a PR (issue #2), leaving a dangling branch with no PR
- The review, CI-fix, and conflict-resolution flows already handle push/PR automatically — the implementation flow was the odd one out
- Now the agent pushes the branch and creates the PR via the GitHub API after Claude finishes committing

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestBuildImplementationPrompt` verifies prompt does NOT contain `git push` or `gh pr create`
- [x] `TestProcessNewIssues_HappyPath` verifies the agent creates the PR via `CreatePR`
- [ ] Deploy and verify the agent creates PRs correctly for new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)