### PR TITLE
Use PR template when building PR description

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -991,10 +991,21 @@ func (a *Agent) defaultBranch() string {
 	return "main"
 }
 
-// buildPRBody constructs a PR description from the git log of the branch.
+// buildPRBody constructs a PR description. If Claude wrote a .pr-body.md file
+// (filled from the repo's PR template), that is used. Otherwise falls back to
+// constructing a body from the git log.
 func (a *Agent) buildPRBody(ctx context.Context, worktreePath string, issueNumber int) string {
-	// Use %b (body only) to skip the commit subject, which would duplicate the "Fixes #N" line.
-	// The --- separator makes multi-commit bodies easier to trim.
+	prBodyFile := filepath.Join(worktreePath, ".pr-body.md")
+	if content, err := os.ReadFile(prBodyFile); err == nil {
+		os.Remove(prBodyFile)
+		body := strings.TrimSpace(string(content))
+		if !strings.Contains(body, botMarker) {
+			body += "\n\n" + botMarker
+		}
+		return body
+	}
+
+	// Fallback: construct from git log body only (skip subject to avoid duplication).
 	logOut, _, _ := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%b---")
 	rawBody := strings.TrimSpace(string(logOut))
 
@@ -1081,6 +1092,9 @@ func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issue
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "reset", "--soft", a.originDefaultBranch()); err != nil {
 		return fmt.Errorf("git reset --soft: %w (stderr: %s)", err, string(stderr))
 	}
+
+	// Unstage .pr-body.md if Claude accidentally staged it — it must not be committed.
+	a.runner.Run(ctx, worktreePath, "git", "restore", "--staged", ".pr-body.md")
 
 	// Create a single commit with a meaningful message.
 	// Strip any Signed-off-by trailers Claude may have added to individual commits

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -25,9 +25,13 @@ Instructions:
 2. Implement the fix for this issue
 3. Run "make lint" and "make test" to verify your changes
 4. Commit your changes with a descriptive message (no trailing period, wrap body at 72 chars)%s
+5. Check if .github/PULL_REQUEST_TEMPLATE.md exists. If it does, fill it in for this PR
+   and write the result to .pr-body.md at the repository root. Start the file with
+   "Fixes #%d" on its own line. Do NOT git add or commit .pr-body.md.
+   If there is no PR template, skip this step.
 
 Do NOT push, create PRs, or amend — the agent handles that automatically.`,
-		issue.Number, issue.Title, issue.Body, signoff)
+		issue.Number, issue.Title, issue.Body, signoff, issue.Number)
 }
 
 func buildReviewResponsePrompt(work IssueWork, comments []ReviewComment, reviews []PRReview, owner, repo string) string {


### PR DESCRIPTION
Instead of mechanically constructing the PR body from \`git log\`, instruct Claude to check for \`.github/PULL_REQUEST_TEMPLATE.md\` and fill it in as part of the implementation step. The filled-in body is written to \`.pr-body.md\` (not committed), which \`buildPRBody\` reads and then removes. Falls back to the git-log approach when no template file exists.

\`gitSquashCommits\` now unstages \`.pr-body.md\` before the final commit so it cannot be accidentally included.

<!-- ai-agent-bot -->