### PR TITLE
Replace wrapper script with native systemd unit for binary management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,36 @@ Claude never merges; a human must approve and merge every PR.
 go build -o oompa ./cmd/oompa
 ```
 
+## Deployment
+
+### Systemd (recommended for production)
+
+For long-running deployments with automatic updates and process supervision, use the systemd unit:
+
+```bash
+cd deploy/systemd
+./install.sh --user issue-resolver  # User-specific installation
+# OR
+sudo ./install.sh issue-resolver    # System-wide installation
+```
+
+See [`deploy/systemd/README.md`](deploy/systemd/README.md) for full documentation, including multi-instance setup and configuration.
+
+### Manual wrapper script
+
+For development or platforms without systemd, use the wrapper script:
+
+```bash
+export GITHUB_TOKEN="ghp_..."
+export CLOUD_ML_REGION="us-east5"
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+
+cd workflows
+./run-oompa.sh --owner myorg --repo myrepo
+```
+
+See [`workflows/README.md`](workflows/README.md) for Ambient Code workflows.
+
 ## Usage
 
 ### With a personal access token (PAT)

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,216 @@
+# Systemd Deployment
+
+This directory contains a native systemd unit for running oompa with automatic binary updates and restart handling.
+
+## Features
+
+- **Auto-update**: Downloads the latest oompa binary from GitHub releases on each restart
+- **Process supervision**: Systemd handles restarts, logging, and dependency management
+- **Multi-instance**: Template unit supports running multiple oompa instances
+- **Journald logging**: All output goes to systemd's journal (`journalctl -u oompa@<instance>`)
+- **Boot-time startup**: Enable with `systemctl enable oompa@<instance>`
+
+## Quick Start
+
+### 1. Install the unit file
+
+**System-wide** (requires root):
+```bash
+sudo cp oompa@.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+**User-specific** (no root required):
+```bash
+mkdir -p ~/.config/systemd/user/
+cp oompa@.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+```
+
+### 2. Configure environment
+
+**System-wide**:
+```bash
+sudo mkdir -p /etc/oompa
+sudo cp example.env /etc/oompa/issue-resolver.env
+sudo nano /etc/oompa/issue-resolver.env  # Add your GITHUB_TOKEN and OOMPA_FLAGS
+```
+
+**User-specific**:
+```bash
+mkdir -p ~/.config/oompa
+cp example.env ~/.config/oompa/issue-resolver.env
+nano ~/.config/oompa/issue-resolver.env  # Add your GITHUB_TOKEN and OOMPA_FLAGS
+```
+
+### 3. Create binary directory
+
+**System-wide**:
+```bash
+sudo mkdir -p /var/lib/oompa/bin
+```
+
+**User-specific**:
+```bash
+mkdir -p ~/var/lib/oompa/bin
+# Edit the service file to use a user-writable path:
+# Environment=OOMPA_BINARY_DIR=%h/var/lib/oompa/bin
+```
+
+### 4. Start the service
+
+**System-wide**:
+```bash
+sudo systemctl start oompa@issue-resolver
+sudo systemctl status oompa@issue-resolver
+```
+
+**User-specific**:
+```bash
+systemctl --user start oompa@issue-resolver
+systemctl --user status oompa@issue-resolver
+```
+
+### 5. Enable on boot (optional)
+
+**System-wide**:
+```bash
+sudo systemctl enable oompa@issue-resolver
+```
+
+**User-specific**:
+```bash
+systemctl --user enable oompa@issue-resolver
+systemctl --user enable --now oompa@issue-resolver  # Enable and start
+```
+
+## Multiple Instances
+
+Run multiple oompa instances with different configurations:
+
+```bash
+# Create separate environment files
+sudo cp example.env /etc/oompa/issue-resolver.env
+sudo cp example.env /etc/oompa/pr-babysitter.env
+sudo cp example.env /etc/oompa/ci-fixer.env
+
+# Edit each with instance-specific configuration
+sudo nano /etc/oompa/issue-resolver.env
+sudo nano /etc/oompa/pr-babysitter.env
+sudo nano /etc/oompa/ci-fixer.env
+
+# Start each instance
+sudo systemctl start oompa@issue-resolver
+sudo systemctl start oompa@pr-babysitter
+sudo systemctl start oompa@ci-fixer
+```
+
+## Managing Services
+
+### View logs
+```bash
+# Follow logs for a specific instance
+sudo journalctl -u oompa@issue-resolver -f
+
+# View logs with user service
+journalctl --user -u oompa@issue-resolver -f
+
+# View logs since last restart
+sudo journalctl -u oompa@issue-resolver --since today
+```
+
+### Restart service
+```bash
+sudo systemctl restart oompa@issue-resolver
+```
+
+### Stop service
+```bash
+sudo systemctl stop oompa@issue-resolver
+```
+
+### Check status
+```bash
+sudo systemctl status oompa@issue-resolver
+```
+
+### Disable auto-start
+```bash
+sudo systemctl disable oompa@issue-resolver
+```
+
+## How It Works
+
+1. **ExecStartPre**: Downloads the latest oompa binary from GitHub releases using `gh release download`
+2. **ExecStart**: Runs oompa with `--exit-on-new-version`, which monitors for new releases
+3. **Restart=always**: When oompa exits (new version detected or crash), systemd restarts it
+4. **RestartSec=5**: Waits 5 seconds between restarts to avoid tight loops
+
+The binary exits cleanly when a new version is available, triggering systemd to restart the service. On restart, ExecStartPre downloads the new binary, creating a seamless auto-update loop.
+
+## Configuration Variables
+
+Environment variables can be set in the `.env` file:
+
+- `GITHUB_TOKEN`: GitHub API token (required)
+- `OOMPA_FLAGS`: Additional command-line flags (e.g., `--repo owner/repo --poll-interval 300`)
+- `OOMPA_BINARY_DIR`: Where to store the binary (default: `/var/lib/oompa/bin`)
+- `OOMPA_RELEASE_REPO`: GitHub repo for binary releases (default: `qinqon/oompa`)
+- `OOMPA_BINARY_NAME`: Binary filename to download (default: `oompa-linux-amd64`)
+
+## Architecture Support
+
+For ARM64 systems, update the environment file:
+```bash
+OOMPA_BINARY_NAME=oompa-linux-arm64
+```
+
+For macOS (with launchd instead of systemd), see the wrapper script at `workflows/run-oompa.sh`.
+
+## Security Notes
+
+- The unit includes basic hardening: `NoNewPrivileges=true` and `PrivateTmp=true`
+- User-specific services run with user privileges (no root access)
+- System-wide services can specify a dedicated user with `User=oompa` in the unit file
+- Store `GITHUB_TOKEN` securely in environment files with restricted permissions:
+  ```bash
+  sudo chmod 600 /etc/oompa/*.env
+  ```
+
+## Troubleshooting
+
+### Service fails to start
+```bash
+# Check service status
+sudo systemctl status oompa@issue-resolver
+
+# View full logs
+sudo journalctl -u oompa@issue-resolver -n 100
+
+# Verify environment file exists and is readable
+sudo cat /etc/oompa/issue-resolver.env
+
+# Test manually
+export $(cat /etc/oompa/issue-resolver.env | xargs)
+/var/lib/oompa/bin/oompa --exit-on-new-version=qinqon/oompa $OOMPA_FLAGS
+```
+
+### Binary download fails
+- Ensure `gh` (GitHub CLI) is installed and authenticated
+- Check network connectivity: `curl -I https://github.com`
+- Verify release exists: `gh release view --repo qinqon/oompa`
+
+### Permission denied
+- System-wide: Ensure `/var/lib/oompa/bin` is writable by the service user
+- User-specific: Use a user-writable path in `OOMPA_BINARY_DIR`
+
+## Migration from Wrapper Script
+
+If you're currently using `workflows/run-oompa.sh`, here's how to migrate:
+
+1. Stop the wrapper script (Ctrl+C or kill the process)
+2. Follow the Quick Start steps above
+3. Set `OOMPA_FLAGS` in the env file to match the arguments you passed to the wrapper script
+4. Start the systemd service
+
+The systemd unit provides the same functionality with better process management and logging.

