### PR TITLE
Agent does not re-investigate CI failures after new pushes

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -653,6 +653,19 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			}
 		}
 
+		// After pushing (or not pushing), fetch the current HEAD SHA to update state
+		currentHeadSHA := task.headSHA
+		if pushed {
+			// Get the new HEAD SHA after the push
+			newHeadSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber)
+			if err != nil {
+				a.logger.Warn("failed to get new HEAD SHA after push", "pr", task.work.PRNumber, "error", err)
+				// Fall back to old SHA if we can't get the new one
+			} else {
+				currentHeadSHA = newHeadSHA
+			}
+		}
+
 		if pushed {
 			a.logger.Info("CI failure is related, pushed a fix", "pr", task.work.PRNumber)
 			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
@@ -668,7 +681,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		}
 		task.work.CIFixAttempts++
 		task.work.LastCIStatus = "failure"
-		task.work.LastCheckedCISHA = task.headSHA
+		task.work.LastCheckedCISHA = currentHeadSHA
 	})
 }
 
@@ -892,8 +905,8 @@ func shortSHA(sha string) string {
 	return sha
 }
 
-// alreadyCheckedCI returns true if a bot comment mentioning the given SHA
-// already exists on the PR, indicating this commit was already investigated.
+// alreadyCheckedCI returns true if a bot comment about CI investigation mentioning
+// the given SHA already exists on the PR, indicating this commit was already investigated for CI.
 func (a *Agent) alreadyCheckedCI(ctx context.Context, prNumber int, sha string) bool {
 	comments, err := a.gh.GetIssueComments(ctx, a.cfg.Owner, a.cfg.Repo, prNumber, 0)
 	if err != nil {
@@ -901,7 +914,8 @@ func (a *Agent) alreadyCheckedCI(ctx context.Context, prNumber int, sha string) 
 	}
 	short := shortSHA(sha)
 	for _, c := range comments {
-		if strings.Contains(c.Body, botMarker) && strings.Contains(c.Body, short) {
+		// Only match CI-specific comments (not rebase or other comments mentioning the SHA)
+		if strings.Contains(c.Body, botMarker) && strings.Contains(c.Body, short) && strings.Contains(c.Body, "CI") {
 			return true
 		}
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -813,6 +813,59 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
+	// Issue #28: Agent should re-investigate CI failures when new commits are pushed,
+	// even if a previous rebase comment mentions the new commit SHA.
+	claudeResult := streamResultJSON(ClaudeResult{Result: "RELATED Fixed CI"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+		prHeadSHAs: []string{"abc1234", "def5678"}, // First call returns abc1234, second returns def5678
+		issueComments: []ReviewComment{
+			// Simulate a rebase comment that mentions the new commit
+			{ID: 1, User: "test-bot", Body: "Rebased commit def5678 on main and pushed.\n\n<!-- ai-agent-bot -->"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:      42,
+		IssueTitle:       "Fix bug",
+		PRNumber:         100,
+		BranchName:       "ai/issue-42",
+		Status:           "pr-open",
+		WorktreePath:     "/tmp/worktree",
+		LastCheckedCISHA: "abc1234", // Already investigated abc1234
+	}
+
+	// First call: should skip because LastCheckedCISHA matches current HEAD (abc1234)
+	agent.ProcessCIFailures(context.Background())
+	if countClaudeCalls(runner.calls) != 0 {
+		t.Errorf("expected 0 claude calls (same SHA), got %d", countClaudeCalls(runner.calls))
+	}
+
+	// Second call: new commit def5678 pushed (e.g., by a human after rebase)
+	// Even though there's a rebase comment mentioning def5678, the agent should
+	// still investigate CI failures on this new commit
+	agent.ProcessCIFailures(context.Background())
+	if countClaudeCalls(runner.calls) != 1 {
+		t.Errorf("expected 1 claude call (new SHA with CI failure), got %d", countClaudeCalls(runner.calls))
+	}
+}
+
+func countClaudeCalls(calls []commandCall) int {
+	count := 0
+	for _, c := range calls {
+		if c.Name == "claude" {
+			count++
+		}
+	}
+	return count
+}
+
 func TestShouldRunReaction_EmptyAllowsAll(t *testing.T) {
 	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
 	// No reactions configured — all should be allowed


### PR DESCRIPTION
Fixes #28

Fix #28: Agent does not re-investigate CI failures after new pushes

Fix #28: Agent re-investigates CI failures after new commits

The alreadyCheckedCI function was checking if ANY bot comment contained
the commit SHA, not just CI-specific comments. This caused the agent to
skip CI investigation when a rebase or conflict resolution comment
mentioned the same SHA.

For example:
1. Agent rebases and posts "Rebased commit abc1234 on main and pushed"
2. Later, CI fails on commit abc1234
3. alreadyCheckedCI finds the rebase comment and skips investigation

Now the function only matches comments that contain both the SHA and "CI",
ensuring CI investigation happens even when other operations (rebase,
conflict resolution) mention the same commit.

Added test to verify the fix: TestProcessCIFailures_ReinvestigatesAfterNewCommits

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->