### PR TITLE
Auto-exit on new version to enable seamless updates

### DIFF
--- a/cmd/ai-agent/main.go
+++ b/cmd/ai-agent/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -22,7 +23,7 @@ func envOrDefault(key, def string) string {
 	return def
 }
 
-func parseConfig() agent.Config {
+func parseConfig() (agent.Config, string) {
 	cfg := agent.Config{}
 
 	var repoFlag string
@@ -53,6 +54,9 @@ func parseConfig() agent.Config {
 
 	var forkFlag string
 	flag.StringVar(&forkFlag, "fork", envOrDefault("AI_AGENT_FORK", ""), "Fork repo as owner/repo for pushing (e.g. qinqon/ovn-kubernetes)")
+
+	var exitOnNewVersion string
+	flag.StringVar(&exitOnNewVersion, "exit-on-new-version", os.Getenv("AI_AGENT_EXIT_ON_NEW_VERSION"), "Exit when a new version is available (format: owner/repo, e.g. qinqon/github-issue-resolver)")
 
 	// Identity flags (optional, auto-detected from auth when not set)
 	flag.StringVar(&cfg.GitHubUser, "github-user", os.Getenv("GITHUB_USER"), "GitHub username (e.g. myapp[bot])")
@@ -158,7 +162,7 @@ func parseConfig() agent.Config {
 		}
 	}
 
-	return cfg
+	return cfg, exitOnNewVersion
 }
 
 func parseDuration(s string) time.Duration {
@@ -198,8 +202,36 @@ func setupLogger(level, logFile string) (*slog.Logger, func()) {
 	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: logLevel})), cleanup
 }
 
+func getCommitSHA() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value
+		}
+	}
+	return ""
+}
+
+func shouldExitForNewVersion(ctx context.Context, ghClient *agent.GoGitHubClient, owner, repo, currentSHA string, logger *slog.Logger) bool {
+	latestSHA, err := ghClient.GetDefaultBranchSHA(ctx, owner, repo)
+	if err != nil {
+		logger.Warn("failed to check for new version", "error", err)
+		return false
+	}
+
+	if latestSHA != currentSHA {
+		logger.Info("new version detected, exiting for update", "current", currentSHA, "latest", latestSHA)
+		return true
+	}
+
+	return false
+}
+
 func main() {
-	cfg := parseConfig()
+	cfg, exitOnNewVersion := parseConfig()
 	logger, closeLog := setupLogger(cfg.LogLevel, cfg.LogFile)
 	defer closeLog()
 
@@ -336,6 +368,24 @@ func main() {
 		a.SetTokenFunc(tokenFunc)
 	}
 
+	// Parse exit-on-new-version flag
+	var exitOnNewVersionOwner, exitOnNewVersionRepo string
+	commitSHA := getCommitSHA()
+	if exitOnNewVersion != "" {
+		if parts := strings.SplitN(exitOnNewVersion, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			exitOnNewVersionOwner = parts[0]
+			exitOnNewVersionRepo = parts[1]
+			if commitSHA == "" {
+				logger.Warn("--exit-on-new-version set but no VCS revision found (dev build), version check disabled")
+			} else {
+				logger.Info("version check enabled", "repo", exitOnNewVersion, "current-sha", commitSHA)
+			}
+		} else {
+			logger.Error("invalid --exit-on-new-version format (must be owner/repo)", "value", exitOnNewVersion)
+			os.Exit(1)
+		}
+	}
+
 	logger.Info("starting ai-agent",
 		"owner", cfg.Owner,
 		"repo", cfg.Repo,
@@ -361,6 +411,9 @@ func main() {
 			return
 		case <-ticker.C:
 			runLoop(ctx, a, logger)
+			if exitOnNewVersionOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOnNewVersionOwner, exitOnNewVersionRepo, commitSHA, logger) {
+				return
+			}
 		}
 	}
 }

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -465,3 +465,17 @@ func (g *GoGitHubClient) GetAuthenticatedUser(ctx context.Context) (login, name,
 
 	return login, name, email, nil
 }
+
+// GetDefaultBranchSHA returns the SHA of the latest commit on the default branch.
+func (g *GoGitHubClient) GetDefaultBranchSHA(ctx context.Context, owner, repo string) (string, error) {
+	commits, _, err := g.client.Repositories.ListCommits(ctx, owner, repo, &github.CommitsListOptions{
+		ListOptions: github.ListOptions{PerPage: 1},
+	})
+	if err != nil {
+		return "", fmt.Errorf("listing commits: %w", err)
+	}
+	if len(commits) == 0 {
+		return "", fmt.Errorf("no commits found for %s/%s", owner, repo)
+	}
+	return commits[0].GetSHA(), nil
+}

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v84/github"
@@ -386,5 +387,40 @@ func TestCreateIssue(t *testing.T) {
 	}
 	if len(receivedLabels) != 1 || receivedLabels[0] != "flaky-test" {
 		t.Errorf("expected labels ['flaky-test'], got %v", receivedLabels)
+	}
+}
+
+func TestGetDefaultBranchSHA(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits", func(w http.ResponseWriter, r *http.Request) {
+		commits := []*github.RepositoryCommit{
+			{SHA: github.Ptr("abc123def456")},
+		}
+		json.NewEncoder(w).Encode(commits)
+	})
+
+	gh := setupTestClient(t, mux)
+	sha, err := gh.GetDefaultBranchSHA(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sha != "abc123def456" {
+		t.Errorf("expected SHA 'abc123def456', got %q", sha)
+	}
+}
+
+func TestGetDefaultBranchSHA_NoCommits(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]*github.RepositoryCommit{})
+	})
+
+	gh := setupTestClient(t, mux)
+	_, err := gh.GetDefaultBranchSHA(context.Background(), "owner", "repo")
+	if err == nil {
+		t.Fatal("expected error for empty commits, got nil")
+	}
+	if !strings.Contains(err.Error(), "no commits found") {
+		t.Errorf("expected 'no commits found' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implement version detection using `runtime/debug.ReadBuildInfo()` to read the `vcs.revision` embedded at build time. After each poll cycle, the agent queries the GitHub API for the latest commit SHA on its own repository. If the SHAs differ, the agent exits cleanly (code 0) so the wrapper script can reinstall and restart with the new version.

## Changes

- Add `--exit-on-new-version` flag (env: `AI_AGENT_EXIT_ON_NEW_VERSION`) to specify the agent's own repository (e.g., `qinqon/github-issue-resolver`)
- Add `getCommitSHA()` function using `runtime/debug.ReadBuildInfo()` to extract the VCS revision
- Add `shouldExitForNewVersion()` helper that compares local SHA with remote SHA
- Add version check in the poll loop that exits cleanly when a new version is detected
- Add `GetDefaultBranchSHA()` method to `GoGitHubClient` to fetch the latest commit SHA
- Add tests for `GetDefaultBranchSHA()` including error cases

## Testing

- `make lint` passes
- `make test` passes
- Tests added for `GetDefaultBranchSHA()` method

Fixes #7