--- a/deploy/systemd/example.env
+++ b/deploy/systemd/example.env
@@ -1,0 +1,18 @@
+# Oompa environment configuration
+# Copy this file to /etc/oompa/<instance-name>.env or ~/.config/oompa/<instance-name>.env
+
+# GitHub token for API access (required)
+GITHUB_TOKEN=ghp_your_token_here
+
+# Additional flags to pass to oompa (optional)
+# Example: OOMPA_FLAGS=--repo qinqon/oompa --poll-interval 300
+OOMPA_FLAGS=
+
+# Override binary directory (optional, defaults to /var/lib/oompa/bin)
+# OOMPA_BINARY_DIR=/custom/path/to/bin
+
+# Override release repository (optional, defaults to qinqon/oompa)
+# OOMPA_RELEASE_REPO=yourorg/yourfork
+
+# Override binary name (optional, defaults to oompa-linux-amd64)
+# OOMPA_BINARY_NAME=oompa-linux-arm64

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Oompa systemd installer
+# Usage: ./install.sh [--user] <instance-name>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+USER_MODE=false
+INSTANCE_NAME=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --user)
+            USER_MODE=true
+            shift
+            ;;
+        *)
+            INSTANCE_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$INSTANCE_NAME" ]; then
+    echo "Usage: $0 [--user] <instance-name>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --user issue-resolver    # Install for current user"
+    echo "  sudo $0 issue-resolver       # Install system-wide (requires root)"
+    exit 1
+fi
+
+if [ "$USER_MODE" = true ]; then
+    echo "Installing oompa@${INSTANCE_NAME} for user: $(whoami)"
+    
+    # User-specific paths
+    UNIT_DIR="${HOME}/.config/systemd/user"
+    ENV_DIR="${HOME}/.config/oompa"
+    BIN_DIR="${HOME}/var/lib/oompa/bin"
+    SYSTEMCTL="systemctl --user"
+    
+    mkdir -p "$UNIT_DIR"
+    mkdir -p "$ENV_DIR"
+    mkdir -p "$BIN_DIR"
+    
+    # Copy unit file
+    cp "${SCRIPT_DIR}/oompa@.service" "$UNIT_DIR/"
+    
+    # Create environment file if it doesn't exist
+    if [ ! -f "${ENV_DIR}/${INSTANCE_NAME}.env" ]; then
+        cp "${SCRIPT_DIR}/example.env" "${ENV_DIR}/${INSTANCE_NAME}.env"
+        echo "Created environment file: ${ENV_DIR}/${INSTANCE_NAME}.env"
+        echo "Please edit this file to add your GITHUB_TOKEN and OOMPA_FLAGS"
+    else
+        echo "Environment file already exists: ${ENV_DIR}/${INSTANCE_NAME}.env"
+    fi
+    
+    # Update binary directory in user service
+    # (User mode needs a writable location)
+    echo "Note: Edit ${UNIT_DIR}/oompa@.service to set OOMPA_BINARY_DIR=${BIN_DIR}"
+    
+    $SYSTEMCTL daemon-reload
+    
+    echo ""
+    echo "Installation complete!"
+    echo ""
+    echo "Next steps:"
+    echo "1. Edit environment file: nano ${ENV_DIR}/${INSTANCE_NAME}.env"
+    echo "2. Start service: systemctl --user start oompa@${INSTANCE_NAME}"
+    echo "3. View logs: journalctl --user -u oompa@${INSTANCE_NAME} -f"
+    echo "4. Enable on login: systemctl --user enable oompa@${INSTANCE_NAME}"
+    
+else
+    # System-wide installation (requires root)
+    if [ "$EUID" -ne 0 ]; then
+        echo "Error: System-wide installation requires root privileges"
+        echo "Please run with sudo or use --user flag for user installation"
+        exit 1
+    fi
+    
+    echo "Installing oompa@${INSTANCE_NAME} system-wide"
+    
+    # System-wide paths
+    UNIT_DIR="/etc/systemd/system"
+    ENV_DIR="/etc/oompa"
+    BIN_DIR="/var/lib/oompa/bin"
+    SYSTEMCTL="systemctl"
+    
+    mkdir -p "$ENV_DIR"
+    mkdir -p "$BIN_DIR"
+    
+    # Copy unit file
+    cp "${SCRIPT_DIR}/oompa@.service" "$UNIT_DIR/"
+    
+    # Create environment file if it doesn't exist
+    if [ ! -f "${ENV_DIR}/${INSTANCE_NAME}.env" ]; then
+        cp "${SCRIPT_DIR}/example.env" "${ENV_DIR}/${INSTANCE_NAME}.env"
+        chmod 600 "${ENV_DIR}/${INSTANCE_NAME}.env"
+        echo "Created environment file: ${ENV_DIR}/${INSTANCE_NAME}.env"
+        echo "Please edit this file to add your GITHUB_TOKEN and OOMPA_FLAGS"
+    else
+        echo "Environment file already exists: ${ENV_DIR}/${INSTANCE_NAME}.env"
+    fi
+    
+    $SYSTEMCTL daemon-reload
+    
+    echo ""
+    echo "Installation complete!"
+    echo ""
+    echo "Next steps:"
+    echo "1. Edit environment file: nano ${ENV_DIR}/${INSTANCE_NAME}.env"
+    echo "2. Start service: systemctl start oompa@${INSTANCE_NAME}"
+    echo "3. View logs: journalctl -u oompa@${INSTANCE_NAME} -f"
+    echo "4. Enable on boot: systemctl enable oompa@${INSTANCE_NAME}"
+fi

