### PR TITLE
Stop posting internal agent errors as GitHub comments

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -262,11 +262,8 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		if err != nil {
 			a.logger.Error("claude failed", "issue", task.issue.Number, "error", err)
 			task.work.Status = "failed"
-
 			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, "ai-failed")
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number,
-				fmt.Sprintf("AI agent failed to implement this issue: %v", err))
 			return
 		}
 
@@ -277,8 +274,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			task.work.Status = "failed"
 			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, "ai-failed")
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number,
-				fmt.Sprintf("AI agent finished but produced no commits for this issue.\n\n%s", botMarker))
 			return
 		}
 
@@ -288,8 +283,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			task.work.Status = "failed"
 			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, "ai-failed")
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number,
-				fmt.Sprintf("AI agent failed to squash commits: %v\n\n%s", err, botMarker))
 			return
 		}
 
@@ -299,8 +292,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			task.work.Status = "failed"
 			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, "ai-failed")
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number,
-				fmt.Sprintf("AI agent failed to push branch: %v\n\n%s", err, botMarker))
 			return
 		}
 
@@ -319,8 +310,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			task.work.Status = "failed"
 			_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 			_ = a.gh.AddLabel(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, "ai-failed")
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number,
-				fmt.Sprintf("AI agent failed to create PR: %v\n\n%s", err, botMarker))
 			return
 		}
 
@@ -588,10 +577,6 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			task.work.CIFixAttempts++
 			task.work.LastCIStatus = "failure"
 			task.work.LastCheckedCISHA = task.headSHA
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("CI investigation failed for commit %s: %v\n\n%s", shortSHA(task.headSHA), err, botMarker)); err != nil {
-				a.logger.Error("failed to post CI investigation error comment", "pr", task.work.PRNumber, "error", err)
-			}
 			return
 		}
 
@@ -815,7 +800,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		if err != nil {
 			a.logger.Error("claude failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Rebase failed on commit %s. Attempted to resolve conflicts automatically but failed. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
+				fmt.Sprintf("Could not resolve conflicts on commit %s automatically. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
 			return
 		}
 
@@ -843,7 +828,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 			a.logger.Error("failed to push after conflict resolution", "pr", task.work.PRNumber, "error", err)
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Rebase failed on commit %s. Attempted to resolve conflicts automatically but failed. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
+				fmt.Sprintf("Could not push conflict resolution for commit %s. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
 		} else {
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
 				fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), botMarker))

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -344,8 +344,8 @@ func TestProcessNewIssues_ClaudeFailure(t *testing.T) {
 	if len(gh.addedLabels) != 1 || gh.addedLabels[0] != "ai-failed" {
 		t.Errorf("expected 'ai-failed' label, got %v", gh.addedLabels)
 	}
-	if len(gh.addedComments) != 2 {
-		t.Errorf("expected 2 comments (in-progress + failure), got %d", len(gh.addedComments))
+	if len(gh.addedComments) != 1 {
+		t.Errorf("expected 1 comment (in-progress only, no error comment), got %d", len(gh.addedComments))
 	}
 
 	work := agent.state.ActiveIssues[42]


### PR DESCRIPTION
## Problem

Raw Go error strings were being posted as GitHub comments on issues/PRs, e.g.:

> AI agent failed to implement this issue: claude invocation failed: exec: "claude": executable file not found in \$PATH

These are noisy, expose internals, and are not actionable for users. The `ai-failed` label already signals that something went wrong.

## Changes

Removed error comments from:
- `ProcessNewIssues`: claude failure, no commits produced, squash failure, push failure, PR creation failure
- `ProcessCIFailures`: claude investigation failure

Kept human-useful notifications (no raw errors):
- "Human intervention needed" for unresolvable conflicts
- "CI still failing after N attempts" exhaustion warning
- All success notifications (rebase pushed, CI fix pushed, UNRELATED explanation)

## Test

Updated `TestProcessNewIssues_ClaudeFailure` to expect 1 comment (in-progress) instead of 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)