### PR TITLE
Skip re-investigating CI failures already reported for the same SHA

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -512,7 +512,8 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		// (handles state recovery after restarts)
 		if work.LastCheckedCISHA == "" && a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
 			work.LastCheckedCISHA = headSHA
-			// Don't continue here - if CI is failing, we should investigate despite the comment
+			a.logger.Info("CI already investigated for this SHA (found existing comment), skipping", "pr", work.PRNumber, "sha", shortSHA(headSHA))
+			continue
 		}
 
 		runs, err := a.gh.GetCheckRuns(ctx, a.cfg.Owner, a.cfg.Repo, headSHA)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -869,6 +869,38 @@ func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+		issueComments: []ReviewComment{
+			{ID: 1, User: "bot", Body: fmt.Sprintf("CI check failed on commit abc1234 but appears unrelated to this PR's changes.\n\nFlaky test\n\n%s", botMarker)},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+		// LastCheckedCISHA is "" — simulates fresh state after restart
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	if countClaudeCalls(runner.calls) != 0 {
+		t.Errorf("expected 0 claude calls (already reported via comment), got %d", countClaudeCalls(runner.calls))
+	}
+	if agent.state.ActiveIssues[42].LastCheckedCISHA != "abc123" {
+		t.Errorf("expected LastCheckedCISHA to be recovered to abc123, got %q", agent.state.ActiveIssues[42].LastCheckedCISHA)
+	}
+}
+
 func countClaudeCalls(calls []commandCall) int {
 	count := 0
 	for _, c := range calls {


### PR DESCRIPTION
## Summary
- After an agent restart, `BuildStateFromGitHub` creates fresh `IssueWork` with `LastCheckedCISHA=""`. The `alreadyCheckedCI()` fallback found existing bot comments but intentionally fell through to re-investigate, wasting a Claude invocation on a failure already reported.
- Now when `alreadyCheckedCI()` finds an existing comment for the current SHA, we recover the SHA in state and skip re-investigation. If the failure was unrelated, it's still unrelated; if it was related and a fix was pushed, the SHA would have changed.
- Added test `TestProcessCIFailures_SkipsAlreadyReportedAfterRestart` to verify the behavior.

## Test plan
- [x] `go test ./...` passes
- [x] New test covers the restart recovery path with existing bot comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)