### PR TITLE
Replace wrapper script with native systemd unit for binary management

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ When using GitHub App auth, the agent pushes branches directly to the upstream r
 
 The agent is stateless on disk. On every startup it rebuilds its state from GitHub by scanning labeled issues and matching PRs, so there is nothing to back up or migrate.
 
+## Deployment
+
+### Long-running service (systemd)
+
+For production deployments on Linux, use the native systemd unit for automatic binary updates, restarts, and proper process supervision:
+
+```bash
+cd deploy/systemd
+./install.sh issue-resolver
+# Edit ~/.config/oompa/issue-resolver.env with your configuration
+systemctl --user start oompa@issue-resolver
+systemctl --user enable oompa@issue-resolver
+```
+
+See [`deploy/systemd/README.md`](deploy/systemd/README.md) for details.
+
+### Wrapper script (legacy)
+
+For Ambient Code platform or quick testing, use the wrapper script:
+
+```bash
+./workflows/run-oompa.sh --owner myorg --repo myrepo
+```
+
 ## Testing
 
 ```bash

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,178 @@
+# Systemd Deployment
+
+This directory contains a native systemd unit for running oompa as a long-running service with automatic binary updates and restarts.
+
+## Overview
+
+The systemd unit replaces the `run-oompa.sh` wrapper script with a cleaner, more maintainable solution that:
+
+- Downloads the latest `oompa` binary from GitHub releases before each start
+- Runs oompa with `--exit-on-new-version` to trigger restarts when updates are available
+- Automatically restarts on exit (new version or transient failures)
+- Integrates with journald for centralized logging
+- Supports multiple instances via systemd templates (e.g., `oompa@issue-resolver.service`, `oompa@pr-babysitter.service`)
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+- Google Cloud Application Default Credentials configured
+- systemd (Linux only)
+
+## Quick Start
+
+### 1. Install the service
+
+```bash
+cd deploy/systemd
+./install.sh issue-resolver
+```
+
+This creates:
+- `~/.config/systemd/user/oompa@.service` - The service template
+- `~/.config/oompa/issue-resolver.env` - Configuration file for this instance
+
+### 2. Configure the environment file
+
+Edit `~/.config/oompa/issue-resolver.env`:
+
+```bash
+# GitHub authentication
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Google Cloud Vertex AI
+CLOUD_ML_REGION=us-east5
+ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
+
+# Oompa command-line flags
+OOMPA_FLAGS=--owner myorg --repo myrepo --label good-for-ai --poll-interval 2m
+```
+
+See `env.example` for all available options.
+
+### 3. Start the service
+
+```bash
+systemctl --user start oompa@issue-resolver
+systemctl --user status oompa@issue-resolver
+```
+
+### 4. Enable auto-start on boot
+
+```bash
+systemctl --user enable oompa@issue-resolver
+loginctl enable-linger $USER  # Run even when not logged in
+```
+
+## Multiple Instances
+
+You can run multiple oompa instances side-by-side for different use cases:
+
+```bash
+# Issue resolver
+./install.sh issue-resolver
+# Edit ~/.config/oompa/issue-resolver.env with: --owner myorg --repo myrepo --label good-for-ai
+
+# PR babysitter
+./install.sh pr-babysitter
+# Edit ~/.config/oompa/pr-babysitter.env with: --owner myorg --repo myrepo --pr-numbers 123,456
+
+# Start both
+systemctl --user start oompa@issue-resolver oompa@pr-babysitter
+```
+
+## Managing the Service
+
+### View logs
+
+```bash
+# Follow logs in real-time
+journalctl --user -u oompa@issue-resolver -f
+
+# View recent logs
+journalctl --user -u oompa@issue-resolver -n 100
+
+# View logs since last boot
+journalctl --user -u oompa@issue-resolver -b
+```
+
+### Stop the service
+
+```bash
+systemctl --user stop oompa@issue-resolver
+```
+
+### Restart manually
+
+```bash
+systemctl --user restart oompa@issue-resolver
+```
+
+### Disable auto-start
+
+```bash
+systemctl --user disable oompa@issue-resolver
+```
+
+## How It Works
+
+1. **ExecStartPre**: Downloads the latest `oompa-linux-amd64` binary from GitHub releases to `/tmp/oompa-bin/`
+2. **ExecStart**: Runs the binary with `--exit-on-new-version=qinqon/oompa` plus user-configured flags
+3. **On exit**: systemd waits 5 seconds (`RestartSec=5`) then loops back to step 1
+
+This ensures oompa automatically picks up new releases without manual intervention.
+
+## Troubleshooting
+
+### Service fails to start
+
+Check the logs:
+```bash
+journalctl --user -u oompa@issue-resolver -n 50
+```
+
+Common issues:
+- Missing `GITHUB_TOKEN` or invalid GitHub App credentials
+- Missing `CLOUD_ML_REGION` or `ANTHROPIC_VERTEX_PROJECT_ID`
+- `gh` CLI not installed or not in PATH
+- Invalid `OOMPA_FLAGS` syntax
+
+### Binary download fails
+
+Ensure:
+- `gh` CLI is authenticated: `gh auth status`
+- Network connectivity to `github.com`
+- GitHub rate limits haven't been exceeded
+
+### Service doesn't restart after new release
+
+Check:
+- Binary is running with `--exit-on-new-version=qinqon/oompa` flag
+- Service restart policy is active: `systemctl --user show oompa@issue-resolver | grep Restart`
+
+## System-wide Installation (Optional)
+
+For system-wide deployment (runs as a dedicated user), install to `/etc/systemd/system/` instead:
+
+```bash
+sudo cp oompa@.service /etc/systemd/system/
+sudo mkdir -p /etc/oompa
+sudo cp env.example /etc/oompa/issue-resolver.env
+# Edit /etc/oompa/issue-resolver.env
+sudo systemctl daemon-reload
+sudo systemctl start oompa@issue-resolver
+sudo systemctl enable oompa@issue-resolver
+```
+
+Update the `User=` directive in the service file to specify the service account.
+
+## Migration from run-oompa.sh
+
+If you're currently using `run-oompa.sh`:
+
+1. Note your current command-line arguments
+2. Stop the wrapper script (Ctrl+C or kill the process)
+3. Follow the installation steps above
+4. Add your arguments to `OOMPA_FLAGS` in the env file
+5. Start the systemd service
+
+The systemd unit provides the same functionality with better process management and logging.

--- a/deploy/systemd/env.example
+++ b/deploy/systemd/env.example
@@ -1,0 +1,31 @@
+# Oompa systemd environment file
+# Copy this to /etc/oompa/<instance-name>.env and customize for your deployment
+
+# GitHub authentication (use either GITHUB_TOKEN or GitHub App credentials)
+GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# GitHub App authentication (alternative to GITHUB_TOKEN)
+# GITHUB_APP_ID=123456
+# GITHUB_APP_PRIVATE_KEY_PATH=/etc/oompa/github-app-key.pem
+# GITHUB_APP_INSTALLATION_ID=78901234
+
+# Google Cloud Vertex AI configuration (required)
+CLOUD_ML_REGION=us-east5
+ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
+
+# Oompa command-line flags (customize for your use case)
+# Example for issue resolver:
+OOMPA_FLAGS=--owner myorg --repo myrepo --label good-for-ai --poll-interval 2m
+
+# Example for PR babysitter (uncomment and edit):
+# OOMPA_FLAGS=--owner myorg --repo myrepo --pr-numbers 123,456 --poll-interval 1m
+
+# Additional options:
+# --clone-dir         Working directory (default: ~/oompa-work)
+# --log-level         debug, info, warn, error (default: info)
+# --log-file          Log to file instead of journald
+# --signed-off-by     Commit trailer
+# --reviewers         Comma-separated reviewer allowlist
+# --create-flaky-issues  Create issues for unrelated CI failures
+# --dry-run           Log actions without executing
+# --one-shot          Run once and exit (for testing)

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+INSTANCE_NAME="${1:-}"
+
+if [ -z "$INSTANCE_NAME" ]; then
+    echo "Usage: $0 <instance-name>"
+    echo ""
+    echo "Example: $0 issue-resolver"
+    echo "         $0 pr-babysitter"
+    echo ""
+    echo "This will install oompa@<instance-name>.service"
+    exit 1
+fi
+
+echo "Installing oompa@${INSTANCE_NAME}.service..."
+
+# Check prerequisites
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI is not installed or not in PATH"
+    echo "Install it from: https://cli.github.com/"
+    exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+    echo "Error: gh CLI is not authenticated"
+    echo "Run: gh auth login"
+    exit 1
+fi
+
+# Create systemd directory structure
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+mkdir -p "${SYSTEMD_USER_DIR}"
+
+# Copy service file to user systemd directory
+cp oompa@.service "${SYSTEMD_USER_DIR}/"
+
+echo "Service file installed to: ${SYSTEMD_USER_DIR}/oompa@.service"
+
+# Create environment file directory
+ENV_DIR="${HOME}/.config/oompa"
+mkdir -p "${ENV_DIR}"
+
+ENV_FILE="${ENV_DIR}/${INSTANCE_NAME}.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Environment file already exists: ${ENV_FILE}"
+    echo "Skipping environment file creation (not overwriting existing config)"
+else
+    cp env.example "${ENV_FILE}"
+    echo "Environment file template created: ${ENV_FILE}"
+    echo ""
+    echo "⚠️  IMPORTANT: Edit ${ENV_FILE} and configure:"
+    echo "   - GitHub authentication (GITHUB_TOKEN or GitHub App credentials)"
+    echo "   - Google Cloud Vertex AI settings (CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID)"
+    echo "   - Oompa flags (OOMPA_FLAGS)"
+fi
+
+# Update the service file to use the user's home directory for the environment file
+sed -i "s|/etc/oompa/%i.env|${ENV_DIR}/%i.env|g" "${SYSTEMD_USER_DIR}/oompa@.service"
+
+# Reload systemd
+systemctl --user daemon-reload
+
+echo ""
+echo "✅ Installation complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Edit the environment file: ${ENV_FILE}"
+echo "  2. Start the service:    systemctl --user start oompa@${INSTANCE_NAME}"
+echo "  3. Enable on boot:       systemctl --user enable oompa@${INSTANCE_NAME}"
+echo "  4. Check status:         systemctl --user status oompa@${INSTANCE_NAME}"
+echo "  5. View logs:            journalctl --user -u oompa@${INSTANCE_NAME} -f"
+echo ""
+echo "To enable lingering (run even when not logged in):"
+echo "  loginctl enable-linger $USER"

--- a/deploy/systemd/oompa@.service
+++ b/deploy/systemd/oompa@.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Oompa %i
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=%u
+EnvironmentFile=/etc/oompa/%i.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=%h
+
+# Download latest binary before starting
+ExecStartPre=/bin/mkdir -p /tmp/oompa-bin
+ExecStartPre=/usr/bin/gh release download --repo qinqon/oompa --pattern oompa-linux-amd64 --dir /tmp/oompa-bin --clobber
+ExecStartPre=/bin/chmod +x /tmp/oompa-bin/oompa-linux-amd64
+
+# Run oompa with auto-restart on new version
+ExecStart=/tmp/oompa-bin/oompa-linux-amd64 --exit-on-new-version=qinqon/oompa ${OOMPA_FLAGS}
+
+# Restart on exit (new version available or transient failure)
+Restart=always
+RestartSec=5
+
+# Timeout settings
+TimeoutStartSec=300
+TimeoutStopSec=30
+
+# Security hardening (optional, uncomment if desired)
+# PrivateTmp=true
+# NoNewPrivileges=true
+# ProtectSystem=strict
+# ProtectHome=read-only
+# ReadWritePaths=%h/oompa-work
+
+[Install]
+WantedBy=multi-user.target

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -26,3 +26,9 @@ The following tools must be installed and available in PATH on the runner:
 3. Claude greets you and asks for the required information (repository, PR numbers, etc.).
 4. Once you provide the details, Claude downloads the runner script and starts the agent.
 5. The runner script downloads the latest `oompa` binary from GitHub releases and runs it in a restart loop with auto-update support.
+
+## Alternative: systemd Deployment
+
+For long-running production deployments on Linux systems, consider using the native systemd unit instead of the wrapper script. This provides better process management, logging via journald, and automatic startup on boot.
+
+See [`../deploy/systemd/README.md`](../deploy/systemd/README.md) for installation instructions.


### PR DESCRIPTION
Fixes #54

Add native systemd unit for binary management

Replace the run-oompa.sh wrapper script with a native systemd unit
template that provides better process management and auto-updates.

The systemd unit (oompa@.service) handles:
- Binary download via gh release download in ExecStartPre
- Execution with --exit-on-new-version flag
- Automatic restart on exit with RestartSec=5
- Environment file support for configuration
- Multiple instances via systemd templates

Benefits over the wrapper script:
- Proper process supervision and signal handling
- Centralized logging via journald
- Dependency management (network-online.target)
- Boot-time startup via systemctl enable
- No shell script to maintain

Includes:
- deploy/systemd/oompa@.service: systemd unit template
- deploy/systemd/env.example: example environment configuration
- deploy/systemd/install.sh: installation helper script
- deploy/systemd/README.md: comprehensive deployment guide

The wrapper script remains available for Ambient Code platform
integration and quick testing scenarios.

---

<!-- oompa-bot -->