### PR TITLE
CI investigation repeats every poll cycle due to markdown prefix mismatch and silent comment failures

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -397,8 +397,15 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
-		// Check if we already investigated this SHA by looking for a bot comment
+		// Check if we already investigated this SHA (in-memory dedup)
+		if work.LastCheckedCISHA == headSHA {
+			continue
+		}
+
+		// Fallback: check if we already investigated this SHA by looking for a bot comment
+		// (handles state recovery after restarts)
 		if a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
+			work.LastCheckedCISHA = headSHA
 			continue
 		}
 
@@ -449,18 +456,26 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			a.logger.Error("claude failed to investigate CI", "pr", work.PRNumber, "error", err)
 			work.CIFixAttempts++
 			work.LastCIStatus = "failure"
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-				fmt.Sprintf("CI investigation failed for commit %s: %v\n\n%s", shortSHA(headSHA), err, botMarker))
+			work.LastCheckedCISHA = headSHA
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+				fmt.Sprintf("CI investigation failed for commit %s: %v\n\n%s", shortSHA(headSHA), err, botMarker)); err != nil {
+				a.logger.Error("failed to post CI investigation error comment", "pr", work.PRNumber, "error", err)
+			}
 			continue
 		}
 
-		if strings.HasPrefix(strings.TrimSpace(result.Result), "UNRELATED") {
+		// Strip markdown formatting (bold, italic) before checking prefix
+		cleaned := strings.TrimLeft(strings.TrimSpace(result.Result), "*_")
+		if strings.HasPrefix(cleaned, "UNRELATED") {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", work.PRNumber)
-			explanation := strings.TrimPrefix(strings.TrimSpace(result.Result), "UNRELATED")
+			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
 			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(headSHA), explanation, botMarker)
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, comment)
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, comment); err != nil {
+				a.logger.Error("failed to post CI unrelated comment", "pr", work.PRNumber, "error", err)
+			}
 			work.LastCIStatus = "unrelated-failure"
+			work.LastCheckedCISHA = headSHA
 
 			// Create a flaky CI issue if configured
 			if a.cfg.CreateFlakyIssues {
@@ -479,8 +494,10 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				} else {
 					a.logger.Info("created flaky CI issue", "issue", issueNum)
 					// Update the PR comment to reference the created issue
-					_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-						fmt.Sprintf("Opened issue #%d to track this flaky test.\n\n%s", issueNum, botMarker))
+					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+						fmt.Sprintf("Opened issue #%d to track this flaky test.\n\n%s", issueNum, botMarker)); err != nil {
+						a.logger.Error("failed to post flaky issue reference comment", "pr", work.PRNumber, "error", err)
+					}
 				}
 			}
 
@@ -501,15 +518,20 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 		if pushed {
 			a.logger.Info("CI failure is related, pushed a fix", "pr", work.PRNumber)
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-				fmt.Sprintf("CI was failing on commit %s. Pushed a fix.\n\n%s", shortSHA(headSHA), botMarker))
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+				fmt.Sprintf("CI was failing on commit %s. Pushed a fix.\n\n%s", shortSHA(headSHA), botMarker)); err != nil {
+				a.logger.Error("failed to post CI fix comment", "pr", work.PRNumber, "error", err)
+			}
 		} else {
 			a.logger.Warn("Claude said RELATED but no changes to push", "pr", work.PRNumber)
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-				fmt.Sprintf("CI is failing on commit %s. Investigated but could not push a fix.\n\n%s", shortSHA(headSHA), botMarker))
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+				fmt.Sprintf("CI is failing on commit %s. Investigated but could not push a fix.\n\n%s", shortSHA(headSHA), botMarker)); err != nil {
+				a.logger.Error("failed to post CI investigation comment", "pr", work.PRNumber, "error", err)
+			}
 		}
 		work.CIFixAttempts++
 		work.LastCIStatus = "failure"
+		work.LastCheckedCISHA = headSHA
 	}
 }
 

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -37,17 +37,18 @@ type ClaudeResult struct {
 
 // IssueWork tracks the state of work on a single issue.
 type IssueWork struct {
-	IssueNumber   int       `json:"issueNumber"`
-	IssueTitle    string    `json:"issueTitle"`
-	WorktreePath  string    `json:"worktreePath"`
-	BranchName    string    `json:"branchName"`
-	PRNumber      int       `json:"prNumber"`
-	LastCommentID int64     `json:"lastCommentID"`
-	LastReviewID  int64     `json:"lastReviewID"`
-	Status        string    `json:"status"` // implementing, pr-open, failed, done
-	CIFixAttempts int       `json:"ciFixAttempts"`
-	LastCIStatus  string    `json:"lastCIStatus"` // "", "pending", "success", "failure"
-	CreatedAt     time.Time `json:"createdAt"`
+	IssueNumber      int       `json:"issueNumber"`
+	IssueTitle       string    `json:"issueTitle"`
+	WorktreePath     string    `json:"worktreePath"`
+	BranchName       string    `json:"branchName"`
+	PRNumber         int       `json:"prNumber"`
+	LastCommentID    int64     `json:"lastCommentID"`
+	LastReviewID     int64     `json:"lastReviewID"`
+	Status           string    `json:"status"` // implementing, pr-open, failed, done
+	CIFixAttempts    int       `json:"ciFixAttempts"`
+	LastCIStatus     string    `json:"lastCIStatus"`     // "", "pending", "success", "failure"
+	LastCheckedCISHA string    `json:"lastCheckedCISHA"` // last commit SHA investigated for CI failures
+	CreatedAt        time.Time `json:"createdAt"`
 }
 
 // PRReview represents a GitHub pull request review (approve, request changes, comment).


### PR DESCRIPTION
Fixes #9

Fix CI investigation repeating due to markdown and error handling

This fixes three bugs that caused CI investigations to repeat:

1. Markdown bold prefix mismatch: Claude sometimes responds with
   `**UNRELATED**` (markdown bold). Strip markdown formatting
   before checking the prefix to handle this case.

2. Silent comment failures: Comment posting errors were discarded
   with `_ =`, making failures invisible. Now all comment posting
   errors in ProcessCIFailures are logged.

3. Missing in-memory dedup: Add LastCheckedCISHA field to
   IssueWork to deduplicate investigations without GitHub API
   round-trips. The alreadyCheckedCI GitHub comment check remains
   as a fallback for state recovery after restarts.

These changes prevent wasting API credits and reduce log noise.

Fixes #9

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->