### PR TITLE
Conflict resolution prompt missing Signed-off-by instruction

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -581,7 +581,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 	// Parallel phase: Claude invocations and post-processing
 	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task ciTask) {
-		prompt := buildCIFixPrompt(*task.work, task.failures, task.diff, task.commits)
+		prompt := buildCIFixPrompt(*task.work, task.failures, task.diff, task.commits, a.cfg.SignedOffBy)
 		result, err := runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
 		if err != nil {
 			a.logger.Error("claude failed to investigate CI", "pr", task.work.PRNumber, "error", err)
@@ -810,7 +810,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
 		commitCountBefore := len(commitsBefore)
 
-		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch())
+		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch(), a.cfg.SignedOffBy)
 		_, err := runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
 		if err != nil {
 			a.logger.Error("claude failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -75,7 +75,7 @@ Do NOT commit, push, or amend — the agent handles that automatically.`, owner,
 	return prompt
 }
 
-func buildCIFixPrompt(work IssueWork, failures []CheckRun, diff string, commits []Commit) string {
+func buildCIFixPrompt(work IssueWork, failures []CheckRun, diff string, commits []Commit, signedOffBy string) string {
 	prompt := fmt.Sprintf(`CI is failing on PR #%d for issue #%d: %s
 
 <user-provided-content>
@@ -124,12 +124,17 @@ Instructions:
    - Run "make lint" and "make test" locally to verify
    `
 
+	signoff := ""
+	if signedOffBy != "" {
+		signoff = fmt.Sprintf("\n   - Add \"Signed-off-by: %s\" as a trailer in every commit message (do NOT use git commit -s, write it directly in the message)", signedOffBy)
+	}
+
 	if len(commits) > 1 {
 		prompt += `   - IMPORTANT: This PR has multiple commits. You MUST identify which specific commit introduced the breaking change
    - After fixing the code, create a fixup commit targeting the commit that introduced the issue:
      git add <fixed-files>
      git commit --fixup <SHA-of-commit-that-introduced-issue>
-   - Do NOT use "git commit --amend" as that would incorrectly amend the last commit
+   - Do NOT use "git commit --amend" as that would incorrectly amend the last commit` + signoff + `
 `
 	} else {
 		prompt += `   - After fixing the code, stage your changes with "git add" but do NOT commit
@@ -142,7 +147,12 @@ Do NOT push or rebase — the agent handles that automatically.`
 	return prompt
 }
 
-func buildConflictResolutionPrompt(work IssueWork, originDefaultBranch string) string {
+func buildConflictResolutionPrompt(work IssueWork, originDefaultBranch string, signedOffBy string) string {
+	signoff := ""
+	if signedOffBy != "" {
+		signoff = fmt.Sprintf("\n5. Add \"Signed-off-by: %s\" as a trailer in every commit message (do NOT use git commit -s, write it directly in the message)", signedOffBy)
+	}
+
 	return fmt.Sprintf(`PR #%d for issue #%d (%s) has merge conflicts with the main branch.
 
 Instructions:
@@ -158,8 +168,8 @@ Instructions:
    - CRITICAL: Do NOT run "git rebase --abort"
    - CRITICAL: Do NOT create new standalone commits on top (no "git commit")
    - The rebase must complete successfully with the original commit structure preserved
-4. Run "make lint" and "make test" to verify the resolved code still works
+4. Run "make lint" and "make test" to verify the resolved code still works%s
 
 Do NOT push — the agent handles that automatically.`,
-		work.PRNumber, work.IssueNumber, work.IssueTitle, originDefaultBranch)
+		work.PRNumber, work.IssueNumber, work.IssueTitle, originDefaultBranch, signoff)
 }

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -108,7 +108,7 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 		PRNumber:    100,
 	}
 
-	prompt := buildConflictResolutionPrompt(work, "origin/main")
+	prompt := buildConflictResolutionPrompt(work, "origin/main", "")
 
 	checks := []string{
 		"PR #100",
@@ -129,5 +129,71 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("prompt missing %q", want)
 		}
+	}
+
+	// With signed-off-by
+	prompt = buildConflictResolutionPrompt(work, "origin/main", "Test User <test@example.com>")
+	if !strings.Contains(prompt, "Signed-off-by: Test User <test@example.com>") {
+		t.Error("prompt missing Signed-off-by when provided")
+	}
+}
+
+func TestBuildCIFixPrompt(t *testing.T) {
+	work := IssueWork{
+		IssueNumber: 42,
+		IssueTitle:  "Fix nil pointer in handler",
+		PRNumber:    100,
+	}
+
+	failures := []CheckRun{
+		{
+			Name:       "lint",
+			Conclusion: "failure",
+			Output:     "golangci-lint found issues",
+		},
+	}
+
+	commits := []Commit{
+		{SHA: "abc123def456", Subject: "Fix handler"},
+		{SHA: "def456abc789", Subject: "Add tests"},
+	}
+
+	diff := "handler.go | 10 +++++++---\n"
+
+	// Test without signed-off-by
+	prompt := buildCIFixPrompt(work, failures, diff, commits, "")
+
+	checks := []string{
+		"PR #100",
+		"issue #42",
+		"Fix nil pointer in handler",
+		"Failed checks:",
+		"lint",
+		"golangci-lint found issues",
+		"handler.go",
+		"UNRELATED",
+		"RELATED",
+		"Do NOT push",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+
+	// With signed-off-by (multi-commit PR should include instruction)
+	prompt = buildCIFixPrompt(work, failures, diff, commits, "Test User <test@example.com>")
+	if !strings.Contains(prompt, "Signed-off-by: Test User <test@example.com>") {
+		t.Error("prompt missing Signed-off-by when provided for multi-commit PR")
+	}
+
+	// Single-commit PR should NOT include signed-off-by instruction (no new commits created)
+	singleCommit := []Commit{
+		{SHA: "abc123def456", Subject: "Fix handler"},
+	}
+	prompt = buildCIFixPrompt(work, failures, diff, singleCommit, "Test User <test@example.com>")
+	if strings.Contains(prompt, "Signed-off-by:") {
+		t.Error("prompt should NOT include Signed-off-by for single-commit PR (no new commits)")
 	}
 }

--- a/specs/prompts.md
+++ b/specs/prompts.md
@@ -19,6 +19,31 @@ Tells Claude to:
 - No force-push
 - If signedOffBy is non-empty, add `Signed-off-by:` to every commit message
 
+## `buildCIFixPrompt(work IssueWork, failures []CheckRun, diff string, commits []Commit, signedOffBy string) string`
+
+Tells Claude to:
+- First investigate whether CI failures are directly caused by PR changes
+- If UNRELATED: output starts with "UNRELATED" and an explanation
+- If RELATED: output starts with "RELATED" and Claude fixes the code
+- For multi-commit PRs: create fixup commits targeting the commit that introduced the issue
+- For single-commit PRs: stage changes but do NOT commit (agent amends)
+- Run lint/test to verify the fix
+- If signedOffBy is non-empty, add `Signed-off-by:` to every commit message
+- Do NOT push or rebase — the agent handles that automatically
+
+## `buildConflictResolutionPrompt(work IssueWork, originDefaultBranch string, signedOffBy string) string`
+
+Tells Claude to:
+- Fetch latest changes and rebase on top of the main branch
+- Resolve conflicts WITHIN the rebase flow (not by creating new commits)
+- After resolving conflicts in files, run `git add <resolved-files>` and `git rebase --continue`
+- Repeat for each conflicting commit until rebase completes
+- Do NOT run `git rebase --abort` or create standalone commits
+- The original commit structure must be preserved
+- Run lint/test to verify the resolved code still works
+- If signedOffBy is non-empty, add `Signed-off-by:` to every commit message
+- Do NOT push — the agent handles that automatically
+
 ## Tests (`prompt_test.go`)
 
 - `TestBuildImplementationPrompt` -- verifies issue number, title, body are interpolated; verifies push/PR instructions are absent


### PR DESCRIPTION
Fixes #35

Fix #35: Conflict resolution prompt missing Signed-off-by instruction

Fix #35: Add Signed-off-by instruction to conflict resolution and CI fix prompts

When the agent resolves merge conflicts or fixes CI failures, the
prompts now include the Signed-off-by instruction to ensure all
commits have the required trailer.

Changes:
- Add signedOffBy parameter to buildConflictResolutionPrompt()
- Add signedOffBy parameter to buildCIFixPrompt()
- Update callers in loop.go to pass a.cfg.SignedOffBy
- Document both functions in specs/prompts.md
- Add tests for signed-off-by behavior in both prompts

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>

Signed-off-by: Enrique Llorente Pastora <ellorent@redhat.com>
---

<!-- ai-agent-bot -->