### PR TITLE
Add --only-assigned flag to filter issues by assignee

### DIFF
--- a/cmd/ai-agent/main.go
+++ b/cmd/ai-agent/main.go
@@ -60,6 +60,7 @@ func parseConfig() (agent.Config, string) {
 	flag.StringVar(&logFile, "log-file", os.Getenv("AI_AGENT_LOG_FILE"), "Log file path (default: stderr)")
 
 	flag.BoolVar(&cfg.CreateFlakyIssues, "create-flaky-issues", envOrDefault("AI_AGENT_CREATE_FLAKY_ISSUES", "") == "true", "Create issues for unrelated CI failures (opt-in)")
+	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("AI_AGENT_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
 	flag.IntVar(&cfg.MaxWorkers, "max-workers", parseIntEnv("AI_AGENT_MAX_WORKERS", 1), "Maximum parallel Claude invocations (default 1 = sequential)")
 
 	var forkFlag string

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
 	Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 
 	// GitHub App authentication (alternative to GITHUB_TOKEN)

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -79,11 +79,16 @@ func (g *GoGitHubClient) ListLabeledIssues(ctx context.Context, owner, repo, lab
 		for _, l := range gi.Labels {
 			labels = append(labels, l.GetName())
 		}
+		var assignees []string
+		for _, a := range gi.Assignees {
+			assignees = append(assignees, a.GetLogin())
+		}
 		issues = append(issues, Issue{
-			Number: gi.GetNumber(),
-			Title:  gi.GetTitle(),
-			Body:   gi.GetBody(),
-			Labels: labels,
+			Number:    gi.GetNumber(),
+			Title:     gi.GetTitle(),
+			Body:      gi.GetBody(),
+			Labels:    labels,
+			Assignees: assignees,
 		})
 	}
 	return issues, nil

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -161,6 +161,11 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			continue
 		}
 
+		if a.cfg.OnlyAssigned && !issueAssignedTo(issue, a.cfg.GitHubUser) {
+			a.logger.Debug("skipping issue not assigned to agent user", "issue", issue.Number, "user", a.cfg.GitHubUser)
+			continue
+		}
+
 		a.logger.Info("processing new issue", "issue", issue.Number, "title", issue.Title)
 
 		branchName := fmt.Sprintf("ai/issue-%d", issue.Number)
@@ -1039,6 +1044,16 @@ func (a *Agent) gitPush(ctx context.Context, worktreePath string, force bool) er
 		return fmt.Errorf("git push: %w (stderr: %s)", err, string(stderr))
 	}
 	return nil
+}
+
+// issueAssignedTo returns true if the given user is among the issue's assignees.
+func issueAssignedTo(issue Issue, user string) bool {
+	for _, a := range issue.Assignees {
+		if a == user {
+			return true
+		}
+	}
+	return false
 }
 
 // isAllowedReviewer returns true if the user is in the reviewers whitelist.

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -4,10 +4,11 @@ import "time"
 
 // Issue represents a GitHub issue.
 type Issue struct {
-	Number int
-	Title  string
-	Body   string
-	Labels []string
+	Number    int
+	Title     string
+	Body      string
+	Labels    []string
+	Assignees []string
 }
 
 // ReviewComment represents a comment on a PR or issue.


### PR DESCRIPTION
## Summary

- Adds a new `--only-assigned` flag (env: `AI_AGENT_ONLY_ASSIGNED=true`) that makes the agent skip any `good-for-ai` issue not assigned to the authenticated GitHub user
- Useful when multiple agents or humans share the same label but each should only handle issues explicitly assigned to them

## Changes

| File | Change |
|---|---|
| `pkg/agent/types.go` | Added `Assignees []string` to `Issue` struct |
| `pkg/agent/github.go` | Populate `Assignees` from `gi.Assignees` in `ListLabeledIssues` |
| `pkg/agent/config.go` | Added `OnlyAssigned bool` field |
| `pkg/agent/loop.go` | Filter in `ProcessNewIssues` + `issueAssignedTo` helper |
| `cmd/ai-agent/main.go` | Wired `--only-assigned` / `AI_AGENT_ONLY_ASSIGNED` flag |

## Usage

```bash
./run-ai-agent.sh --repo owner/repo --only-assigned
```

When enabled, an issue must be assigned to the running agent's GitHub user to be processed. Unassigned issues (or issues assigned to others) are skipped with a debug log.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/...` passes
- [ ] Manual: label an issue `good-for-ai` without assigning it → agent skips it
- [ ] Manual: assign the issue to the agent user → agent picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)