### PR TITLE
Cross-reference existing flaky test issues when reporting unrelated CI failures on PRs

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -59,6 +59,9 @@ func parseConfig() (agent.Config, string) {
 	var triageJobs string
 	flag.StringVar(&triageJobs, "triage-jobs", os.Getenv("OOMPA_TRIAGE_JOBS"), "Comma-separated CI job URLs to monitor for periodic job triage")
 
+	var flakyLabels string
+	flag.StringVar(&flakyLabels, "flaky-labels", os.Getenv("OOMPA_FLAKY_LABELS"), "Comma-separated labels to search for flaky test issues (e.g., kind/flake,ci/flaky)")
+
 	var logFile string
 	flag.StringVar(&logFile, "log-file", os.Getenv("OOMPA_LOG_FILE"), "Log file path (default: stderr)")
 
@@ -181,6 +184,15 @@ func parseConfig() (agent.Config, string) {
 			url = strings.TrimSpace(url)
 			if url != "" {
 				cfg.TriageJobs = append(cfg.TriageJobs, url)
+			}
+		}
+	}
+
+	if flakyLabels != "" {
+		for _, label := range strings.Split(flakyLabels, ",") {
+			label = strings.TrimSpace(label)
+			if label != "" {
+				cfg.FlakyLabels = append(cfg.FlakyLabels, label)
 			}
 		}
 	}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -23,10 +23,11 @@ type Config struct {
 	ForkRepo        string   // name of the fork repo (empty = same as Repo)
 	GitAuthorName   string   // git commit author name
 	GitAuthorEmail  string   // git commit author email
-	Reviewers       []string // whitelist of users/bots whose reviews to address
+	Reviewers         []string // whitelist of users/bots whose reviews to address
 	WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
 	Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+	FlakyLabels       []string // labels to search for existing flaky test issues (e.g., "kind/flake", "ci/flaky")
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 	TriageJobs        []string // CI job URLs to monitor for periodic job triage

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -587,38 +587,78 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
-			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(task.headSHA), explanation, botMarker)
+
+			// Search for existing flaky issues if configured or if we're creating flaky issues
+			var existingFlakyIssues []Issue
+			labelsToSearch := a.cfg.FlakyLabels
+			if len(labelsToSearch) == 0 && a.cfg.CreateFlakyIssues {
+				// If creating flaky issues but no labels configured, use default "flaky-test"
+				labelsToSearch = []string{"flaky-test"}
+			}
+			if len(labelsToSearch) > 0 {
+				checkName := task.failures[0].Name
+				for _, label := range labelsToSearch {
+					searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%s \"%s\" in:title",
+						a.cfg.Owner, a.cfg.Repo, label, checkName)
+					issues, err := a.gh.SearchIssues(ctx, searchQuery)
+					if err != nil {
+						a.logger.Warn("failed to search for flaky issues", "label", label, "error", err)
+						continue
+					}
+					existingFlakyIssues = append(existingFlakyIssues, issues...)
+				}
+			}
+
+			// Build PR comment
+			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s", shortSHA(task.headSHA), explanation)
+			if len(existingFlakyIssues) > 0 {
+				comment += "\n\nKnown flake(s):"
+				for _, issue := range existingFlakyIssues {
+					comment += fmt.Sprintf("\n- #%d", issue.Number)
+				}
+			}
+			comment += fmt.Sprintf("\n\n%s", botMarker)
+
 			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
 				a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
 			}
+
+			// Comment on each existing flaky issue with PR and CI details
+			if len(existingFlakyIssues) > 0 {
+				ciRunURL := ""
+				for _, f := range task.failures {
+					if f.Name == task.failures[0].Name {
+						// Try to construct a URL to the check run
+						// GitHub check run URL format: https://github.com/owner/repo/actions/runs/RUN_ID
+						// We don't have the workflow run ID here, but we can link to the commit's checks
+						ciRunURL = fmt.Sprintf("https://github.com/%s/%s/commit/%s/checks", a.cfg.Owner, a.cfg.Repo, task.headSHA)
+						break
+					}
+				}
+				flakyComment := fmt.Sprintf("This flake occurred on PR #%d.\n\n**CI run**: %s\n\n%s",
+					task.work.PRNumber, ciRunURL, botMarker)
+				for _, issue := range existingFlakyIssues {
+					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number, flakyComment); err != nil {
+						a.logger.Error("failed to comment on flaky issue", "issue", issue.Number, "error", err)
+					} else {
+						a.logger.Info("commented on flaky issue", "issue", issue.Number, "pr", task.work.PRNumber)
+					}
+				}
+			}
+
 			task.work.LastCIStatus = "unrelated-failure"
 			task.work.LastCheckedCISHA = task.headSHA
 
