### PR TITLE
Agent processes recovered PRs not in --watch-prs filter

### DIFF
--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -24,13 +24,16 @@ func NewState() *State {
 func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, cloneDir string, logger *slog.Logger) *State {
 	state := NewState()
 
-	issues, err := gh.ListLabeledIssues(ctx, cfg.Owner, cfg.Repo, cfg.Label)
-	if err != nil {
-		logger.Error("failed to list issues for state rebuild", "error", err)
-		return state
-	}
+	// Skip labeled issue scanning when --watch-prs is configured
+	// (watch mode bypasses issue discovery)
+	if len(cfg.WatchPRs) == 0 {
+		issues, err := gh.ListLabeledIssues(ctx, cfg.Owner, cfg.Repo, cfg.Label)
+		if err != nil {
+			logger.Error("failed to list issues for state rebuild", "error", err)
+			return state
+		}
 
-	for _, issue := range issues {
+		for _, issue := range issues {
 		branchName := fmt.Sprintf("ai/issue-%d", issue.Number)
 		worktreePath := filepath.Join(cloneDir, "worktrees", branchName)
 
@@ -94,6 +97,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 		}
 
 		state.ActiveIssues[issue.Number] = work
+		}
 	}
 
 	// Bootstrap state for watched PRs

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -84,3 +84,44 @@ func TestBuildStateFromGitHub_SkipsNewIssues(t *testing.T) {
 		t.Error("new issues without PRs should not be in recovered state")
 	}
 }
+
+func TestBuildStateFromGitHub_WatchPRsSkipsLabeledIssues(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 123, Title: "Labeled issue", Labels: []string{"good-for-ai"}}},
+		prs: []PR{
+			{Number: 299, State: "open", Head: "ai/issue-123"},
+			{Number: 313, State: "open", Head: "kube-linter", Title: "Watched PR"},
+		},
+	}
+	cfg := Config{
+		Owner:    "owner",
+		Repo:     "repo",
+		Label:    "good-for-ai",
+		WatchPRs: []int{313}, // Only watch PR 313
+	}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	// Should only contain the watched PR, not the labeled issue's PR
+	if len(state.ActiveIssues) != 1 {
+		t.Errorf("expected 1 issue in state, got %d", len(state.ActiveIssues))
+	}
+
+	work, ok := state.ActiveIssues[313]
+	if !ok {
+		t.Fatal("expected watched PR 313 in state")
+	}
+	if work.PRNumber != 313 {
+		t.Errorf("expected PR 313, got %d", work.PRNumber)
+	}
+
+	// PR 299 from the labeled issue should NOT be in state
+	if _, exists := state.ActiveIssues[123]; exists {
+		t.Error("labeled issue 123 should not be in state when watch-prs is configured")
+	}
+	for _, w := range state.ActiveIssues {
+		if w.PRNumber == 299 {
+			t.Error("PR 299 from labeled issue should not be recovered when watch-prs is configured")
+		}
+	}
+}


### PR DESCRIPTION
Fixes #25

Fix #25: Agent processes recovered PRs not in --watch-prs filter

Fix #25: Filter out labeled issues when --watch-prs is configured

When --watch-prs is specified, BuildStateFromGitHub should only
recover watched PRs, not PRs from labeled issues. This aligns with
the main loop behavior where --watch-prs bypasses issue discovery.

The fix skips labeled issue scanning in BuildStateFromGitHub when
cfg.WatchPRs is non-empty, preventing recovery of PRs that aren't
in the current watch list.

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->