### PR TITLE
Agent should squash commits into a single commit before creating PR

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -192,8 +192,20 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			continue
 		}
 
-		// Push the branch
-		if err := a.gitPush(ctx, worktreePath, false); err != nil {
+		// Squash all commits into a single commit before pushing
+		if err := a.gitSquashCommits(ctx, worktreePath, issue.Number, issue.Title); err != nil {
+			a.logger.Error("failed to squash commits", "issue", issue.Number, "error", err)
+			work.Status = "failed"
+			a.state.ActiveIssues[issue.Number] = work
+			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, a.cfg.GitHubUser)
+			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, "ai-failed")
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number,
+				fmt.Sprintf("AI agent failed to squash commits: %v\n\n%s", err, botMarker))
+			continue
+		}
+
+		// Push the branch (force push because squashing rewrites history)
+		if err := a.gitPush(ctx, worktreePath, true); err != nil {
 			a.logger.Error("failed to push branch", "issue", issue.Number, "error", err)
 			work.Status = "failed"
 			a.state.ActiveIssues[issue.Number] = work
@@ -846,6 +858,37 @@ func (a *Agent) gitAmendAll(ctx context.Context, worktreePath string) error {
 	return nil
 }
 
+// gitSquashCommits squashes all commits since the origin default branch into a single commit.
+func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issueNumber int, issueTitle string) error {
+	// Get all commit messages since origin default branch
+	logOut, _, err := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%B")
+	if err != nil {
+		return fmt.Errorf("getting commit messages: %w", err)
+	}
+	commitMessages := strings.TrimSpace(string(logOut))
+
+	// Reset to origin default branch while keeping changes staged
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "reset", "--soft", a.originDefaultBranch()); err != nil {
+		return fmt.Errorf("git reset --soft: %w (stderr: %s)", err, string(stderr))
+	}
+
+	// Create a single commit with a meaningful message
+	commitMsg := fmt.Sprintf("Fix #%d: %s", issueNumber, issueTitle)
+	if commitMessages != "" {
+		// Include original commit messages in the body
+		commitMsg += "\n\n" + commitMessages
+	}
+	if a.cfg.SignedOffBy != "" {
+		commitMsg += fmt.Sprintf("\n\nSigned-off-by: %s", a.cfg.SignedOffBy)
+	}
+
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "-m", commitMsg); err != nil {
+		return fmt.Errorf("git commit after squash: %w (stderr: %s)", err, string(stderr))
+	}
+
+	return nil
+}
+
 // deleteRemoteBranch removes a branch from the push remote.
 func (a *Agent) deleteRemoteBranch(ctx context.Context, worktreePath, branchName string) {
 	pushRemote := "origin"
@@ -898,3 +941,4 @@ func (a *Agent) isAllowedReviewer(user string) bool {
 	}
 	return false
 }
+

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -4,29 +4,30 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
 
 // mockGitHubClient implements GitHubClient for testing.
 type mockGitHubClient struct {
-	issues        []Issue
-	prComments    []ReviewComment
-	issueComments []ReviewComment
-	prState       string
-	prs           []PR
-	addedComments  []string
-	addedLabels    []string
-	removedLabels  []string
-	addedReactions []string
-	checkRuns      []CheckRun
+	issues          []Issue
+	prComments      []ReviewComment
+	issueComments   []ReviewComment
+	prState         string
+	prs             []PR
+	addedComments   []string
+	addedLabels     []string
+	removedLabels   []string
+	addedReactions  []string
+	checkRuns       []CheckRun
 	prHeadSHAs      []string // returns these in sequence; if empty returns "abc123"
 	prsAfterNCalls  int      // only return PRs after this many ListPRsByHead calls
 	prsCallCount    int
-	mergeableState  string   // mergeable state to return from GetPRMergeable (default: "clean")
-	prBehind        bool     // whether IsPRBehind returns true
-	createdIssues   []Issue  // tracks issues created via CreateIssue
-	nextIssueNumber int      // next issue number to return (defaults to 1)
+	mergeableState  string  // mergeable state to return from GetPRMergeable (default: "clean")
+	prBehind        bool    // whether IsPRBehind returns true
+	createdIssues   []Issue // tracks issues created via CreateIssue
+	nextIssueNumber int     // next issue number to return (defaults to 1)
 
 	listIssuesErr error
 }
@@ -956,5 +957,70 @@ func TestHasWatchedPRs(t *testing.T) {
 	agent.cfg.WatchPRs = []int{123}
 	if !agent.HasWatchedPRs() {
 		t.Error("expected true with watched PRs")
+	}
+}
+func TestProcessNewIssues_SquashesCommits(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "Fixed it"})
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Fix the bug", Body: "broken"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify git reset --soft was called to squash commits
+	foundReset := false
+	foundCommit := false
+	foundForcePush := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 2 {
+			if c.Args[0] == "reset" && c.Args[1] == "--soft" {
+				foundReset = true
+				// Should reset to origin/main
+				if len(c.Args) >= 3 && c.Args[2] != "origin/main" {
+					t.Errorf("expected reset to origin/main, got %v", c.Args)
+				}
+			}
+			if c.Args[0] == "commit" && c.Args[1] == "-m" {
+				foundCommit = true
+				// Verify commit message includes issue number
+				if len(c.Args) >= 3 {
+					commitMsg := c.Args[2]
+					if !strings.Contains(commitMsg, "Fix #42") {
+						t.Errorf("expected commit message to contain 'Fix #42', got: %s", commitMsg)
+					}
+					if !strings.Contains(commitMsg, "Signed-off-by") {
+						t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+					}
+				}
+			}
+			if c.Args[0] == "push" {
+				// Should be force push after squashing
+				hasForce := false
+				for _, arg := range c.Args {
+					if arg == "--force" {
+						hasForce = true
+						foundForcePush = true
+						break
+					}
+				}
+				if !hasForce {
+					t.Error("expected force push after squashing commits")
+				}
+			}
+		}
+	}
+
+	if !foundReset {
+		t.Error("expected git reset --soft to be called for commit squashing")
+	}
+	if !foundCommit {
+		t.Error("expected git commit to be called after squashing")
+	}
+	if !foundForcePush {
+		t.Error("expected git push --force after squashing")
 	}
 }


### PR DESCRIPTION
Fixes #10

Squash commits into a single commit before creating PR

Before pushing the branch and creating a PR, squash all commits made
by Claude into a single, well-crafted commit. This results in cleaner
git history and makes PRs easier to review.

The implementation adds a gitSquashCommits method that:
- Gathers all commit messages since the origin default branch
- Uses git reset --soft to move HEAD back while keeping changes staged
- Creates a single commit with a message referencing the issue number
- Includes original commit messages in the body for reference
- Adds the Signed-off-by trailer when configured

The push operation after squashing uses force since squashing rewrites
history.

Added comprehensive test coverage in TestProcessNewIssues_SquashesCommits
to verify the squashing behavior, including checking that git reset,
commit, and force push are called correctly.

Fixes #10

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->