### PR TITLE
Fix wrapper script to stop cleanly on signals

### DIFF
--- a/workflows/run-ai-agent.sh
+++ b/workflows/run-ai-agent.sh
@@ -12,6 +12,18 @@ BINARY_PATH="${INSTALL_DIR}/${BINARY_NAME}"
 
 mkdir -p "${INSTALL_DIR}"
 
+CHILD_PID=0
+
+cleanup() {
+    if [ "$CHILD_PID" -ne 0 ]; then
+        kill "$CHILD_PID" 2>/dev/null || true
+        wait "$CHILD_PID" 2>/dev/null || true
+    fi
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
 while true; do
 
     echo "Downloading latest ai-agent binary..."
@@ -29,9 +41,19 @@ while true; do
 
     echo "Starting ai-agent..."
 
-    "${BINARY_PATH}" --exit-on-new-version="${RELEASE_REPO}" "$@" || true
+    "${BINARY_PATH}" --exit-on-new-version="${RELEASE_REPO}" "$@" &
+    CHILD_PID=$!
+    wait "$CHILD_PID"
+    EXIT_CODE=$?
+    CHILD_PID=0
 
-    echo "Agent exited, restarting in 5 seconds..."
+    # If killed by a signal (exit code > 128), propagate instead of restarting
+    if [ "$EXIT_CODE" -gt 128 ]; then
+        echo "Agent killed by signal (exit code $EXIT_CODE), exiting..."
+        exit "$EXIT_CODE"
+    fi
+
+    echo "Agent exited (code $EXIT_CODE), restarting in 5 seconds..."
 
     sleep 5
 


### PR DESCRIPTION
## Summary
- Killing the ai-agent binary no longer causes the wrapper to silently restart a new instance
- Added signal trapping (SIGTERM/SIGINT) so the wrapper forwards signals to the child and exits cleanly
- Signal-caused exits (code > 128) now propagate instead of being swallowed by `|| true`
- Normal exits (e.g. new version detected) still trigger a restart as before

## Problem
The previous `|| true` on the agent invocation swallowed all exit codes, including signal kills. When an operator killed the agent binary, the `while true` loop would restart a new instance, leading to multiple agents running simultaneously.

## Test plan
- [ ] Kill the wrapper script with `kill <pid>` — agent child should also be killed, no restart
- [ ] Kill the agent binary directly with `kill <agent-pid>` — wrapper should exit instead of restarting
- [ ] Agent exits normally (e.g. `--exit-on-new-version` triggers) — wrapper should restart as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)