### PR TITLE
Add --flaky-label flag to configure flaky CI issue label

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -63,6 +63,7 @@ func parseConfig() (agent.Config, string) {
 	flag.StringVar(&logFile, "log-file", os.Getenv("OOMPA_LOG_FILE"), "Log file path (default: stderr)")
 
 	flag.BoolVar(&cfg.CreateFlakyIssues, "create-flaky-issues", envOrDefault("OOMPA_CREATE_FLAKY_ISSUES", "") == "true", "Create issues for unrelated CI failures (opt-in)")
+	flag.StringVar(&cfg.FlakyLabel, "flaky-label", envOrDefault("OOMPA_FLAKY_LABEL", "flaky-test"), "Label to apply to flaky CI issues")
 	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("OOMPA_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
 	flag.IntVar(&cfg.MaxWorkers, "max-workers", parseIntEnv("OOMPA_MAX_WORKERS", 1), "Maximum parallel Claude invocations (default 1 = sequential)")
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	WatchPRs          []int    // PR numbers to monitor directly (bypasses issue discovery)
 	Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
+	FlakyLabel        string   // label applied to flaky CI issues (default: "flaky-test")
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 	TriageJobs        []string // CI job URLs to monitor for periodic job triage

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -605,8 +605,8 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
 
 				// Search for existing open issues with the same check name
-				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:flaky-test \"%s\"",
-					a.cfg.Owner, a.cfg.Repo, issueTitle)
+				searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%s \"%s\"",
+					a.cfg.Owner, a.cfg.Repo, a.cfg.FlakyLabel, issueTitle)
 				existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
 
 				var issueNum int
@@ -633,7 +633,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 					"**Check output**:\n```\n%s\n```\n\n"+
 					"%s",
 					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, explanation, task.failures[0].Output, botMarker)
-				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{"flaky-test"})
+				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
 				if err != nil {
 					a.logger.Error("failed to create flaky CI issue", "error", err)
 				} else {
@@ -1022,7 +1022,7 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 *This issue was automatically created by oompa based on CI failure analysis.*
 <!-- oompa-triage -->`, ciSource.JobName(), latestRun.ID, latestRun.LogURL, analysis)
 
-				issueNumber, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, title, body, []string{"ci-flake"})
+				issueNumber, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, title, body, []string{a.cfg.FlakyLabel})
 				if err != nil {
 					a.logger.Error("failed to create issue", "error", err)
 				} else {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -227,7 +227,7 @@ func newTestAgent(gh *mockGitHubClient, runner *mockCommandRunner, wt *mockWorkt
 		runner:    runner,
 		worktrees: wt,
 		state:     NewState(),
-		cfg:       Config{Owner: "owner", Repo: "repo", Label: "good-for-ai"},
+		cfg:       Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", FlakyLabel: "flaky-test"},
 		logger:    slog.Default(),
 	}
 }
@@ -1470,6 +1470,7 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 		Repo:              "repo",
 		TriageJobs:        []string{}, // Empty to avoid actual HTTP calls
 		CreateFlakyIssues: true,
+		FlakyLabel:        "ci-flake",
 	}
 
 	NewAgent(gh, runner, wtm, state, cfg, slog.Default())
@@ -1486,7 +1487,7 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 	}
 
 	issueNum, err := gh.CreateIssue(context.Background(), "owner", "repo",
-		"CI Failure: test-job", "Analysis output", []string{"ci-flake"})
+		"CI Failure: test-job", "Analysis output", []string{cfg.FlakyLabel})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `--flaky-label` flag (env: `OOMPA_FLAKY_LABEL`, default: `flaky-test`) to make the label applied to flaky CI issues configurable
- Replaces hard-coded `"flaky-test"` and `"ci-flake"` labels in both `ProcessCIFailures` and `ProcessTriageJobs`
- Needed for repos like ovn-kubernetes that use `kind/ci-flake` instead of the default

## Test plan

- [x] All existing tests pass with `FlakyLabel` set in test configs
- [x] `TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated` — uses configured label
- [x] `TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled` — uses configured label

🤖 Generated with [Claude Code](https://claude.com/claude-code)