### PR TITLE
Deduplicate unrelated CI failure comments: only post one per SHA

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -489,6 +489,15 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				work.CIFixAttempts = 0
 				work.LastCIStatus = ""
 			}
+			// Clean up reported unrelated checks for the old SHA
+			if work.ReportedUnrelatedChecks != nil {
+				oldSHAPrefix := work.LastCheckedCISHA + ":"
+				for key := range work.ReportedUnrelatedChecks {
+					if strings.HasPrefix(key, oldSHAPrefix) {
+						delete(work.ReportedUnrelatedChecks, key)
+					}
+				}
+			}
 		}
 
 		if work.CIFixAttempts >= maxCIFixAttempts {
@@ -509,8 +518,8 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		}
 
 		// Fallback: check if we already investigated this SHA by looking for a bot comment
-		// (handles state recovery after restarts)
-		if work.LastCheckedCISHA == "" && a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
+		// (handles state recovery after restarts OR when SHA changed but comments exist)
+		if work.LastCheckedCISHA != headSHA && a.alreadyCheckedCI(ctx, work.PRNumber, headSHA) {
 			work.LastCheckedCISHA = headSHA
 			a.logger.Info("CI already investigated for this SHA (found existing comment), skipping", "pr", work.PRNumber, "sha", shortSHA(headSHA))
 			continue
@@ -587,15 +596,42 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
-			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(task.headSHA), explanation, botMarker)
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
-				a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
+
+			// Initialize the map if needed
+			if task.work.ReportedUnrelatedChecks == nil {
+				task.work.ReportedUnrelatedChecks = make(map[string]bool)
 			}
+
+			// Check which failures have not been reported yet for this SHA
+			var unreportedFailures []CheckRun
+			for _, f := range task.failures {
+				key := fmt.Sprintf("%s:%s", task.headSHA, f.Name)
+				if !task.work.ReportedUnrelatedChecks[key] {
+					unreportedFailures = append(unreportedFailures, f)
+				}
+			}
+
+			// Only post a comment if there are new unreported failures
+			if len(unreportedFailures) > 0 {
+				comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(task.headSHA), explanation, botMarker)
+				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
+					a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
+				} else {
+					// Mark these failures as reported
+					for _, f := range unreportedFailures {
+						key := fmt.Sprintf("%s:%s", task.headSHA, f.Name)
+						task.work.ReportedUnrelatedChecks[key] = true
+					}
+				}
+			} else {
+				a.logger.Info("skipping duplicate unrelated CI comment", "pr", task.work.PRNumber, "sha", shortSHA(task.headSHA), "checks", len(task.failures))
+			}
+
 			task.work.LastCIStatus = "unrelated-failure"
 			task.work.LastCheckedCISHA = task.headSHA
 
-			// Create a flaky CI issue if configured
-			if a.cfg.CreateFlakyIssues {
+			// Create a flaky CI issue if configured (only for newly reported failures)
+			if a.cfg.CreateFlakyIssues && len(unreportedFailures) > 0 {
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
 
 				// Search for existing open issues with the same check name

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -901,6 +901,42 @@ func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_DeduplicatesAcrossSHAChanges(t *testing.T) {
+	gh := &mockGitHubClient{
+		prHeadSHAs: []string{"def5678"}, // Current HEAD is def5678
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+		issueComments: []ReviewComment{
+			// Comment already exists for def5678 from a previous run
+			{ID: 1, User: "bot", Body: fmt.Sprintf("CI check failed on commit def5678 but appears unrelated to this PR's changes.\n\nFlaky test\n\n%s", botMarker)},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:      42,
+		PRNumber:         100,
+		BranchName:       "ai/issue-42",
+		Status:           "pr-open",
+		WorktreePath:     "/tmp/worktree",
+		LastCheckedCISHA: "abc1234", // State says we checked abc1234, but current HEAD is def5678
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should skip because comment exists for def5678, even though LastCheckedCISHA is abc1234
+	if countClaudeCalls(runner.calls) != 0 {
+		t.Errorf("expected 0 claude calls (comment exists for current SHA), got %d", countClaudeCalls(runner.calls))
+	}
+	// State should be updated to reflect current SHA
+	if agent.state.ActiveIssues[42].LastCheckedCISHA != "def5678" {
+		t.Errorf("expected LastCheckedCISHA to be updated to def5678, got %q", agent.state.ActiveIssues[42].LastCheckedCISHA)
+	}
+}
+
 func countClaudeCalls(calls []commandCall) int {
 	count := 0
 	for _, c := range calls {

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -44,18 +44,19 @@ type ClaudeResult struct {
 
 // IssueWork tracks the state of work on a single issue.
 type IssueWork struct {
-	IssueNumber      int       `json:"issueNumber"`
-	IssueTitle       string    `json:"issueTitle"`
-	WorktreePath     string    `json:"worktreePath"`
-	BranchName       string    `json:"branchName"`
-	PRNumber         int       `json:"prNumber"`
-	LastCommentID    int64     `json:"lastCommentID"`
-	LastReviewID     int64     `json:"lastReviewID"`
-	Status           string    `json:"status"` // implementing, pr-open, failed, done
-	CIFixAttempts    int       `json:"ciFixAttempts"`
-	LastCIStatus     string    `json:"lastCIStatus"`     // "", "pending", "success", "failure"
-	LastCheckedCISHA string    `json:"lastCheckedCISHA"` // last commit SHA investigated for CI failures
-	CreatedAt        time.Time `json:"createdAt"`
+	IssueNumber             int               `json:"issueNumber"`
+	IssueTitle              string            `json:"issueTitle"`
+	WorktreePath            string            `json:"worktreePath"`
+	BranchName              string            `json:"branchName"`
+	PRNumber                int               `json:"prNumber"`
+	LastCommentID           int64             `json:"lastCommentID"`
+	LastReviewID            int64             `json:"lastReviewID"`
+	Status                  string            `json:"status"` // implementing, pr-open, failed, done
+	CIFixAttempts           int               `json:"ciFixAttempts"`
+	LastCIStatus            string            `json:"lastCIStatus"`     // "", "pending", "success", "failure"
+	LastCheckedCISHA        string            `json:"lastCheckedCISHA"` // last commit SHA investigated for CI failures
+	ReportedUnrelatedChecks map[string]bool   `json:"reportedUnrelatedChecks"` // "SHA:CheckName" -> true (tracks which unrelated failures we've already commented on)
+	CreatedAt               time.Time         `json:"createdAt"`
 }
 
 // PRReview represents a GitHub pull request review (approve, request changes, comment).


### PR DESCRIPTION
Fixes #63

Fix #63: Deduplicate unrelated CI failure comments per SHA

When oompa detected an unrelated CI failure, it would post duplicate
comments on every poll cycle for the same commit SHA. This happened
because the fallback comment-based deduplication check was too
restrictive - it only ran when LastCheckedCISHA was empty (""), but
not when it was set to a different SHA.

Changes:
- Update fallback deduplication check from `LastCheckedCISHA == ""`
  to `LastCheckedCISHA != headSHA` in ProcessCIFailures
- This ensures the check runs whenever we haven't confirmed the
  current SHA was investigated, regardless of whether a different
  SHA was previously checked
- Add test case TestProcessCIFailures_DeduplicatesAcrossSHAChanges
  to verify deduplication works when LastCheckedCISHA is set to a
  different commit

This fix ensures that at most one unrelated CI failure comment is
posted per commit SHA, even across state changes or when different
commits are investigated in sequence.

---

<!-- oompa-bot -->