### PR TITLE
Split rebase reaction from conflicts

### DIFF
--- a/cmd/ai-agent/main.go
+++ b/cmd/ai-agent/main.go
@@ -54,7 +54,7 @@ func parseConfig() (agent.Config, string) {
 	flag.StringVar(&watchPRs, "watch-prs", os.Getenv("AI_AGENT_WATCH_PRS"), "Comma-separated PR numbers to monitor directly (bypasses issue discovery)")
 
 	var reactions string
-	flag.StringVar(&reactions, "reactions", os.Getenv("AI_AGENT_REACTIONS"), "Comma-separated list of reactions to run: reviews, ci, conflicts (empty = all)")
+	flag.StringVar(&reactions, "reactions", os.Getenv("AI_AGENT_REACTIONS"), "Comma-separated list of reactions to run: reviews, ci, conflicts, rebase (empty = all)")
 
 	var logFile string
 	flag.StringVar(&logFile, "log-file", os.Getenv("AI_AGENT_LOG_FILE"), "Log file path (default: stderr)")
@@ -159,14 +159,14 @@ func parseConfig() (agent.Config, string) {
 	}
 
 	if reactions != "" {
-		validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true}
+		validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true, "rebase": true}
 		for _, r := range strings.Split(reactions, ",") {
 			r = strings.TrimSpace(r)
 			if r == "" {
 				continue
 			}
 			if !validReactions[r] {
-				fmt.Fprintf(os.Stderr, "invalid reaction type %q: valid values are reviews, ci, conflicts\n", r)
+				fmt.Fprintf(os.Stderr, "invalid reaction type %q: valid values are reviews, ci, conflicts, rebase\n", r)
 				os.Exit(1)
 			}
 			cfg.Reactions = append(cfg.Reactions, r)
@@ -448,6 +448,9 @@ func runLoop(ctx context.Context, a *agent.Agent, logger *slog.Logger) {
 	}
 	if a.ShouldRunReaction("conflicts") {
 		a.ProcessConflicts(ctx)
+	}
+	if a.ShouldRunReaction("rebase") {
+		a.ProcessRebase(ctx)
 	}
 	if a.ShouldRunReaction("ci") {
 		a.ProcessCIFailures(ctx)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -723,7 +723,8 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 const maxConflictFixAttempts = 2
 
-// ProcessConflicts checks for merge conflicts and tries to rebase/resolve them.
+// ProcessConflicts checks for merge conflicts (dirty mergeable_state) and tries to resolve them.
+// For simple rebases when a PR is just behind the base branch, use ProcessRebase instead.
 func (a *Agent) ProcessConflicts(ctx context.Context) {
 	// Sequential phase: GitHub API calls, worktree setup, git fetch, automatic rebase attempts
 	var tasks []conflictTask
@@ -741,19 +742,8 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 
 		a.logger.Debug("PR mergeable state", "pr", work.PRNumber, "state", mergeState)
 
-		needsRebase := mergeState == "dirty" || mergeState == "behind"
-
-		// When mergeable_state is something else (e.g. "unstable"), it may mask
-		// the branch being behind. Use the compare API as a fallback.
-		if !needsRebase {
-			behind, err := a.gh.IsPRBehind(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
-			if err != nil {
-				a.logger.Warn("failed to check if PR is behind", "pr", work.PRNumber, "error", err)
-			}
-			needsRebase = behind
-		}
-
-		if !needsRebase {
+		// Only handle actual merge conflicts
+		if mergeState != "dirty" {
 			continue
 		}
 
@@ -851,6 +841,75 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 	})
 }
 
+// ProcessRebase rebases PRs that are behind the base branch but have no merge conflicts.
+// For PRs with actual merge conflicts (dirty state), use ProcessConflicts instead.
+func (a *Agent) ProcessRebase(ctx context.Context) {
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != "pr-open" {
+			continue
+		}
+
+		mergeState, err := a.gh.GetPRMergeable(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			a.logger.Error("failed to get PR mergeable state", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		a.logger.Debug("PR mergeable state", "pr", work.PRNumber, "state", mergeState)
+
+		needsRebase := mergeState == "behind"
+
+		// When mergeable_state is something else (e.g. "unstable", "blocked"), it may mask
+		// the branch being behind. Use the compare API as a fallback.
+		if !needsRebase && mergeState != "dirty" {
+			behind, err := a.gh.IsPRBehind(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+			if err != nil {
+				a.logger.Warn("failed to check if PR is behind", "pr", work.PRNumber, "error", err)
+			}
+			needsRebase = behind
+		}
+
+		if !needsRebase {
+			continue
+		}
+
+		headSHA, _ := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if headSHA != "" && a.hasExistingBotComment(ctx, work.PRNumber, "rebase") && a.hasExistingBotComment(ctx, work.PRNumber, shortSHA(headSHA)) {
+			continue
+		}
+
+		a.logger.Info("PR is behind base branch, rebasing", "pr", work.PRNumber, "mergeable_state", mergeState)
+
+		if err := a.ensureWorktreeReady(ctx, work); err != nil {
+			a.logger.Error("failed to prepare worktree", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		a.runner.Run(ctx, work.WorktreePath, "git", "fetch", "--all")
+
+		_, stderr, rebaseErr := a.runner.Run(ctx, work.WorktreePath, "git", "rebase", a.originDefaultBranch())
+		if rebaseErr != nil {
+			// Rebase should not fail since there are no conflicts — abort and log
+			a.runner.Run(ctx, work.WorktreePath, "git", "rebase", "--abort")
+			a.logger.Error("rebase failed unexpectedly (no conflicts expected)", "pr", work.PRNumber, "stderr", string(stderr))
+			continue
+		}
+
+		pushRemote := "origin"
+		if wtm, ok := a.worktrees.(*GitWorktreeManager); ok {
+			pushRemote = wtm.PushRemote()
+		}
+		_, stderr, pushErr := a.runner.Run(ctx, work.WorktreePath, "git", "push", pushRemote, "--force-with-lease")
+		if pushErr != nil {
+			a.logger.Error("failed to push after rebase", "pr", work.PRNumber, "error", pushErr, "stderr", string(stderr))
+		} else {
+			a.logger.Info("rebased and pushed successfully", "pr", work.PRNumber)
+			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
+				fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), botMarker))
+		}
+	}
+}
+
 // CleanupDone removes worktrees for merged or closed PRs.
 func (a *Agent) CleanupDone(ctx context.Context) {
 	for issueNum, work := range a.state.ActiveIssues {
@@ -885,7 +944,7 @@ func (a *Agent) HasWatchedPRs() bool {
 
 // ShouldRunReaction returns true if the given reaction type should be executed.
 // If cfg.Reactions is empty, all reactions are enabled.
-// Valid reaction names: "reviews", "ci", "conflicts".
+// Valid reaction names: "reviews", "ci", "conflicts", "rebase".
 func (a *Agent) ShouldRunReaction(reaction string) bool {
 	if len(a.cfg.Reactions) == 0 {
 		return true

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -972,7 +972,7 @@ func TestBootstrapWatchedPRs_SkipsAlreadyTracked(t *testing.T) {
 	}
 }
 
-func TestProcessConflicts_RebasesWhenBehind(t *testing.T) {
+func TestProcessConflicts_SkipsWhenBehind(t *testing.T) {
 	gh := &mockGitHubClient{
 		mergeableState: "behind",
 	}
@@ -989,6 +989,36 @@ func TestProcessConflicts_RebasesWhenBehind(t *testing.T) {
 	}
 
 	agent.ProcessConflicts(context.Background())
+
+	// ProcessConflicts should NOT rebase when state is "behind" (no conflicts)
+	var rebaseCalls int
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
+			rebaseCalls++
+		}
+	}
+	if rebaseCalls != 0 {
+		t.Error("ProcessConflicts should not rebase when state is behind (use ProcessRebase instead)")
+	}
+}
+
+func TestProcessRebase_RebasesWhenBehind(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "behind",
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessRebase(context.Background())
 
 	// Should have attempted a rebase (git fetch + git rebase)
 	var fetchCalls, rebaseCalls int
@@ -1008,7 +1038,7 @@ func TestProcessConflicts_RebasesWhenBehind(t *testing.T) {
 	}
 }
 
-func TestProcessConflicts_RebasesWhenUnstableButBehind(t *testing.T) {
+func TestProcessRebase_RebasesWhenUnstableButBehind(t *testing.T) {
 	gh := &mockGitHubClient{
 		mergeableState: "unstable",
 		prBehind:       true,
@@ -1025,7 +1055,7 @@ func TestProcessConflicts_RebasesWhenUnstableButBehind(t *testing.T) {
 		WorktreePath: "/tmp/worktree",
 	}
 
-	agent.ProcessConflicts(context.Background())
+	agent.ProcessRebase(context.Background())
 
 	var rebaseCalls int
 	for _, c := range runner.calls {
@@ -1060,6 +1090,58 @@ func TestProcessConflicts_SkipsUnstableNotBehind(t *testing.T) {
 	for _, c := range runner.calls {
 		if c.Name == "git" {
 			t.Errorf("should not run git commands for unstable+not-behind PR, got: git %v", c.Args)
+		}
+	}
+}
+
+func TestProcessRebase_SkipsUnstableNotBehind(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "unstable",
+		prBehind:       false,
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessRebase(context.Background())
+
+	for _, c := range runner.calls {
+		if c.Name == "git" {
+			t.Errorf("should not run git commands for unstable+not-behind PR, got: git %v", c.Args)
+		}
+	}
+}
+
+func TestProcessRebase_SkipsDirty(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "dirty",
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessRebase(context.Background())
+
+	// ProcessRebase should NOT handle dirty state (that's for ProcessConflicts)
+	for _, c := range runner.calls {
+		if c.Name == "git" {
+			t.Errorf("ProcessRebase should not run git commands for dirty PR, got: git %v", c.Args)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Separates the `conflicts` reaction into two distinct reactions: `conflicts` (only `dirty` mergeable state — actual merge conflicts) and `rebase` (branch behind base — no conflicts, just outdated)
- `ProcessRebase` is a new method that handles simple rebases without invoking Claude, since no conflict resolution is needed
- Backwards compatible: omitting `--reactions` enables all reactions including the new `rebase`

## Test plan
- [x] Existing tests updated: `ProcessConflicts` no longer triggers on `behind` state
- [x] New tests added for `ProcessRebase`: behind, unstable+behind, unstable+not-behind, dirty (skip)
- [x] `go test ./...` passes
- [ ] Manual test: `--reactions conflicts` should not rebase when PR is just behind
- [ ] Manual test: `--reactions rebase` should rebase when behind but skip dirty PRs
- [ ] Manual test: `--reactions conflicts,rebase` should handle both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)