### PR TITLE
Integrate Gemini as an AI code reviewer

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -66,6 +66,14 @@ func parseConfig() (agent.Config, string) {
 	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("OOMPA_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
 	flag.IntVar(&cfg.MaxWorkers, "max-workers", parseIntEnv("OOMPA_MAX_WORKERS", 1), "Maximum parallel Claude invocations (default 1 = sequential)")
 
+	// Gemini reviewer flags
+	flag.BoolVar(&cfg.GeminiReviewer, "gemini-reviewer", envOrDefault("OOMPA_GEMINI_REVIEWER", "") == "true", "Enable Gemini AI code reviews on PRs")
+	flag.StringVar(&cfg.GeminiModel, "gemini-model", envOrDefault("OOMPA_GEMINI_MODEL", "gemini-2.0-flash-exp"), "Gemini model to use for reviews (e.g. gemini-2.0-flash-exp, gemini-2.5-pro)")
+	flag.StringVar(&cfg.GeminiReviewSeverity, "gemini-review-severity", envOrDefault("OOMPA_GEMINI_REVIEW_SEVERITY", "warning"), "Minimum severity to comment on: info, warning, error")
+
+	var geminiReviewOn string
+	flag.StringVar(&geminiReviewOn, "gemini-review-on", os.Getenv("OOMPA_GEMINI_REVIEW_ON"), "When to trigger reviews: new-pr, push (comma-separated, empty = both)")
+
 	var forkFlag string
 	flag.StringVar(&forkFlag, "fork", envOrDefault("OOMPA_FORK", ""), "Fork repo as owner/repo for pushing (e.g. qinqon/ovn-kubernetes)")
 
@@ -162,14 +170,14 @@ func parseConfig() (agent.Config, string) {
 	}
 
 	if reactions != "" {
-		validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true, "rebase": true}
+		validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true, "rebase": true, "gemini": true}
 		for _, r := range strings.Split(reactions, ",") {
 			r = strings.TrimSpace(r)
 			if r == "" {
 				continue
 			}
 			if !validReactions[r] {
-				fmt.Fprintf(os.Stderr, "invalid reaction type %q: valid values are reviews, ci, conflicts, rebase\n", r)
+				fmt.Fprintf(os.Stderr, "invalid reaction type %q: valid values are reviews, ci, conflicts, rebase, gemini\n", r)
 				os.Exit(1)
 			}
 			cfg.Reactions = append(cfg.Reactions, r)
@@ -182,6 +190,21 @@ func parseConfig() (agent.Config, string) {
 			if url != "" {
 				cfg.TriageJobs = append(cfg.TriageJobs, url)
 			}
+		}
+	}
+
+	if geminiReviewOn != "" {
+		validTriggers := map[string]bool{"new-pr": true, "push": true}
+		for _, t := range strings.Split(geminiReviewOn, ",") {
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+			if !validTriggers[t] {
+				fmt.Fprintf(os.Stderr, "invalid gemini-review-on trigger %q: valid values are new-pr, push\n", t)
+				os.Exit(1)
+			}
+			cfg.GeminiReviewOn = append(cfg.GeminiReviewOn, t)
 		}
 	}
 
@@ -466,6 +489,9 @@ func runLoop(ctx context.Context, a *agent.Agent, logger *slog.Logger) {
 	}
 	if a.ShouldRunReaction("ci") {
 		a.ProcessCIFailures(ctx)
+	}
+	if a.ShouldRunReaction("gemini") {
+		a.ProcessGeminiReviews(ctx)
 	}
 
 	// ProcessTriageJobs is independent of other reactions and runs when triage jobs are configured

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -31,6 +31,12 @@ type Config struct {
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 	TriageJobs        []string // CI job URLs to monitor for periodic job triage
 
+	// Gemini reviewer configuration
+	GeminiReviewer       bool     // enable Gemini PR reviews
+	GeminiModel          string   // Gemini model to use (e.g. gemini-2.5-pro)
+	GeminiReviewOn       []string // when to trigger reviews: "new-pr", "push" (empty = both)
+	GeminiReviewSeverity string   // minimum severity to comment on: "info", "warning", "error"
+
 	// GitHub App authentication (alternative to GITHUB_TOKEN)
 	GitHubAppID             int64
 	GitHubAppPrivateKey     []byte

--- a/pkg/agent/gemini.go
+++ b/pkg/agent/gemini.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// GeminiReviewer defines the interface for Gemini-based code reviews.
+type GeminiReviewer interface {
+	ReviewPR(ctx context.Context, diff, title, description string) (GeminiReview, error)
+}
+
+// GeminiReview represents the result of a Gemini code review.
+type GeminiReview struct {
+	Summary  string              // Overall review summary
+	Comments []GeminiReviewIssue // Specific issues found in the code
+}
+
+// GeminiReviewIssue represents a single issue found during review.
+type GeminiReviewIssue struct {
+	File     string // File path where the issue was found
+	Line     int    // Line number (0 if not applicable)
+	Severity string // "info", "warning", or "error"
+	Message  string // Description of the issue
+}
+
+// VertexGeminiReviewer implements GeminiReviewer using Google Vertex AI.
+type VertexGeminiReviewer struct {
+	runner  CommandRunner
+	cfg     Config
+	model   string
+	project string
+	region  string
+}
+
+// NewVertexGeminiReviewer creates a new Gemini reviewer using Vertex AI.
+func NewVertexGeminiReviewer(runner CommandRunner, cfg Config) *VertexGeminiReviewer {
+	model := cfg.GeminiModel
+	if model == "" {
+		model = "gemini-2.0-flash-exp" // Default to latest stable model
+	}
+	return &VertexGeminiReviewer{
+		runner:  runner,
+		cfg:     cfg,
+		model:   model,
+		project: cfg.VertexProject,
+		region:  cfg.VertexRegion,
+	}
+}
+
+// ReviewPR performs a code review on the given PR diff using Gemini.
+func (g *VertexGeminiReviewer) ReviewPR(ctx context.Context, diff, title, description string) (GeminiReview, error) {
+	prompt := buildReviewPrompt(diff, title, description, g.cfg.GeminiReviewSeverity)
+
+	// Use gcloud CLI to call Gemini via Vertex AI
+	// This avoids adding additional SDK dependencies
+	args := []string{
+		"ai", "models", "generate-text",
+		"--model", g.model,
+		"--project", g.project,
+		"--region", g.region,
+		"--prompt", prompt,
+	}
+
+	stdout, stderr, err := g.runner.Run(ctx, "", "gcloud", args...)
+	if err != nil {
+		return GeminiReview{}, fmt.Errorf("gcloud gemini invocation failed: %w (stderr: %s)", err, string(stderr))
+	}
+
+	return parseGeminiResponse(string(stdout))
+}
+
+// buildReviewPrompt constructs the prompt for Gemini to review the PR.
+func buildReviewPrompt(diff, title, description, severity string) string {
+	minSeverity := severity
+	if minSeverity == "" {
+		minSeverity = "warning"
+	}
+
+	return fmt.Sprintf(`You are an expert code reviewer. Review the following pull request and identify potential issues.
+
+PR Title: %s
+PR Description:
+%s
+
+Diff:
+%s
+
+Please review the code and identify:
+- Bugs or logic errors
+- Missing error handling
+- Test coverage gaps
+- Style/convention issues
+- Security concerns
+- Performance issues
+
+For each issue found, provide:
+1. File path (if applicable)
+2. Line number (if applicable, otherwise 0)
+3. Severity: "info", "warning", or "error"
+4. Message: A clear description of the issue and suggested fix
+
+Respond in the following format:
+SUMMARY: [Overall assessment of the PR]
+
+ISSUES:
+FILE: [file path or "general"]
+LINE: [line number or 0]
+SEVERITY: [info/warning/error]
+MESSAGE: [description]
+---
+[Repeat for each issue]
+
+Only include issues with severity level "%s" or higher. If no issues are found, respond with just "SUMMARY: No issues found. Code looks good!"`, title, description, diff, minSeverity)
+}
+
+// parseGeminiResponse parses the Gemini API response into a structured review.
+func parseGeminiResponse(response string) (GeminiReview, error) {
+	lines := strings.Split(response, "\n")
+	review := GeminiReview{
+		Comments: []GeminiReviewIssue{},
+	}
+
+	var currentIssue *GeminiReviewIssue
+	inIssueSection := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "SUMMARY:") {
+			review.Summary = strings.TrimSpace(strings.TrimPrefix(line, "SUMMARY:"))
+			continue
+		}
+
+		if strings.HasPrefix(line, "ISSUES:") {
+			inIssueSection = true
+			continue
+		}
+
+		if !inIssueSection {
+			continue
+		}
+
+		if line == "---" {
+			if currentIssue != nil {
+				review.Comments = append(review.Comments, *currentIssue)
+			}
+			currentIssue = &GeminiReviewIssue{}
+			continue
+		}
+
+		if strings.HasPrefix(line, "FILE:") {
+			if currentIssue == nil {
+				currentIssue = &GeminiReviewIssue{}
+			}
+			currentIssue.File = strings.TrimSpace(strings.TrimPrefix(line, "FILE:"))
+		} else if strings.HasPrefix(line, "LINE:") {
+			if currentIssue != nil {
+				lineStr := strings.TrimSpace(strings.TrimPrefix(line, "LINE:"))
+				fmt.Sscanf(lineStr, "%d", &currentIssue.Line)
+			}
+		} else if strings.HasPrefix(line, "SEVERITY:") {
+			if currentIssue != nil {
+				currentIssue.Severity = strings.TrimSpace(strings.TrimPrefix(line, "SEVERITY:"))
+			}
+		} else if strings.HasPrefix(line, "MESSAGE:") {
+			if currentIssue != nil {
+				currentIssue.Message = strings.TrimSpace(strings.TrimPrefix(line, "MESSAGE:"))
+			}
+		}
+	}
+
+	// Don't forget the last issue
+	if currentIssue != nil && currentIssue.Message != "" {
+		review.Comments = append(review.Comments, *currentIssue)
+	}
+
+	return review, nil
+}

