### PR TITLE
Cross-reference existing flaky test issues when reporting unrelated CI failures on PRs

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -63,6 +63,7 @@ func parseConfig() (agent.Config, string) {
 	flag.StringVar(&logFile, "log-file", os.Getenv("OOMPA_LOG_FILE"), "Log file path (default: stderr)")
 
 	flag.BoolVar(&cfg.CreateFlakyIssues, "create-flaky-issues", envOrDefault("OOMPA_CREATE_FLAKY_ISSUES", "") == "true", "Create issues for unrelated CI failures (opt-in)")
+	flag.StringVar(&cfg.FlakyLabel, "flaky-label", envOrDefault("OOMPA_FLAKY_LABEL", ""), "Label used to find/tag flaky test issues (empty = skip cross-referencing)")
 	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("OOMPA_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
 	flag.IntVar(&cfg.MaxWorkers, "max-workers", parseIntEnv("OOMPA_MAX_WORKERS", 1), "Maximum parallel Claude invocations (default 1 = sequential)")
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
 	Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+	FlakyLabel        string   // label used to find/tag flaky test issues (empty = skip cross-referencing)
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 	TriageJobs        []string // CI job URLs to monitor for periodic job triage

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -594,13 +594,14 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			task.work.LastCIStatus = "unrelated-failure"
 			task.work.LastCheckedCISHA = task.headSHA
 
-			// Create a flaky CI issue if configured
-			if a.cfg.CreateFlakyIssues {
+			// Cross-reference flaky CI issues if configured
+			if a.cfg.CreateFlakyIssues && a.cfg.FlakyLabel != "" {
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
+				ciRunURL := fmt.Sprintf("https://github.com/%s/%s/runs/%d", a.cfg.Owner, a.cfg.Repo, task.failures[0].ID)
 
 				// Search for existing open issues with the same check name
-				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:flaky-test \"%s\"",
-					a.cfg.Owner, a.cfg.Repo, issueTitle)
+				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%s \"%s\"",
+					a.cfg.Owner, a.cfg.Repo, a.cfg.FlakyLabel, issueTitle)
 				existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
 
 				var issueNum int
@@ -608,13 +609,22 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 					a.logger.Warn("failed to search for existing flaky issues", "error", err)
 					// Continue with creation despite search failure
 				} else if len(existingIssues) > 0 {
-					// Issue already exists, reference it instead of creating a duplicate
+					// Issue already exists, reference it on the PR and comment on the flaky issue
 					issueNum = existingIssues[0].Number
 					a.logger.Info("found existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
+
+					// Comment on the PR referencing the known flake
 					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-						fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, botMarker)); err != nil {
+						fmt.Sprintf("CI failure in `%s` is unrelated to this PR. Known flake: #%d\n\n%s", task.failures[0].Name, issueNum, botMarker)); err != nil {
 						a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
 					}
+
+					// Comment on the flaky issue with the new occurrence
+					occurrenceComment := fmt.Sprintf("This flake occurred again on PR #%d. CI run: %s\n\n%s", task.work.PRNumber, ciRunURL, botMarker)
+					if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issueNum, occurrenceComment); err != nil {
+						a.logger.Error("failed to comment on flaky issue", "issue", issueNum, "error", err)
+					}
+
 					return
 				}
 
@@ -622,12 +632,13 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				issueBody := fmt.Sprintf("A CI failure was detected that appears unrelated to PR changes.\n\n"+
 					"**Detected in PR**: #%d\n"+
 					"**Commit**: %s\n"+
-					"**Failed check**: %s\n\n"+
+					"**Failed check**: %s\n"+
+					"**CI run**: %s\n\n"+
 					"**Analysis**:\n%s\n\n"+
 					"**Check output**:\n```\n%s\n```\n\n"+
 					"%s",
-					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, explanation, task.failures[0].Output, botMarker)
-				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
+					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, ciRunURL, explanation, task.failures[0].Output, botMarker)
+				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
 				if err != nil {
 					a.logger.Error("failed to create flaky CI issue", "error", err)
 				} else {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -678,6 +678,7 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true // Enable flaky issue creation
+	agent.cfg.FlakyLabel = "flaky-test" // Set flaky label
 	agent.state.ActiveIssues[42] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
@@ -719,6 +720,7 @@ func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false // Disabled by default
+	agent.cfg.FlakyLabel = "flaky-test"
 	agent.state.ActiveIssues[42] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
@@ -756,6 +758,7 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
+	agent.cfg.FlakyLabel = "flaky-test"
 	agent.state.ActiveIssues[42] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
@@ -772,14 +775,22 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 		t.Errorf("expected 0 created issues (should reference existing), got %d", len(gh.createdIssues))
 	}
 