--- a/deploy/systemd/oompa@.service
+++ b/deploy/systemd/oompa@.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=Oompa agent: %i
+Documentation=https://github.com/qinqon/oompa
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Run as the invoking user (systemctl --user) or specified user (system-wide)
+User=%u
+EnvironmentFile=-/etc/oompa/%i.env
+EnvironmentFile=-%h/.config/oompa/%i.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=HOME=%h
+Environment=OOMPA_BINARY_DIR=/var/lib/oompa/bin
+Environment=OOMPA_RELEASE_REPO=qinqon/oompa
+Environment=OOMPA_BINARY_NAME=oompa-linux-amd64
+
+# Create binary directory
+ExecStartPre=/usr/bin/mkdir -p ${OOMPA_BINARY_DIR}
+
+# Download latest binary
+# Use a temporary directory to avoid "text file busy" errors
+ExecStartPre=/bin/sh -c 'gh release download --repo ${OOMPA_RELEASE_REPO} --pattern ${OOMPA_BINARY_NAME} --dir ${OOMPA_BINARY_DIR}/tmp-download --clobber'
+
+# Move to final location and make executable
+ExecStartPre=/bin/sh -c 'mv ${OOMPA_BINARY_DIR}/tmp-download/${OOMPA_BINARY_NAME} ${OOMPA_BINARY_DIR}/oompa'
+ExecStartPre=/usr/bin/chmod +x ${OOMPA_BINARY_DIR}/oompa
+
+# Run oompa with auto-update support
+# The binary exits when a new version is detected, triggering a restart
+ExecStart=${OOMPA_BINARY_DIR}/oompa --exit-on-new-version=${OOMPA_RELEASE_REPO} ${OOMPA_FLAGS}
+
+# Restart policy: always restart (handles auto-updates and crashes)
+Restart=always
+RestartSec=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=oompa-%i
+
+# Security hardening (optional, can be relaxed if needed)
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -26,3 +26,7 @@ The following tools must be installed and available in PATH on the runner:
 3. Claude greets you and asks for the required information (repository, PR numbers, etc.).
 4. Once you provide the details, Claude downloads the runner script and starts the agent.
 5. The runner script downloads the latest `oompa` binary from GitHub releases and runs it in a restart loop with auto-update support.
+
+## Alternative: Systemd Deployment
+
+For long-running production deployments with better process supervision and automatic updates, consider using the systemd unit instead of the wrapper script. See [`../deploy/systemd/README.md`](../deploy/systemd/README.md) for details.


### PR DESCRIPTION
Fixes #54

Add systemd unit for native binary management

Replace wrapper script with a native systemd unit that handles binary
download, execution, and auto-update restarts without shell scripting.

The systemd deployment provides:
- Binary management: Downloads latest oompa from GitHub releases
- Auto-restart: Restarts on exit (new version detected)
- Process supervision: Native systemd signal handling and logging
- Multi-instance: Template unit supports multiple instances
- Boot-time startup: Enable with systemctl enable

Created files:
- deploy/systemd/oompa@.service: Template unit file
- deploy/systemd/example.env: Environment configuration template
- deploy/systemd/install.sh: Installation helper script
- deploy/systemd/README.md: Full deployment documentation

Updated README.md and workflows/README.md to reference the new systemd
deployment as the recommended production option, with the wrapper script
as a fallback for development or non-systemd platforms.

Fixes #54

---

<!-- oompa-bot -->