--- a/pkg/agent/gemini_test.go
+++ b/pkg/agent/gemini_test.go
@@ -1,0 +1,204 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// MockGeminiReviewer implements GeminiReviewer for testing.
+type MockGeminiReviewer struct {
+	ReviewFunc func(ctx context.Context, diff, title, description string) (GeminiReview, error)
+}
+
+func (m *MockGeminiReviewer) ReviewPR(ctx context.Context, diff, title, description string) (GeminiReview, error) {
+	if m.ReviewFunc != nil {
+		return m.ReviewFunc(ctx, diff, title, description)
+	}
+	return GeminiReview{
+		Summary: "No issues found. Code looks good!",
+	}, nil
+}
+
+func TestBuildReviewPrompt(t *testing.T) {
+	diff := "diff --git a/file.go b/file.go\n+func foo() {}\n"
+	title := "Add foo function"
+	description := "This adds a new function"
+	severity := "warning"
+
+	prompt := buildReviewPrompt(diff, title, description, severity)
+
+	if prompt == "" {
+		t.Fatal("prompt should not be empty")
+	}
+
+	// Check that key elements are in the prompt
+	if !contains(prompt, title) {
+		t.Errorf("prompt should contain PR title")
+	}
+	if !contains(prompt, description) {
+		t.Errorf("prompt should contain PR description")
+	}
+	if !contains(prompt, diff) {
+		t.Errorf("prompt should contain diff")
+	}
+	if !contains(prompt, severity) {
+		t.Errorf("prompt should contain severity level")
+	}
+}
+
+func TestParseGeminiResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     GeminiReview
+	}{
+		{
+			name:     "no issues",
+			response: "SUMMARY: No issues found. Code looks good!",
+			want: GeminiReview{
+				Summary:  "No issues found. Code looks good!",
+				Comments: []GeminiReviewIssue{},
+			},
+		},
+		{
+			name: "single issue",
+			response: `SUMMARY: Found one issue
+
+ISSUES:
+FILE: main.go
+LINE: 42
+SEVERITY: warning
+MESSAGE: Variable x is never used
+---`,
+			want: GeminiReview{
+				Summary: "Found one issue",
+				Comments: []GeminiReviewIssue{
+					{
+						File:     "main.go",
+						Line:     42,
+						Severity: "warning",
+						Message:  "Variable x is never used",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple issues",
+			response: `SUMMARY: Found several issues
+
+ISSUES:
+FILE: file1.go
+LINE: 10
+SEVERITY: error
+MESSAGE: Potential nil pointer dereference
+---
+FILE: file2.go
+LINE: 25
+SEVERITY: info
+MESSAGE: Consider adding a comment
+---`,
+			want: GeminiReview{
+				Summary: "Found several issues",
+				Comments: []GeminiReviewIssue{
+					{
+						File:     "file1.go",
+						Line:     10,
+						Severity: "error",
+						Message:  "Potential nil pointer dereference",
+					},
+					{
+						File:     "file2.go",
+						Line:     25,
+						Severity: "info",
+						Message:  "Consider adding a comment",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGeminiResponse(tt.response)
+			if err != nil {
+				t.Fatalf("parseGeminiResponse() error = %v", err)
+			}
+
+			if got.Summary != tt.want.Summary {
+				t.Errorf("Summary = %q, want %q", got.Summary, tt.want.Summary)
+			}
+
+			if len(got.Comments) != len(tt.want.Comments) {
+				t.Fatalf("Comments length = %d, want %d", len(got.Comments), len(tt.want.Comments))
+			}
+
+			for i, wantComment := range tt.want.Comments {
+				gotComment := got.Comments[i]
+				if gotComment.File != wantComment.File {
+					t.Errorf("Comment[%d].File = %q, want %q", i, gotComment.File, wantComment.File)
+				}
+				if gotComment.Line != wantComment.Line {
+					t.Errorf("Comment[%d].Line = %d, want %d", i, gotComment.Line, wantComment.Line)
+				}
+				if gotComment.Severity != wantComment.Severity {
+					t.Errorf("Comment[%d].Severity = %q, want %q", i, gotComment.Severity, wantComment.Severity)
+				}
+				if gotComment.Message != wantComment.Message {
+					t.Errorf("Comment[%d].Message = %q, want %q", i, gotComment.Message, wantComment.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestNewVertexGeminiReviewer(t *testing.T) {
+	runner := &mockCommandRunner{}
+	cfg := Config{
+		GeminiModel:   "gemini-2.0-flash-exp",
+		VertexProject: "test-project",
+		VertexRegion:  "us-central1",
+	}
+
+	reviewer := NewVertexGeminiReviewer(runner, cfg)
+
+	if reviewer == nil {
+		t.Fatal("NewVertexGeminiReviewer should not return nil")
+	}
+	if reviewer.model != cfg.GeminiModel {
+		t.Errorf("model = %q, want %q", reviewer.model, cfg.GeminiModel)
+	}
+	if reviewer.project != cfg.VertexProject {
+		t.Errorf("project = %q, want %q", reviewer.project, cfg.VertexProject)
+	}
+	if reviewer.region != cfg.VertexRegion {
+		t.Errorf("region = %q, want %q", reviewer.region, cfg.VertexRegion)
+	}
+}
+
+func TestNewVertexGeminiReviewer_DefaultModel(t *testing.T) {
+	runner := &mockCommandRunner{}
+	cfg := Config{
+		GeminiModel:   "", // Empty should use default
+		VertexProject: "test-project",
+		VertexRegion:  "us-central1",
+	}
+
+	reviewer := NewVertexGeminiReviewer(runner, cfg)
+
+	if reviewer.model == "" {
+		t.Error("model should have a default value when not specified")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -41,6 +41,8 @@ type GitHubClient interface {
 	ListWorkflowRuns(ctx context.Context, owner, repo, workflowID string, status string, limit int) ([]WorkflowRun, error)
 	ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error)
 	GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error)
+	GetPRDiff(ctx context.Context, owner, repo string, prNumber int) (string, error)
+	SubmitPRReview(ctx context.Context, owner, repo string, prNumber int, body string, comments []ReviewComment, event string) error
 }
 
 // GoGitHubClient implements GitHubClient using go-github.
@@ -591,4 +593,62 @@ func (g *GoGitHubClient) GetWorkflowJobLogs(ctx context.Context, owner, repo str
 	}
 
 	return string(body), nil
+}
+
+// GetPRDiff fetches the diff for a pull request.
+func (g *GoGitHubClient) GetPRDiff(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	// Get PR to retrieve base and head SHAs
+	pr, _, err := g.client.PullRequests.Get(ctx, owner, repo, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("getting PR: %w", err)
+	}
+
+	// Use GitHub's compare API to get the diff
+	comparison, _, err := g.client.Repositories.CompareCommits(ctx, owner, repo,
+		pr.GetBase().GetSHA(), pr.GetHead().GetSHA(), &github.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("comparing commits: %w", err)
+	}
+
+	// Build diff from files
+	var diffBuilder strings.Builder
+	for _, file := range comparison.Files {
+		if file.GetPatch() == "" {
+			continue
+		}
+		diffBuilder.WriteString(fmt.Sprintf("diff --git a/%s b/%s\n", file.GetFilename(), file.GetFilename()))
+		diffBuilder.WriteString(file.GetPatch())
+		diffBuilder.WriteString("\n")
+	}
+
+	return diffBuilder.String(), nil
+}
+
+// SubmitPRReview submits a review on a pull request with optional comments.
+// event can be "APPROVE", "REQUEST_CHANGES", or "COMMENT".
+func (g *GoGitHubClient) SubmitPRReview(ctx context.Context, owner, repo string, prNumber int, body string, comments []ReviewComment, event string) error {
+	review := &github.PullRequestReviewRequest{
+		Body:  github.Ptr(body),
+		Event: github.Ptr(event),
+	}
+
+	// Add inline comments if provided
+	if len(comments) > 0 {
+		var ghComments []*github.DraftReviewComment
+		for _, c := range comments {
+			ghComments = append(ghComments, &github.DraftReviewComment{
+				Path: github.Ptr(c.Path),
+				Line: github.Ptr(c.Line),
+				Body: github.Ptr(c.Body),
+			})
+		}
+		review.Comments = ghComments
+	}
+
+	_, _, err := g.client.PullRequests.CreateReview(ctx, owner, repo, prNumber, review)
+	if err != nil {
+		return fmt.Errorf("submitting review: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -291,6 +291,17 @@ func (f *fakeGitHubClient) GetWorkflowJobLogs(_ context.Context, _, _ string, _ 
 	return "", nil
 }
 
+func (f *fakeGitHubClient) GetPRDiff(_ context.Context, _, _ string, _ int) (string, error) {
+	return "diff --git a/file.go b/file.go\n+new content", nil
+}
+
+func (f *fakeGitHubClient) SubmitPRReview(_ context.Context, _, _ string, _ int, body string, _ []ReviewComment, _ string) error {
+	f.state.mu.Lock()
+	defer f.state.mu.Unlock()
+	f.state.postedComments = append(f.state.postedComments, "review:"+body)
+	return nil
+}
+
 // initBareRepo creates a bare repo and a working clone for the agent to use.
 // Returns (cloneDir, cleanup).
 func initBareRepo(t *testing.T) string {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1423,3 +1423,143 @@ func (a *Agent) isAllowedReviewer(user string) bool {
 	}
 	return false
 }
+
+// ProcessGeminiReviews checks for new commits on tracked PRs and triggers Gemini reviews.
+func (a *Agent) ProcessGeminiReviews(ctx context.Context) {
+	if !a.cfg.GeminiReviewer {
+		return
+	}
+
+	var tasks []geminiTask
+	for issueNumber, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 {
+			continue // No PR yet
+		}
+
+		// Check if we should review this PR based on GeminiReviewOn config
+		shouldReview := false
+		if len(a.cfg.GeminiReviewOn) == 0 {
+			// Default: review on both new-pr and push
+			shouldReview = true
+		} else {
+			for _, trigger := range a.cfg.GeminiReviewOn {
+				if trigger == "new-pr" && work.LastGeminiReviewSHA == "" {
+					shouldReview = true
+					break
+				}
+				if trigger == "push" {
+					shouldReview = true
+					break
+				}
+			}
+		}
+
+		if !shouldReview {
+			continue
+		}
+
+		// Get current head SHA
+		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			a.logger.Error("failed to get PR head SHA for Gemini review", "issue", issueNumber, "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		// Skip if already reviewed this SHA
+		if headSHA == work.LastGeminiReviewSHA {
+			continue
+		}
+
+		tasks = append(tasks, geminiTask{
+			work:    work,
+			headSHA: headSHA,
+		})
+	}
+
+	if len(tasks) == 0 {
+		return
+	}
+
+	a.logger.Info("processing Gemini reviews", "count", len(tasks))
+
+	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task geminiTask) {
+		if err := a.processGeminiReview(ctx, task); err != nil {
+			a.logger.Error("Gemini review failed", "issue", task.work.IssueNumber, "pr", task.work.PRNumber, "error", err)
+		}
+	})
+}
+
+type geminiTask struct {
+	work    *IssueWork
+	headSHA string
+}
+
+func (a *Agent) processGeminiReview(ctx context.Context, task geminiTask) error {
+	work := task.work
+	headSHA := task.headSHA
+
+	a.logger.Info("running Gemini review", "issue", work.IssueNumber, "pr", work.PRNumber, "sha", headSHA[:7])
+
+	// Get PR details
+	pr, err := a.gh.GetPR(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+	if err != nil {
+		return fmt.Errorf("getting PR details: %w", err)
+	}
+
+	// Get PR diff
+	diff, err := a.gh.GetPRDiff(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+	if err != nil {
+		return fmt.Errorf("getting PR diff: %w", err)
+	}
+
+	// Create Gemini reviewer
+	reviewer := NewVertexGeminiReviewer(a.runner, a.cfg)
+
+	// Perform review
+	review, err := reviewer.ReviewPR(ctx, diff, pr.Title, work.IssueTitle)
+	if err != nil {
+		return fmt.Errorf("Gemini review failed: %w", err)
+	}
+
+	// Submit review to GitHub
+	if err := a.submitGeminiReview(ctx, work.PRNumber, review); err != nil {
+		return fmt.Errorf("submitting review to GitHub: %w", err)
+	}
+
+	// Update state
+	work.LastGeminiReviewSHA = headSHA
+
+	a.logger.Info("Gemini review complete", "issue", work.IssueNumber, "pr", work.PRNumber, "issues_found", len(review.Comments))
+	return nil
+}
+
+func (a *Agent) submitGeminiReview(ctx context.Context, prNumber int, review GeminiReview) error {
+	// Build review body with bot marker
+	body := fmt.Sprintf("%s\n\n🤖 **Gemini Review**\n\n%s", botMarker, review.Summary)
+
+	// Convert Gemini comments to GitHub review comments
+	var comments []ReviewComment
+	for _, issue := range review.Comments {
+		if issue.File == "general" || issue.File == "" || issue.Line == 0 {
+			// Add to main review body instead of inline comment
+			body += fmt.Sprintf("\n\n**%s**: %s", strings.ToUpper(issue.Severity), issue.Message)
+		} else {
+			comments = append(comments, ReviewComment{
+				Path: issue.File,
+				Line: issue.Line,
+				Body: fmt.Sprintf("**%s**: %s", strings.ToUpper(issue.Severity), issue.Message),
+			})
+		}
+	}
+
+	// Determine review event based on severity of issues
+	event := "COMMENT"
+	for _, issue := range review.Comments {
+		if issue.Severity == "error" {
+			event = "REQUEST_CHANGES"
+			break
+		}
+	}
+
+	return a.gh.SubmitPRReview(ctx, a.cfg.Owner, a.cfg.Repo, prNumber, body, comments, event)
+}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -191,6 +191,15 @@ func (m *mockGitHubClient) GetWorkflowJobLogs(_ context.Context, _, _ string, _ 
 	return "", nil
 }
 
+func (m *mockGitHubClient) GetPRDiff(_ context.Context, _, _ string, _ int) (string, error) {
+	return "diff --git a/file.go b/file.go\n+new content", nil
+}
+
+func (m *mockGitHubClient) SubmitPRReview(_ context.Context, _, _ string, _ int, body string, _ []ReviewComment, _ string) error {
+	m.addedComments = append(m.addedComments, "review:"+body)
+	return nil
+}
+
 // mockWorktreeManager implements WorktreeManager for testing.
 type mockWorktreeManager struct {
 	createdBranches []string

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -52,10 +52,11 @@ type IssueWork struct {
 	LastCommentID    int64     `json:"lastCommentID"`
 	LastReviewID     int64     `json:"lastReviewID"`
 	Status           string    `json:"status"` // implementing, pr-open, failed, done
-	CIFixAttempts    int       `json:"ciFixAttempts"`
-	LastCIStatus     string    `json:"lastCIStatus"`     // "", "pending", "success", "failure"
-	LastCheckedCISHA string    `json:"lastCheckedCISHA"` // last commit SHA investigated for CI failures
-	CreatedAt        time.Time `json:"createdAt"`
+	CIFixAttempts       int       `json:"ciFixAttempts"`
+	LastCIStatus        string    `json:"lastCIStatus"`        // "", "pending", "success", "failure"
+	LastCheckedCISHA    string    `json:"lastCheckedCISHA"`    // last commit SHA investigated for CI failures
+	LastGeminiReviewSHA string    `json:"lastGeminiReviewSHA"` // last commit SHA reviewed by Gemini
+	CreatedAt           time.Time `json:"createdAt"`
 }
 
 // PRReview represents a GitHub pull request review (approve, request changes, comment).


### PR DESCRIPTION
Fixes #56

Add Gemini integration as AI code reviewer for PRs

This commit adds support for using Google Gemini as an AI-powered code
reviewer that automatically reviews PR diffs and posts review comments.

Key features:
- New --gemini-reviewer flag to enable Gemini reviews
- --gemini-model flag to specify model (default: gemini-2.0-flash-exp)
- --gemini-review-on flag to control when reviews trigger (new-pr, push)
- --gemini-review-severity flag to set minimum severity (info/warning/error)
- New "gemini" reaction type for --reactions flag
- Reviews are posted as GitHub PR reviews with inline comments
- Automatic REQUEST_CHANGES for PRs with error-level issues

Implementation:
- Created pkg/agent/gemini.go with GeminiReviewer interface and
  VertexGeminiReviewer implementation using gcloud CLI
- Added GetPRDiff and SubmitPRReview methods to GitHubClient interface
- Added ProcessGeminiReviews method to main agent loop
- Tracks last reviewed SHA to avoid duplicate reviews
- Comprehensive tests in gemini_test.go

Gemini uses the same Vertex AI credentials as Claude (reuses existing
--vertex-project and --vertex-region flags), avoiding the need for
additional authentication setup.

---

<!-- oompa-bot -->