-	// Check that comments were added (unrelated notice + duplicate reference)
-	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+	// Check that 3 comments were added: unrelated notice + PR reference to flaky issue + comment on flaky issue
+	if len(gh.addedComments) != 3 {
+		t.Fatalf("expected 3 comments (unrelated + PR reference + flaky issue comment), got %d", len(gh.addedComments))
 	}
 
-	// Verify the duplicate reference comment
-	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #50") {
-		t.Errorf("expected duplicate reference comment, got: %q", gh.addedComments[1])
+	// Verify the PR comment references the known flake
+	if !strings.Contains(gh.addedComments[1], "Known flake: #50") {
+		t.Errorf("expected 'Known flake: #50' comment, got: %q", gh.addedComments[1])
+	}
+
+	// Verify the flaky issue comment with PR and CI run details
+	if !strings.Contains(gh.addedComments[2], "occurred again on PR #100") {
+		t.Errorf("expected occurrence comment on flaky issue, got: %q", gh.addedComments[2])
+	}
+	if !strings.Contains(gh.addedComments[2], "https://github.com/") {
+		t.Errorf("expected CI run URL in flaky issue comment, got: %q", gh.addedComments[2])
 	}
 }
 
@@ -796,6 +807,7 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
+	agent.cfg.FlakyLabel = "flaky-test"
 	agent.state.ActiveIssues[42] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
@@ -823,6 +835,41 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 	// Check that comments were added (unrelated notice + new issue reference)
 	if len(gh.addedComments) != 2 {
 		t.Fatalf("expected 2 comments (unrelated + issue link), got %d", len(gh.addedComments))
+	}
+}
+
+func TestProcessCIFailures_SkipsCrossReferencingWhenLabelNotSet(t *testing.T) {
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true  // Enabled
+	agent.cfg.FlakyLabel = ""           // But no label configured
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that no flaky issue was created (label not configured)
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues when label is not configured, got %d", len(gh.createdIssues))
+	}
+
+	// Check that only one comment was added (the unrelated notice)
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment (unrelated notice only), got %d", len(gh.addedComments))
 	}
 }
 

--- a/specs/config.md
+++ b/specs/config.md
@@ -19,6 +19,7 @@ type Config struct {
     WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
     Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
     CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+    FlakyLabel        string   // label used to find/tag flaky test issues (empty = skip cross-referencing)
 }
 ```
 
@@ -40,6 +41,7 @@ type Config struct {
 | `OOMPA_WATCH_PRS` | `--watch-prs` | (empty) | Comma-separated PR numbers to monitor directly (bypasses issue discovery) |
 | `OOMPA_REACTIONS` | `--reactions` | (empty = all) | Comma-separated list of reactions to run: `reviews`, `ci`, `conflicts` |
 | `OOMPA_CREATE_FLAKY_ISSUES` | `--create-flaky-issues` | `false` | When true, create issues for unrelated CI failures (opt-in) |
+| `OOMPA_FLAKY_LABEL` | `--flaky-label` | (empty) | Label used to find/tag flaky test issues (empty = skip cross-referencing) |
 
 Config from env vars (`OOMPA_*`) with flag overrides, read in `main()`.
 


### PR DESCRIPTION
Fixes #55

Add configurable flaky label for cross-referencing CI failures

Implements cross-referencing of flaky test issues when oompa detects
unrelated CI failures on PRs. The new --flaky-label flag allows users
to configure which label is used to find and tag flaky test issues.

When an unrelated CI failure is detected and the flaky label is set:
- Searches for existing issues with the configured label matching the
  failed check name
- If found, comments on the PR with "Known flake: #X" and adds a
  comment to the flaky issue with PR and CI run details
- If not found, creates a new flaky issue with the configured label

The feature requires both --create-flaky-issues and --flaky-label to
be configured. When --flaky-label is not set, cross-referencing is
skipped even if --create-flaky-issues is enabled.

---

<!-- oompa-bot -->