### PR TITLE
Flaky CI issue creation has no duplicate detection

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -37,6 +37,7 @@ type GitHubClient interface {
 	GetPR(ctx context.Context, owner, repo string, prNumber int) (PR, error)
 	IsPRBehind(ctx context.Context, owner, repo string, prNumber int) (bool, error)
 	CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (int, error)
+	SearchIssues(ctx context.Context, query string) ([]Issue, error)
 }
 
 // GoGitHubClient implements GitHubClient using go-github.
@@ -442,6 +443,31 @@ func (g *GoGitHubClient) CreateIssue(ctx context.Context, owner, repo, title, bo
 		return 0, fmt.Errorf("creating issue: %w", err)
 	}
 	return issue.GetNumber(), nil
+}
+
+func (g *GoGitHubClient) SearchIssues(ctx context.Context, query string) ([]Issue, error) {
+	result, _, err := g.client.Search.Issues(ctx, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("searching issues: %w", err)
+	}
+
+	var issues []Issue
+	for _, ghIssue := range result.Issues {
+		if ghIssue.IsPullRequest() {
+			continue
+		}
+		var labels []string
+		for _, l := range ghIssue.Labels {
+			labels = append(labels, l.GetName())
+		}
+		issues = append(issues, Issue{
+			Number: ghIssue.GetNumber(),
+			Title:  ghIssue.GetTitle(),
+			Body:   ghIssue.GetBody(),
+			Labels: labels,
+		})
+	}
+	return issues, nil
 }
 
 // GetAuthenticatedUser returns the login, name, and email of the authenticated user.

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -421,3 +421,87 @@ func TestGetLatestReleaseSHA_NoRelease(t *testing.T) {
 		t.Fatal("expected error for no release, got nil")
 	}
 }
