### PR TITLE
Agent should squash commits into a single commit before creating PR

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -192,8 +192,20 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			continue
 		}
 
-		// Push the branch
-		if err := a.gitPush(ctx, worktreePath, false); err != nil {
+		// Squash all commits into a single commit for cleaner git history
+		if err := a.gitSquashCommits(ctx, worktreePath, issue.Number, issue.Title); err != nil {
+			a.logger.Error("failed to squash commits", "issue", issue.Number, "error", err)
+			work.Status = "failed"
+			a.state.ActiveIssues[issue.Number] = work
+			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
+			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, "ai-failed")
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number,
+				fmt.Sprintf("AI agent failed to squash commits: %v\n\n%s", err, botMarker))
+			continue
+		}
+
+		// Push the branch (force push because squashing rewrites history)
+		if err := a.gitPush(ctx, worktreePath, true); err != nil {
 			a.logger.Error("failed to push branch", "issue", issue.Number, "error", err)
 			work.Status = "failed"
 			a.state.ActiveIssues[issue.Number] = work
@@ -820,6 +832,25 @@ func (a *Agent) gitAmendAll(ctx context.Context, worktreePath string) error {
 	}
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
 		return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
+	}
+	return nil
+}
+
+// gitSquashCommits squashes all commits since the base branch into a single commit.
+func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issueNumber int, issueTitle string) error {
+	// Reset to base branch, keeping all changes staged
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "reset", "--soft", a.originDefaultBranch()); err != nil {
+		return fmt.Errorf("git reset --soft: %w (stderr: %s)", err, string(stderr))
+	}
+
+	// Create a single commit with a meaningful message
+	commitMsg := fmt.Sprintf("Fix issue #%d: %s", issueNumber, issueTitle)
+	if a.cfg.SignedOffBy != "" {
+		commitMsg += fmt.Sprintf("\n\nSigned-off-by: %s", a.cfg.SignedOffBy)
+	}
+
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "-m", commitMsg); err != nil {
+		return fmt.Errorf("git commit: %w (stderr: %s)", err, string(stderr))
 	}
 	return nil
 }

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -958,3 +958,64 @@ func TestHasWatchedPRs(t *testing.T) {
 		t.Error("expected true with watched PRs")
 	}
 }
+
+func TestProcessNewIssues_SquashesCommits(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "Fixed it"})
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Fix the bug", Body: "broken"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify git reset --soft was called to squash commits
+	foundReset := false
+	foundCommit := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 2 {
+			if c.Args[0] == "reset" && c.Args[1] == "--soft" {
+				foundReset = true
+				// Should reset to origin/main
+				if len(c.Args) >= 3 && c.Args[2] != "origin/main" {
+					t.Errorf("expected reset to origin/main, got %v", c.Args)
+				}
+			}
+			if c.Args[0] == "commit" && c.Args[1] == "-m" {
+				foundCommit = true
+				// Verify commit message includes issue number
+				if len(c.Args) >= 3 {
+					commitMsg := c.Args[2]
+					if !containsSubstring(commitMsg, "Fix issue #42") {
+						t.Errorf("expected commit message to contain 'Fix issue #42', got: %s", commitMsg)
+					}
+					if !containsSubstring(commitMsg, "Signed-off-by") {
+						t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+					}
+				}
+			}
+		}
+	}
+
+	if !foundReset {
+		t.Error("expected git reset --soft to be called for commit squashing")
+	}
+	if !foundCommit {
+		t.Error("expected git commit to be called after squashing")
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #10

## Summary

The agent now squashes all commits on a working branch into a single commit before pushing and creating the PR. This results in cleaner git history and makes PRs easier to review.

## Implementation

- Added `gitSquashCommits()` function that uses `git reset --soft` to squash all commits since branching from main
- Creates a single commit with message format: "Fix issue #N: title"
- Includes proper error handling and failure reporting
- Added test to verify squash behavior

## Testing

- All existing tests pass
- Added `TestProcessNewIssues_SquashesCommits` to verify the squashing behavior
- Verified that `git reset --soft` is called with `origin/main`
- Verified that commit message includes issue number and Signed-off-by trailer