### PR TITLE
Create flaky CI issue when unrelated CI failure is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A single long-running Go binary that automatically resolves GitHub issues using 
 3. **Open PR** — pushes the branch and creates a pull request linked to the issue.
 4. **Address reviews** — picks up reviewer comments, runs Claude again to iterate.
 5. **Rebase conflicts** — detects PRs with merge conflicts, attempts an automatic rebase, and falls back to Claude if that fails.
-6. **Handle CI failures** — detects CI failures and asks Claude to fix them.
+6. **Handle CI failures** — detects CI failures and asks Claude to fix them. Optionally creates issues for unrelated CI failures (flaky tests) when `--create-flaky-issues` is enabled.
 
 Claude never merges; a human must approve and merge every PR.
 
@@ -93,6 +93,7 @@ When using GitHub App auth, the agent pushes branches directly to the upstream r
 | `--log-file` | `AI_AGENT_LOG_FILE` | stderr | Write logs to a file instead of stderr |
 | `--signed-off-by` | `AI_AGENT_SIGNED_OFF_BY` | auto-detected | `Signed-off-by` line for commits |
 | `--reviewers` | `AI_AGENT_REVIEWERS` | all | Comma-separated allowlist of reviewers to respond to |
+| `--create-flaky-issues` | `AI_AGENT_CREATE_FLAKY_ISSUES` | `false` | Create issues for unrelated CI failures (opt-in) |
 | `--dry-run` | — | `false` | Log actions without executing them |
 | `--one-shot` | — | `false` | Run one poll cycle and exit |
 | — | `GITHUB_TOKEN` | *required (PAT)* | GitHub personal access token |

--- a/cmd/ai-agent/main.go
+++ b/cmd/ai-agent/main.go
@@ -49,6 +49,8 @@ func parseConfig() agent.Config {
 	var logFile string
 	flag.StringVar(&logFile, "log-file", os.Getenv("AI_AGENT_LOG_FILE"), "Log file path (default: stderr)")
 
+	flag.BoolVar(&cfg.CreateFlakyIssues, "create-flaky-issues", envOrDefault("AI_AGENT_CREATE_FLAKY_ISSUES", "") == "true", "Create issues for unrelated CI failures (opt-in)")
+
 	var forkFlag string
 	flag.StringVar(&forkFlag, "fork", envOrDefault("AI_AGENT_FORK", ""), "Fork repo as owner/repo for pushing (e.g. qinqon/ovn-kubernetes)")
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -24,8 +24,9 @@ type Config struct {
 	GitAuthorName   string   // git commit author name
 	GitAuthorEmail  string   // git commit author email
 	Reviewers       []string // whitelist of users/bots whose reviews to address
-	WatchPRs        []int    // PR numbers to monitor directly (bypasses issue discovery)
-	Reactions       []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
+	WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
+	Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
+	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
 
 	// GitHub App authentication (alternative to GITHUB_TOKEN)
 	GitHubAppID             int64

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -36,6 +36,7 @@ type GitHubClient interface {
 	HasLinkedPR(ctx context.Context, owner, repo string, issueNumber int) (bool, error)
 	GetPR(ctx context.Context, owner, repo string, prNumber int) (PR, error)
 	IsPRBehind(ctx context.Context, owner, repo string, prNumber int) (bool, error)
+	CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (int, error)
 }
 
 // GoGitHubClient implements GitHubClient using go-github.
@@ -428,6 +429,19 @@ func (g *GoGitHubClient) IsPRBehind(ctx context.Context, owner, repo string, prN
 	}
 
 	return comparison.GetBehindBy() > 0, nil
+}
+
+func (g *GoGitHubClient) CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (int, error) {
+	req := &github.IssueRequest{
+		Title:  &title,
+		Body:   &body,
+		Labels: &labels,
+	}
+	issue, _, err := g.client.Issues.Create(ctx, owner, repo, req)
+	if err != nil {
+		return 0, fmt.Errorf("creating issue: %w", err)
+	}
+	return issue.GetNumber(), nil
 }
 
 // GetAuthenticatedUser returns the login, name, and email of the authenticated user.

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -351,3 +351,40 @@ func TestGetAuthenticatedUser_FallbackToLogin(t *testing.T) {
 		t.Errorf("expected noreply email fallback, got %q", email)
 	}
 }
