### PR TITLE
Agent does not re-investigate CI failures after new pushes

### DIFF
--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -27,6 +27,7 @@ type fakeGitHub struct {
 	nextPRNumber   int
 	nextCommentID  int64
 	shaCounter     int
+	prHeadSHAs     map[int]string // prNumber -> current head SHA
 }
 
 func newFakeGitHub() *fakeGitHub {
@@ -35,6 +36,7 @@ func newFakeGitHub() *fakeGitHub {
 		prComments:    make(map[int][]ReviewComment),
 		nextPRNumber:  100,
 		nextCommentID: 1000,
+		prHeadSHAs:    make(map[int]string),
 	}
 }
 
@@ -50,7 +52,18 @@ func (f *fakeGitHub) addPR(branch string) int {
 	num := f.nextPRNumber
 	f.nextPRNumber++
 	f.prs[num] = &PR{Number: num, State: "open", Head: branch}
+	// Assign initial SHA for this PR
+	f.shaCounter++
+	f.prHeadSHAs[num] = fmt.Sprintf("fakesha%d", f.shaCounter)
 	return num
+}
+
+// simulatePush increments the head SHA for a PR (simulates a force push or new commit)
+func (f *fakeGitHub) simulatePush(prNumber int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.shaCounter++
+	f.prHeadSHAs[prNumber] = fmt.Sprintf("fakesha%d", f.shaCounter)
 }
 
 func (f *fakeGitHub) addReviewComment(prNumber int, user, body, path string, line int) int64 {
@@ -181,11 +194,15 @@ func (f *fakeGitHubClient) GetCheckRunLog(_ context.Context, _, _ string, _ int6
 	return "", nil
 }
 
-func (f *fakeGitHubClient) GetPRHeadSHA(_ context.Context, _, _ string, _ int) (string, error) {
+func (f *fakeGitHubClient) GetPRHeadSHA(_ context.Context, _, _ string, prNumber int) (string, error) {
 	f.state.mu.Lock()
 	defer f.state.mu.Unlock()
-	f.state.shaCounter++
-	return fmt.Sprintf("fakesha%d", f.state.shaCounter), nil
+	// Return the current head SHA for this PR (consistent unless simulatePush is called)
+	if sha, ok := f.state.prHeadSHAs[prNumber]; ok {
+		return sha, nil
+	}
+	// PR not found or no SHA set, return a default
+	return "fakesha", nil
 }
 
 func (f *fakeGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, _ int64, _, _ string) (bool, error) {
@@ -849,6 +866,76 @@ func TestIntegration_SyncWorktreePullsManualCommits(t *testing.T) {
 	// Verify the manual commit is now in the worktree
 	if _, err := os.Stat(filepath.Join(work.WorktreePath, "manual.txt")); os.IsNotExist(err) {
 		t.Error("manual.txt should exist in worktree after sync")
+	}
+}
+
+func TestIntegration_CIFailureAfterNewPush(t *testing.T) {
+	ctx := context.Background()
+	cloneDir := initBareRepo(t)
+	gh := newFakeGitHub()
+	ghClient := &fakeGitHubClient{state: gh}
+	runner := &fakeClaudeRunner{}
+
+	bareDir := filepath.Join(filepath.Dir(cloneDir), "repo.git")
+	wtManager := NewGitWorktreeManager(&ExecRunner{}, cloneDir, bareDir, bareDir)
+
+	agent := NewAgent(
+		ghClient,
+		runner,
+		wtManager,
+		NewState(),
+		Config{Owner: "owner", Repo: "repo", Label: "good-for-ai"},
+		slog.Default(),
+	)
+
+	// Setup: issue with open PR (Claude creates PR)
+	gh.addIssue(Issue{Number: 91, Title: "Add feature", Body: "new feature"})
+	runner.onClaudeRun = func() {
+		gh.addPR("ai/issue-91")
+	}
+
+	agent.CleanupDone(ctx)
+	agent.ProcessNewIssues(ctx)
+	runner.onClaudeRun = nil
+
+	work := agent.state.ActiveIssues[91]
+	if work == nil {
+		t.Fatal("issue 91 should be in state")
+	}
+	prNum := work.PRNumber
+
+	// CI fails on initial commit
+	gh.setCheckRuns([]CheckRun{
+		{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "test failed"},
+	})
+
+	// First CI fix attempt
+	agent.ProcessCIFailures(ctx)
+	if agent.state.ActiveIssues[91].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[91].CIFixAttempts)
+	}
+
+	// Simulate a new push to the PR (force push or new commit by human/external process)
+	gh.simulatePush(prNum)
+
+	// CI fails again on the new commit
+	gh.setCheckRuns([]CheckRun{
+		{ID: 2, Name: "test", Status: "completed", Conclusion: "failure", Output: "different test failed"},
+	})
+
+	// Agent should detect new SHA and reset attempts counter, then re-investigate
+	agent.ProcessCIFailures(ctx)
+
+	// Verify that attempts counter was reset to 0 and then incremented to 1 (fresh investigation)
+	if agent.state.ActiveIssues[91].CIFixAttempts != 1 {
+		t.Errorf("expected CI fix attempts to be reset to 1 after new push, got %d", agent.state.ActiveIssues[91].CIFixAttempts)
+	}
+
+	// Verify the agent investigated the new SHA
+	work = agent.state.ActiveIssues[91]
+	currentSHA, _ := ghClient.GetPRHeadSHA(ctx, "owner", "repo", prNum)
+	if work.LastCheckedCISHA != currentSHA {
+		t.Errorf("expected LastCheckedCISHA to be updated to %s, got %s", currentSHA, work.LastCheckedCISHA)
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -486,6 +486,21 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
+		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			a.logger.Error("failed to get PR head SHA", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		// Reset fix attempts counter if HEAD SHA changed (new commits pushed)
+		if work.LastCheckedCISHA != "" && work.LastCheckedCISHA != headSHA {
+			if work.CIFixAttempts > 0 {
+				a.logger.Info("new commits detected, resetting CI fix attempts", "pr", work.PRNumber, "old_sha", shortSHA(work.LastCheckedCISHA), "new_sha", shortSHA(headSHA), "previous_attempts", work.CIFixAttempts)
+				work.CIFixAttempts = 0
+				work.LastCIStatus = ""
+			}
+		}
+
 		if work.CIFixAttempts >= maxCIFixAttempts {
 			if work.LastCIStatus != "max-retries-reached" {
 				a.logger.Warn("CI fix attempts exhausted", "pr", work.PRNumber, "attempts", work.CIFixAttempts)
@@ -496,22 +511,18 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
-		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
-		if err != nil {
-			a.logger.Error("failed to get PR head SHA", "pr", work.PRNumber, "error", err)
-			continue
-		}
-
-		// Check if we already investigated this SHA (in-memory dedup)
-		if work.LastCheckedCISHA == headSHA {
+		// Check if we already investigated this SHA (skip if no prior attempts, allow retries otherwise)
+		if work.LastCheckedCISHA == headSHA && work.CIFixAttempts == 0 {
+			// Already investigated this SHA and haven't started fix attempts yet
+			// (e.g., recovered from restart or marked as UNRELATED)
 			continue
 		}
 
 		// Fallback: check if we already investigated this SHA by looking for a bot comment
 		// (handles state recovery after restarts)
-		if a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
+		if work.LastCheckedCISHA == "" && a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
 			work.LastCheckedCISHA = headSHA
-			continue
+			// Don't continue here - if CI is failing, we should investigate despite the comment
 		}
 
 		runs, err := a.gh.GetCheckRuns(ctx, a.cfg.Owner, a.cfg.Repo, headSHA)
@@ -653,6 +664,19 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			}
 		}
 
+		// After pushing (or not pushing), fetch the current HEAD SHA to update state
+		currentHeadSHA := task.headSHA
+		if pushed {
+			// Get the new HEAD SHA after the push
+			newHeadSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber)
+			if err != nil {
+				a.logger.Warn("failed to get new HEAD SHA after push", "pr", task.work.PRNumber, "error", err)
+				// Fall back to old SHA if we can't get the new one
+			} else {
+				currentHeadSHA = newHeadSHA
+			}
+		}
+
 		if pushed {
 			a.logger.Info("CI failure is related, pushed a fix", "pr", task.work.PRNumber)
 			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
@@ -668,7 +692,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		}
 		task.work.CIFixAttempts++
 		task.work.LastCIStatus = "failure"
-		task.work.LastCheckedCISHA = task.headSHA
+		task.work.LastCheckedCISHA = currentHeadSHA
 	})
 }
 
