### PR TITLE
Fix review feedback loop: update LastReviewID after processing

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -461,6 +461,13 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 				task.work.LastCommentID = c.ID
 			}
 		}
+
+		// Update last seen review ID
+		for _, r := range task.humanReviews {
+			if r.ID > task.work.LastReviewID {
+				task.work.LastReviewID = r.ID
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
ProcessReviewComments never updated `work.LastReviewID` after handling reviews, causing `GetPRReviews` to return the same reviews on every poll cycle. This resulted in Claude being invoked repeatedly (~$1 per invocation every 2 minutes) for already-addressed feedback, burning credits without pushing changes.

## Root Cause

Only `LastCommentID` was updated after review processing — the corresponding `LastReviewID` update was missing.

## Fix

Add the missing `LastReviewID` update alongside the existing `LastCommentID` update in the parallel phase cleanup.

Fixes #66