### PR TITLE
Conflict resolution creates new commits instead of resolving within rebase

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -806,6 +806,10 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 
 	// Parallel phase: Claude invocations for conflict resolution
 	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task conflictTask) {
+		// Get commit count before invoking Claude
+		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
+		commitCountBefore := len(commitsBefore)
+
 		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch())
 		_, err := runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
 		if err != nil {
@@ -813,6 +817,26 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
 				fmt.Sprintf("Rebase failed on commit %s. Attempted to resolve conflicts automatically but failed. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
 			return
+		}
+
+		// Verify that no unexpected new commits were created
+		commitsAfter := a.getPRCommits(ctx, task.work.WorktreePath)
+		commitCountAfter := len(commitsAfter)
+
+		if commitCountAfter > commitCountBefore {
+			a.logger.Warn("conflict resolution created new commits instead of resolving within rebase",
+				"pr", task.work.PRNumber,
+				"before", commitCountBefore,
+				"after", commitCountAfter,
+				"new_commits", commitCountAfter-commitCountBefore)
+
+			// Warn user - the improved prompt should prevent this, but if it happens, request human intervention
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("⚠️ Conflict resolution created %d unexpected new commit(s) instead of resolving within the rebase flow.\n\n"+
+					"Expected: %d commits (original structure preserved)\n"+
+					"Got: %d commits (new commits added)\n\n"+
+					"Please review the commit history and manually squash or rebase to preserve the original commit structure.\n\n%s",
+					commitCountAfter-commitCountBefore, commitCountBefore, commitCountAfter, botMarker))
 		}
 
 		// Push the rebased branch

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -148,9 +148,16 @@ func buildConflictResolutionPrompt(work IssueWork, originDefaultBranch string) s
 Instructions:
 1. Run "git fetch origin" to get the latest changes
 2. Run "git rebase %s" to rebase on top of the latest main branch
-3. Resolve any merge conflicts that arise:
+3. Resolve conflicts WITHIN the rebase flow:
+   - When "git rebase" stops due to conflicts, edit the conflicting files to resolve them
    - Understand the intent of both the PR changes and the upstream changes
    - Keep the PR's functionality intact while incorporating upstream changes
+   - After resolving conflicts in the files, run "git add <resolved-files>"
+   - Then run "git rebase --continue" to continue the rebase
+   - Repeat for each conflicting commit until the rebase completes
+   - CRITICAL: Do NOT run "git rebase --abort"
+   - CRITICAL: Do NOT create new standalone commits on top (no "git commit")
+   - The rebase must complete successfully with the original commit structure preserved
 4. Run "make lint" and "make test" to verify the resolved code still works
 
 Do NOT push — the agent handles that automatically.`,

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -100,3 +100,34 @@ func TestBuildReviewResponsePrompt(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildConflictResolutionPrompt(t *testing.T) {
+	work := IssueWork{
+		IssueNumber: 42,
+		IssueTitle:  "Fix nil pointer in handler",
+		PRNumber:    100,
+	}
+
+	prompt := buildConflictResolutionPrompt(work, "origin/main")
+
+	checks := []string{
+		"PR #100",
+		"issue #42",
+		"Fix nil pointer in handler",
+		"merge conflicts",
+		"git fetch origin",
+		"git rebase origin/main",
+		"git add",
+		"git rebase --continue",
+		"Do NOT run \"git rebase --abort\"",
+		"Do NOT create new standalone commits",
+		"original commit structure preserved",
+		"Do NOT push",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #36

Fix #36: Conflict resolution creates new commits instead of resolving within rebase

Fix #36: Conflict resolution creates new commits instead of resolving within rebase

Fix #36: Instruct Claude to resolve conflicts within rebase flow

Updated buildConflictResolutionPrompt() to explicitly tell Claude to:
- Resolve conflicts by editing files, running "git add", then
  "git rebase --continue" for each conflicting commit
- NOT abort the rebase with "git rebase --abort"
- NOT create new standalone commits on top
- Preserve the original commit structure

Added verification in ProcessConflicts() to detect if Claude created
unexpected new commits instead of resolving within the rebase. If
detected, the agent warns the user to manually review and fix the
commit structure.

Added test coverage for the conflict resolution prompt to ensure it
includes the critical instructions.

The improved prompt should prevent Claude from taking the easier path
of aborting the rebase and creating new "fix" commits, which pollutes
the commit history.

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Fix #36: Conflict resolution creates new commits instead of resolving within rebase

Fix #36: Tell Claude to resolve conflicts within rebase flow

Update buildConflictResolutionPrompt() to explicitly instruct Claude to
resolve conflicts within the rebase using git add + git rebase
--continue for each conflicting commit, rather than aborting and
creating new standalone commits.

Changes:
- Add explicit step-by-step instructions for conflict resolution
- Add warnings against aborting rebase or creating new commits
- Add test for buildConflictResolutionPrompt()
- Simplify verification logic to warn users if unexpected commits are
  detected instead of attempting auto-squash

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->