+
+func TestCreateIssue(t *testing.T) {
+	var receivedTitle, receivedBody string
+	var receivedLabels []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		var req github.IssueRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		receivedTitle = req.GetTitle()
+		receivedBody = req.GetBody()
+		receivedLabels = *req.Labels
+		issue := &github.Issue{
+			Number: github.Ptr(123),
+			Title:  req.Title,
+			Body:   req.Body,
+		}
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	gh := setupTestClient(t, mux)
+	issueNum, err := gh.CreateIssue(context.Background(), "owner", "repo", "Test Issue", "Test body", []string{"flaky-test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if issueNum != 123 {
+		t.Errorf("expected issue number 123, got %d", issueNum)
+	}
+	if receivedTitle != "Test Issue" {
+		t.Errorf("expected title 'Test Issue', got %q", receivedTitle)
+	}
+	if receivedBody != "Test body" {
+		t.Errorf("expected body 'Test body', got %q", receivedBody)
+	}
+	if len(receivedLabels) != 1 || receivedLabels[0] != "flaky-test" {
+		t.Errorf("expected labels ['flaky-test'], got %v", receivedLabels)
+	}
+}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -242,6 +242,19 @@ func (f *fakeGitHubClient) IsPRBehind(_ context.Context, _, _ string, _ int) (bo
 	return false, nil
 }
 
+func (f *fakeGitHubClient) CreateIssue(_ context.Context, _, _ string, title, body string, labels []string) (int, error) {
+	f.state.mu.Lock()
+	defer f.state.mu.Unlock()
+	issueNum := len(f.state.issues) + 1
+	f.state.issues = append(f.state.issues, Issue{
+		Number: issueNum,
+		Title:  title,
+		Body:   body,
+		Labels: labels,
+	})
+	return issueNum, nil
+}
+
 // initBareRepo creates a bare repo and a working clone for the agent to use.
 // Returns (cloneDir, cleanup).
 func initBareRepo(t *testing.T) string {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -461,6 +461,29 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(headSHA), explanation, botMarker)
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, comment)
 			work.LastCIStatus = "unrelated-failure"
+
+			// Create a flaky CI issue if configured
+			if a.cfg.CreateFlakyIssues {
+				issueTitle := fmt.Sprintf("Flaky CI: %s", failures[0].Name)
+				issueBody := fmt.Sprintf("A CI failure was detected that appears unrelated to PR changes.\n\n"+
+					"**Detected in PR**: #%d\n"+
+					"**Commit**: %s\n"+
+					"**Failed check**: %s\n\n"+
+					"**Analysis**:\n%s\n\n"+
+					"**Check output**:\n```\n%s\n```\n\n"+
+					"%s",
+					work.PRNumber, shortSHA(headSHA), failures[0].Name, explanation, failures[0].Output, botMarker)
+				issueNum, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
+				if err != nil {
+					a.logger.Error("failed to create flaky CI issue", "error", err)
+				} else {
+					a.logger.Info("created flaky CI issue", "issue", issueNum)
+					// Update the PR comment to reference the created issue
+					_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+						fmt.Sprintf("Opened issue #%d to track this flaky test.\n\n%s", issueNum, botMarker))
+				}
+			}
+
 			continue
 		}
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -20,11 +20,13 @@ type mockGitHubClient struct {
 	removedLabels  []string
 	addedReactions []string
 	checkRuns      []CheckRun
-	prHeadSHAs     []string // returns these in sequence; if empty returns "abc123"
-	prsAfterNCalls int      // only return PRs after this many ListPRsByHead calls
-	prsCallCount   int
-	mergeableState string   // mergeable state to return from GetPRMergeable (default: "clean")
-	prBehind       bool     // whether IsPRBehind returns true
+	prHeadSHAs      []string // returns these in sequence; if empty returns "abc123"
+	prsAfterNCalls  int      // only return PRs after this many ListPRsByHead calls
+	prsCallCount    int
+	mergeableState  string   // mergeable state to return from GetPRMergeable (default: "clean")
+	prBehind        bool     // whether IsPRBehind returns true
+	createdIssues   []Issue  // tracks issues created via CreateIssue
+	nextIssueNumber int      // next issue number to return (defaults to 1)
 
 	listIssuesErr error
 }
@@ -153,6 +155,21 @@ func (m *mockGitHubClient) AssignIssue(_ context.Context, _, _ string, _ int, _ 
 
 func (m *mockGitHubClient) UnassignIssue(_ context.Context, _, _ string, _ int, _ string) error {
 	return nil
+}
+
+func (m *mockGitHubClient) CreateIssue(_ context.Context, _, _ string, title, body string, labels []string) (int, error) {
+	if m.nextIssueNumber == 0 {
+		m.nextIssueNumber = 1
+	}
+	issueNum := m.nextIssueNumber
+	m.nextIssueNumber++
+	m.createdIssues = append(m.createdIssues, Issue{
+		Number: issueNum,
+		Title:  title,
+		Body:   body,
+		Labels: labels,
+	})
+	return issueNum, nil
 }
 
 // mockWorktreeManager implements WorktreeManager for testing.
@@ -627,6 +644,81 @@ func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
 
 	if len(runner.calls) != 0 {
 		t.Error("should not invoke claude while CI is still running")
+	}
+}
+
+func TestProcessCIFailures_CreatesFlakYIssueWhenUnrelated(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true // Enable flaky issue creation
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that a flaky issue was created
+	if len(gh.createdIssues) != 1 {
+		t.Fatalf("expected 1 created issue, got %d", len(gh.createdIssues))
+	}
+	issue := gh.createdIssues[0]
+	if issue.Title != "Flaky CI: integration-tests" {
+		t.Errorf("expected title 'Flaky CI: integration-tests', got %q", issue.Title)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0] != "flaky-test" {
+		t.Errorf("expected labels ['flaky-test'], got %v", issue.Labels)
+	}
+
+	// Check that a comment was added to the PR
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (unrelated + issue link), got %d", len(gh.addedComments))
+	}
+}
+
+func TestProcessCIFailures_SkipsFlakYIssueWhenDisabled(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false // Disabled by default
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that no flaky issue was created
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues when feature is disabled, got %d", len(gh.createdIssues))
+	}
+
+	// Check that only one comment was added (the unrelated notice)
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment (unrelated notice), got %d", len(gh.addedComments))
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -647,7 +647,7 @@ func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
 	}
 }
 
