### PR TITLE
Agent misses CI failures beyond first page of check-runs API

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -242,7 +242,10 @@ func (g *GoGitHubClient) AddPRCommentReaction(ctx context.Context, owner, repo s
 }
 
 func (g *GoGitHubClient) GetCheckRuns(ctx context.Context, owner, repo, ref string) ([]CheckRun, error) {
-	result, _, err := g.client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, nil)
+	opts := &github.ListCheckRunsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	result, _, err := g.client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opts)
 	if err != nil {
 		return nil, fmt.Errorf("listing check runs: %w", err)
 	}

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -505,3 +505,64 @@ func TestSearchIssues_FiltersPullRequests(t *testing.T) {
 		t.Errorf("expected issue 42, got %d", issues[0].Number)
 	}
 }
+
+func TestGetCheckRuns_UsesPerPage100(t *testing.T) {
+	var receivedPerPage int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		// Capture the per_page query parameter
+		if pp := r.URL.Query().Get("per_page"); pp != "" {
+			receivedPerPage = 100 // If per_page is set in URL, it should be 100
+			if pp != "100" {
+				t.Errorf("expected per_page=100, got %q", pp)
+			}
+		}
+
+		result := map[string]any{
+			"total_count": 2,
+			"check_runs": []map[string]any{
+				{
+					"id":         int64(1001),
+					"name":       "test-job",
+					"status":     "completed",
+					"conclusion": "success",
+				},
+				{
+					"id":         int64(1002),
+					"name":       "lint-job",
+					"status":     "completed",
+					"conclusion": "failure",
+					"output": map[string]any{
+						"text":    "Linting errors found",
+						"summary": "3 errors",
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+
+	gh := setupTestClient(t, mux)
+	runs, err := gh.GetCheckRuns(context.Background(), "owner", "repo", "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 check runs, got %d", len(runs))
+	}
+	if runs[0].ID != 1001 {
+		t.Errorf("expected check run ID 1001, got %d", runs[0].ID)
+	}
+	if runs[0].Conclusion != "success" {
+		t.Errorf("expected conclusion 'success', got %q", runs[0].Conclusion)
+	}
+	if runs[1].ID != 1002 {
+		t.Errorf("expected check run ID 1002, got %d", runs[1].ID)
+	}
+	if runs[1].Output != "Linting errors found" {
+		t.Errorf("expected output 'Linting errors found', got %q", runs[1].Output)
+	}
+	if receivedPerPage != 100 {
+		t.Error("expected per_page parameter to be set to 100")
+	}
+}


### PR DESCRIPTION
Fixes #51

Fix check-runs pagination to request 100 results per page

The GetCheckRuns method was using default pagination (30 results),
causing CI failures beyond the first page to be missed. This updates
the implementation to request up to 100 results per page, which is
the maximum allowed by the GitHub API.

Also adds a test to verify the per_page parameter is correctly set.

Fixes #51

---

<!-- oompa-bot -->