-			// Create a flaky CI issue if configured
-			if a.cfg.CreateFlakyIssues {
+			// Create a flaky CI issue if configured and no existing issue was found
+			if a.cfg.CreateFlakyIssues && len(existingFlakyIssues) == 0 {
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
 
-				// Search for existing open issues with the same check name
-				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:flaky-test \"%s\"",
-					a.cfg.Owner, a.cfg.Repo, issueTitle)
-				existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
-
-				var issueNum int
-				if err != nil {
-					a.logger.Warn("failed to search for existing flaky issues", "error", err)
-					// Continue with creation despite search failure
-				} else if len(existingIssues) > 0 {
-					// Issue already exists, reference it instead of creating a duplicate
-					issueNum = existingIssues[0].Number
-					a.logger.Info("found existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
-					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-						fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, botMarker)); err != nil {
-						a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
-					}
-					return
+				// Use configured labels or fall back to "flaky-test"
+				labels := a.cfg.FlakyLabels
+				if len(labels) == 0 {
+					labels = []string{"flaky-test"}
 				}
 
-				// No existing issue found, create a new one
 				issueBody := fmt.Sprintf("A CI failure was detected that appears unrelated to PR changes.\n\n"+
 					"**Detected in PR**: #%d\n"+
 					"**Commit**: %s\n"+
@@ -627,7 +667,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 					"**Check output**:\n```\n%s\n```\n\n"+
 					"%s",
 					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, explanation, task.failures[0].Output, botMarker)
-				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
+				issueNum, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, labels)
 				if err != nil {
 					a.logger.Error("failed to create flaky CI issue", "error", err)
 				} else {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -772,14 +772,19 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 		t.Errorf("expected 0 created issues (should reference existing), got %d", len(gh.createdIssues))
 	}
 
-	// Check that comments were added (unrelated notice + duplicate reference)
+	// Check that comments were added (PR comment with flaky reference + comment on flaky issue)
 	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+		t.Fatalf("expected 2 comments (PR comment + flaky issue comment), got %d", len(gh.addedComments))
 	}
 
-	// Verify the duplicate reference comment
-	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #50") {
-		t.Errorf("expected duplicate reference comment, got: %q", gh.addedComments[1])
+	// Verify the PR comment references the flaky issue
+	if !strings.Contains(gh.addedComments[0], "Known flake(s)") || !strings.Contains(gh.addedComments[0], "#50") {
+		t.Errorf("expected PR comment to reference flaky issue #50, got: %q", gh.addedComments[0])
+	}
+
+	// Verify the comment on the flaky issue references the PR
+	if !strings.Contains(gh.addedComments[1], "This flake occurred on PR #100") {
+		t.Errorf("expected flaky issue comment to reference PR #100, got: %q", gh.addedComments[1])
 	}
 }
 

--- a/specs/config.md
+++ b/specs/config.md
@@ -19,6 +19,7 @@ type Config struct {
     WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
     Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
     CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+    FlakyLabels       []string // labels to search when cross-referencing flaky test issues (e.g. "kind/flake", "ci/flaky")
 }
 ```
 
@@ -40,6 +41,7 @@ type Config struct {
 | `OOMPA_WATCH_PRS` | `--watch-prs` | (empty) | Comma-separated PR numbers to monitor directly (bypasses issue discovery) |
 | `OOMPA_REACTIONS` | `--reactions` | (empty = all) | Comma-separated list of reactions to run: `reviews`, `ci`, `conflicts` |
 | `OOMPA_CREATE_FLAKY_ISSUES` | `--create-flaky-issues` | `false` | When true, create issues for unrelated CI failures (opt-in) |
+| `OOMPA_FLAKY_LABELS` | `--flaky-labels` | (empty) | Comma-separated labels to search when cross-referencing flaky test issues (e.g. `kind/flake,ci/flaky`) |
 
 Config from env vars (`OOMPA_*`) with flag overrides, read in `main()`.
 


### PR DESCRIPTION
Fixes #55

Add cross-referencing for flaky test issues in CI failures

When oompa detects an unrelated CI failure on a PR, it now searches
for existing flaky test issues and creates bidirectional links:

1. Searches for existing issues using --flaky-labels (configurable
   comma-separated list like "kind/flake,ci/flaky")
2. References existing flaky issues in the PR comment
3. Comments on the flaky issue with PR number and CI run details
4. Uses configured labels when creating new flaky issues
5. Falls back to "flaky-test" label if no labels configured

This creates a bidirectional link between PRs and known flakes,
making it easier to:
- Track how often a flake is hitting PRs
- Help PR authors understand failures are not their fault
- Build evidence for prioritizing flaky test fixes

Configuration:
- OOMPA_FLAKY_LABELS / --flaky-labels: labels to search for existing
  flaky test issues (optional, defaults to "flaky-test" when
  --create-flaky-issues is enabled)

---

<!-- oompa-bot -->