-func TestProcessCIFailures_CreatesFlakYIssueWhenUnrelated(t *testing.T) {
+func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{
@@ -688,7 +688,7 @@ func TestProcessCIFailures_CreatesFlakYIssueWhenUnrelated(t *testing.T) {
 	}
 }
 
-func TestProcessCIFailures_SkipsFlakYIssueWhenDisabled(t *testing.T) {
+func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{

--- a/specs/config.md
+++ b/specs/config.md
@@ -4,20 +4,21 @@
 
 ```go
 type Config struct {
-    Owner         string
-    Repo          string
-    Label         string
-    CloneDir      string
-    StatePath     string
-    PollInterval  time.Duration
-    VertexRegion  string
-    VertexProject string
-    LogLevel      string
-    DryRun        bool
-    SignedOffBy   string
-    Reviewers     []string // whitelist of users/bots whose reviews to address
-    WatchPRs      []int    // PR numbers to monitor directly (bypasses issue discovery)
-    Reactions     []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
+    Owner             string
+    Repo              string
+    Label             string
+    CloneDir          string
+    StatePath         string
+    PollInterval      time.Duration
+    VertexRegion      string
+    VertexProject     string
+    LogLevel          string
+    DryRun            bool
+    SignedOffBy       string
+    Reviewers         []string // whitelist of users/bots whose reviews to address
+    WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
+    Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
+    CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
 }
 ```
 
@@ -38,6 +39,7 @@ type Config struct {
 | `AI_AGENT_REVIEWERS` | `--reviewers` | (empty = all) | Comma-separated whitelist of users/bots whose reviews to address |
 | `AI_AGENT_WATCH_PRS` | `--watch-prs` | (empty) | Comma-separated PR numbers to monitor directly (bypasses issue discovery) |
 | `AI_AGENT_REACTIONS` | `--reactions` | (empty = all) | Comma-separated list of reactions to run: `reviews`, `ci`, `conflicts` |
+| `AI_AGENT_CREATE_FLAKY_ISSUES` | `--create-flaky-issues` | `false` | When true, create issues for unrelated CI failures (opt-in) |
 
 Config from env vars (`AI_AGENT_*`) with flag overrides, read in `main()`.
 

--- a/specs/github-client.md
+++ b/specs/github-client.md
@@ -34,6 +34,7 @@ type GitHubClient interface {
 | `AddPRCommentReaction` | `client.Reactions.CreatePullRequestCommentReaction()` |
 | `GetPR` | `client.PullRequests.Get()`, returns `PR{Number, Title, State, Merged, Head}` |
 | `GetAuthenticatedUser` | `client.Users.Get("")`, returns name + email with login/noreply fallbacks |
+| `CreateIssue` | `client.Issues.Create()`, creates a new issue with title, body, and labels |
 
 ## Additional Methods (on concrete type, not interface)
 
@@ -55,3 +56,4 @@ Use `net/http/httptest` with canned JSON responses. Point go-github client at te
 - `TestListPRsByHead` -- filters by branch
 - `TestGetAuthenticatedUser_WithNameAndEmail` -- returns name and email
 - `TestGetAuthenticatedUser_FallbackToLogin` -- falls back to login and noreply email
+- `TestCreateIssue` -- creates an issue and returns its number


### PR DESCRIPTION
Fixes #2

Update README to document --create-flaky-issues flag

Add documentation for the new --create-flaky-issues flag that enables
automatic issue creation for unrelated CI failures.

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---
Fix typo in test function names

Change "FlakY" to "Flaky" in test function names for consistency with
proper spelling.

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---
Add opt-in flag to create issues for unrelated CI failures

When --create-flaky-issues is enabled and Claude determines a CI failure
is unrelated to PR changes, automatically create a new issue to track
the flaky test or infrastructure problem. The created issue includes:
- Failed check name in the title
- PR number, commit SHA, and analysis in the body
- "flaky-test" label for filtering
- Link back to the original PR

This helps maintain visibility into CI reliability without blocking PR
progress.

Fixes #2

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->