@@ -892,8 +916,8 @@ func shortSHA(sha string) string {
 	return sha
 }
 
-// alreadyCheckedCI returns true if a bot comment mentioning the given SHA
-// already exists on the PR, indicating this commit was already investigated.
+// alreadyCheckedCI returns true if a bot comment about CI investigation mentioning
+// the given SHA already exists on the PR, indicating this commit was already investigated for CI.
 func (a *Agent) alreadyCheckedCI(ctx context.Context, prNumber int, sha string) bool {
 	comments, err := a.gh.GetIssueComments(ctx, a.cfg.Owner, a.cfg.Repo, prNumber, 0)
 	if err != nil {
@@ -901,7 +925,8 @@ func (a *Agent) alreadyCheckedCI(ctx context.Context, prNumber int, sha string) 
 	}
 	short := shortSHA(sha)
 	for _, c := range comments {
-		if strings.Contains(c.Body, botMarker) && strings.Contains(c.Body, short) {
+		// Only match CI-specific comments (not rebase or other comments mentioning the SHA)
+		if strings.Contains(c.Body, botMarker) && strings.Contains(c.Body, short) && strings.Contains(c.Body, "CI") {
 			return true
 		}
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -813,6 +813,59 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
+	// Issue #28: Agent should re-investigate CI failures when new commits are pushed,
+	// even if a previous rebase comment mentions the new commit SHA.
+	claudeResult := streamResultJSON(ClaudeResult{Result: "RELATED Fixed CI"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+		prHeadSHAs: []string{"abc1234", "def5678"}, // First call returns abc1234, second returns def5678
+		issueComments: []ReviewComment{
+			// Simulate a rebase comment that mentions the new commit
+			{ID: 1, User: "test-bot", Body: "Rebased commit def5678 on main and pushed.\n\n<!-- ai-agent-bot -->"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:      42,
+		IssueTitle:       "Fix bug",
+		PRNumber:         100,
+		BranchName:       "ai/issue-42",
+		Status:           "pr-open",
+		WorktreePath:     "/tmp/worktree",
+		LastCheckedCISHA: "abc1234", // Already investigated abc1234
+	}
+
+	// First call: should skip because LastCheckedCISHA matches current HEAD (abc1234)
+	agent.ProcessCIFailures(context.Background())
+	if countClaudeCalls(runner.calls) != 0 {
+		t.Errorf("expected 0 claude calls (same SHA), got %d", countClaudeCalls(runner.calls))
+	}
+
+	// Second call: new commit def5678 pushed (e.g., by a human after rebase)
+	// Even though there's a rebase comment mentioning def5678, the agent should
+	// still investigate CI failures on this new commit
+	agent.ProcessCIFailures(context.Background())
+	if countClaudeCalls(runner.calls) != 1 {
+		t.Errorf("expected 1 claude call (new SHA with CI failure), got %d", countClaudeCalls(runner.calls))
+	}
+}
+
+func countClaudeCalls(calls []commandCall) int {
+	count := 0
+	for _, c := range calls {
+		if c.Name == "claude" {
+			count++
+		}
+	}
+	return count
+}
+
 func TestShouldRunReaction_EmptyAllowsAll(t *testing.T) {
 	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
 	// No reactions configured — all should be allowed


### PR DESCRIPTION
Fixes #28

Fix #28: Agent does not re-investigate CI failures after new pushes

Fix #28: Re-investigate CI failures after new commits are pushed

The agent was not re-investigating CI failures when new commits were
pushed to a PR after the agent had already attempted a fix. This was
caused by two issues:

1. LastCheckedCISHA was set to the old SHA before a fix was pushed,
   not the new SHA after pushing. This meant the agent would
   immediately re-investigate its own fix before CI could run.

2. CIFixAttempts counter was never reset when new commits were
   pushed, causing the agent to hit max retries and stop
   investigating even on fresh commits.

This commit fixes both issues:

- Update LastCheckedCISHA to the new HEAD SHA after successfully
  pushing a fix, ensuring the agent tracks the actual current state
- Reset CIFixAttempts when HEAD SHA changes, allowing the agent to
  retry on new commits even if max attempts were reached on old ones
- Adjust skip logic to allow retries on same SHA while preventing
  duplicate investigations of already-handled commits
- Fix fake GitHub client to return consistent SHAs per PR, avoiding
  false positives in tests

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Fix #28: Agent does not re-investigate CI failures after new pushes

Fix #28: Agent does not re-investigate CI failures after new pushes

Fix #28: Agent re-investigates CI failures after new commits

The alreadyCheckedCI function was checking if ANY bot comment contained
the commit SHA, not just CI-specific comments. This caused the agent to
skip CI investigation when a rebase or conflict resolution comment
mentioned the same SHA.

For example:
1. Agent rebases and posts "Rebased commit abc1234 on main and pushed"
2. Later, CI fails on commit abc1234
3. alreadyCheckedCI finds the rebase comment and skips investigation

Now the function only matches comments that contain both the SHA and "CI",
ensuring CI investigation happens even when other operations (rebase,
conflict resolution) mention the same commit.

Added test to verify the fix: TestProcessCIFailures_ReinvestigatesAfterNewCommits

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->