### PR TITLE
Deduplicate unrelated CI failure comments: only post one per SHA

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -587,9 +587,16 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
-			comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(task.headSHA), explanation, botMarker)
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
-				a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
+
+			// Only post comment if we haven't already reported this SHA as unrelated
+			// This prevents duplicate comments across poll cycles for the same commit
+			if task.work.LastCheckedCISHA != task.headSHA || task.work.LastCIStatus != "unrelated-failure" {
+				comment := fmt.Sprintf("CI check failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", shortSHA(task.headSHA), explanation, botMarker)
+				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
+					a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
+				}
+			} else {
+				a.logger.Info("skipping duplicate unrelated comment for same SHA", "pr", task.work.PRNumber, "sha", shortSHA(task.headSHA))
 			}
 			task.work.LastCIStatus = "unrelated-failure"
 			task.work.LastCheckedCISHA = task.headSHA

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -911,6 +911,57 @@ func countClaudeCalls(calls []commandCall) int {
 	return count
 }
 
+func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
+	// Issue #63: Should only post one unrelated comment per SHA, not on every poll cycle
+	claudeResult := streamResultJSON(ClaudeResult{Result: "UNRELATED Flaky test"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	// First poll cycle: should investigate and post comment
+	agent.ProcessCIFailures(context.Background())
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment on first poll, got %d", len(gh.addedComments))
+	}
+	if !strings.Contains(gh.addedComments[0], "CI check failed on commit abc123 but appears unrelated") {
+		t.Errorf("unexpected comment body: %s", gh.addedComments[0])
+	}
+
+	// Verify state was updated
+	work := agent.state.ActiveIssues[42]
+	if work.LastCheckedCISHA != "abc123" {
+		t.Errorf("expected LastCheckedCISHA to be abc123, got %q", work.LastCheckedCISHA)
+	}
+	if work.LastCIStatus != "unrelated-failure" {
+		t.Errorf("expected LastCIStatus to be unrelated-failure, got %q", work.LastCIStatus)
+	}
+
+	// Second poll cycle: same SHA, CI still failing
+	// Should skip investigation entirely (no Claude call, no comment)
+	agent.ProcessCIFailures(context.Background())
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected still only 1 comment after second poll (no duplicate), got %d", len(gh.addedComments))
+	}
+	// Verify Claude was not called again
+	if countClaudeCalls(runner.calls) != 1 {
+		t.Errorf("expected only 1 claude call total, got %d", countClaudeCalls(runner.calls))
+	}
+}
+
 func TestShouldRunReaction_EmptyAllowsAll(t *testing.T) {
 	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
 	// No reactions configured — all should be allowed


### PR DESCRIPTION
Fixes #63

Fix #63: Deduplicate unrelated CI failure comments per SHA

When oompa detects an unrelated CI failure, it now checks if it has
already posted a comment for the same commit SHA before posting a new
one. This prevents comment spam across multiple poll cycles.

The fix adds a check before posting the "CI check failed on commit..."
comment to verify that we haven't already reported this SHA as having
an unrelated failure. If LastCheckedCISHA matches the current SHA and
LastCIStatus is "unrelated-failure", the comment posting is skipped
with a log message.

A new test TestProcessCIFailures_DeduplicatesUnrelatedComments verifies
that only one comment is posted across multiple poll cycles for the
same SHA with the same unrelated CI failure.

---

<!-- oompa-bot -->