+
+func TestSearchIssues(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"total_count": 2,
+			"items": []map[string]any{
+				{
+					"number": 42,
+					"title":  "Flaky CI: integration-tests",
+					"body":   "Test failure",
+					"labels": []map[string]any{
+						{"name": "flaky-test"},
+					},
+				},
+				{
+					"number": 43,
+					"title":  "Flaky CI: e2e-tests",
+					"body":   "Another failure",
+					"labels": []map[string]any{
+						{"name": "flaky-test"},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+
+	gh := setupTestClient(t, mux)
+	issues, err := gh.SearchIssues(context.Background(), "repo:owner/repo is:issue is:open label:flaky-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	if issues[0].Number != 42 {
+		t.Errorf("expected issue 42, got %d", issues[0].Number)
+	}
+	if issues[0].Title != "Flaky CI: integration-tests" {
+		t.Errorf("expected title 'Flaky CI: integration-tests', got %q", issues[0].Title)
+	}
+	if len(issues[0].Labels) != 1 || issues[0].Labels[0] != "flaky-test" {
+		t.Errorf("expected labels ['flaky-test'], got %v", issues[0].Labels)
+	}
+}
+
+func TestSearchIssues_FiltersPullRequests(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"total_count": 2,
+			"items": []map[string]any{
+				{
+					"number":       42,
+					"title":        "Flaky CI: integration-tests",
+					"body":         "Test failure",
+					"labels":       []map[string]any{{"name": "flaky-test"}},
+				},
+				{
+					"number":       100,
+					"title":        "Fix flaky test",
+					"body":         "PR description",
+					"pull_request": map[string]any{"url": "https://api.github.com/repos/owner/repo/pulls/100"},
+					"labels":       []map[string]any{{"name": "flaky-test"}},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+
+	gh := setupTestClient(t, mux)
+	issues, err := gh.SearchIssues(context.Background(), "repo:owner/repo label:flaky-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should filter out PRs and only return issues
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue (PR filtered out), got %d", len(issues))
+	}
+	if issues[0].Number != 42 {
+		t.Errorf("expected issue 42, got %d", issues[0].Number)
+	}
+}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -255,6 +255,13 @@ func (f *fakeGitHubClient) CreateIssue(_ context.Context, _, _ string, title, bo
 	return issueNum, nil
 }
 
+func (f *fakeGitHubClient) SearchIssues(_ context.Context, _ string) ([]Issue, error) {
+	f.state.mu.Lock()
+	defer f.state.mu.Unlock()
+	// For integration tests, just return empty results (no existing duplicates)
+	return nil, nil
+}
+
 // initBareRepo creates a bare repo and a working clone for the agent to use.
 // Returns (cloneDir, cleanup).
 func initBareRepo(t *testing.T) string {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -590,6 +590,28 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			// Create a flaky CI issue if configured
 			if a.cfg.CreateFlakyIssues {
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
+
+				// Search for existing open issues with the same check name
+				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:flaky-test \"%s\"",
+					a.cfg.Owner, a.cfg.Repo, issueTitle)
+				existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
+
+				var issueNum int
+				if err != nil {
+					a.logger.Warn("failed to search for existing flaky issues", "error", err)
+					// Continue with creation despite search failure
+				} else if len(existingIssues) > 0 {
+					// Issue already exists, reference it instead of creating a duplicate
+					issueNum = existingIssues[0].Number
+					a.logger.Info("found existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
+					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+						fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, botMarker)); err != nil {
+						a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
+					}
+					return
+				}
+
+				// No existing issue found, create a new one
 				issueBody := fmt.Sprintf("A CI failure was detected that appears unrelated to PR changes.\n\n"+
 					"**Detected in PR**: #%d\n"+
 					"**Commit**: %s\n"+
@@ -598,7 +620,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 					"**Check output**:\n```\n%s\n```\n\n"+
 					"%s",
 					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, explanation, task.failures[0].Output, botMarker)
-				issueNum, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
+				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
 				if err != nil {
 					a.logger.Error("failed to create flaky CI issue", "error", err)
 				} else {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -28,6 +28,7 @@ type mockGitHubClient struct {
 	prBehind        bool    // whether IsPRBehind returns true
 	createdIssues   []Issue // tracks issues created via CreateIssue
 	nextIssueNumber int     // next issue number to return (defaults to 1)
+	searchResults   []Issue // results to return from SearchIssues
 
 	listIssuesErr error
 }
@@ -171,6 +172,10 @@ func (m *mockGitHubClient) CreateIssue(_ context.Context, _, _ string, title, bo
 		Labels: labels,
 	})
 	return issueNum, nil
+}
+
+func (m *mockGitHubClient) SearchIssues(_ context.Context, _ string) ([]Issue, error) {
+	return m.searchResults, nil
 }
 
 // mockWorktreeManager implements WorktreeManager for testing.
@@ -720,6 +725,91 @@ func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 	// Check that only one comment was added (the unrelated notice)
 	if len(gh.addedComments) != 1 {
 		t.Fatalf("expected 1 comment (unrelated notice), got %d", len(gh.addedComments))
+	}
+}
+
+func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		searchResults: []Issue{
+			{Number: 50, Title: "Flaky CI: integration-tests", Labels: []string{"flaky-test"}},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that no new issue was created (existing one should be referenced)
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues (should reference existing), got %d", len(gh.createdIssues))
+	}
+
+	// Check that comments were added (unrelated notice + duplicate reference)
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+	}
+
+	// Verify the duplicate reference comment
+	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #50") {
+		t.Errorf("expected duplicate reference comment, got: %q", gh.addedComments[1])
+	}
+}
+
+func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		searchResults: []Issue{}, // No existing issues
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that a new issue was created
+	if len(gh.createdIssues) != 1 {
+		t.Fatalf("expected 1 created issue, got %d", len(gh.createdIssues))
+	}
+
+	issue := gh.createdIssues[0]
+	if issue.Title != "Flaky CI: integration-tests" {
+		t.Errorf("expected title 'Flaky CI: integration-tests', got %q", issue.Title)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0] != "flaky-test" {
+		t.Errorf("expected labels ['flaky-test'], got %v", issue.Labels)
+	}
+
+	// Check that comments were added (unrelated notice + new issue reference)
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (unrelated + issue link), got %d", len(gh.addedComments))
 	}
 }
 


### PR DESCRIPTION
Fixes #22

Fix #22: Flaky CI issue creation has no duplicate detection

Fix #22: Add duplicate detection for flaky CI issues

When --create-flaky-issues is enabled, the agent now checks for existing
open issues before creating a new flaky CI issue. This prevents creating
duplicate issues for the same failing check across multiple PRs.

Changes:
- Added SearchIssues method to GitHubClient interface
- Implemented SearchIssues using GitHub's search API
- Updated ProcessCIFailures to search for existing flaky issues before
  creating new ones
- If an existing issue is found, the agent references it in the PR
  comment instead of creating a duplicate
- Added comprehensive test coverage for duplicate detection

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->