### PR TITLE
SearchIssues does not paginate, may miss duplicates when >30 flaky issues exist

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -463,28 +463,42 @@ func (g *GoGitHubClient) CreateIssue(ctx context.Context, owner, repo, title, bo
 }
 
 func (g *GoGitHubClient) SearchIssues(ctx context.Context, query string) ([]Issue, error) {
-	result, _, err := g.client.Search.Issues(ctx, query, nil)
-	if err != nil {
-		return nil, fmt.Errorf("searching issues: %w", err)
+	var allIssues []Issue
+	opts := &github.SearchOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
 	}
 
-	var issues []Issue
-	for _, ghIssue := range result.Issues {
-		if ghIssue.IsPullRequest() {
-			continue
+	for {
+		result, resp, err := g.client.Search.Issues(ctx, query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("searching issues: %w", err)
 		}
-		var labels []string
-		for _, l := range ghIssue.Labels {
-			labels = append(labels, l.GetName())
+
+		for _, ghIssue := range result.Issues {
+			if ghIssue.IsPullRequest() {
+				continue
+			}
+			var labels []string
+			for _, l := range ghIssue.Labels {
+				labels = append(labels, l.GetName())
+			}
+			allIssues = append(allIssues, Issue{
+				Number: ghIssue.GetNumber(),
+				Title:  ghIssue.GetTitle(),
+				Body:   ghIssue.GetBody(),
+				Labels: labels,
+			})
 		}
-		issues = append(issues, Issue{
-			Number: ghIssue.GetNumber(),
-			Title:  ghIssue.GetTitle(),
-			Body:   ghIssue.GetBody(),
-			Labels: labels,
-		})
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
-	return issues, nil
+
+	return allIssues, nil
 }
 
 // GetAuthenticatedUser returns the login, name, and email of the authenticated user.

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -506,6 +506,79 @@ func TestSearchIssues_FiltersPullRequests(t *testing.T) {
 	}
 }
 
+func TestSearchIssues_Paginates(t *testing.T) {
+	var requestedPages []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		perPage := r.URL.Query().Get("per_page")
+
+		// Verify per_page is set to 100
+		if perPage != "100" {
+			t.Errorf("expected per_page=100, got %q", perPage)
+		}
+
+		requestedPages = append(requestedPages, page)
+
+		// Return different results based on page
+		if page == "" || page == "1" {
+			// First page
+			w.Header().Set("Link", `<https://api.github.com/search/issues?page=2>; rel="next", <https://api.github.com/search/issues?page=2>; rel="last"`)
+			result := map[string]any{
+				"total_count": 3,
+				"items": []map[string]any{
+					{
+						"number": 1,
+						"title":  "Issue 1",
+						"body":   "Body 1",
+						"labels": []map[string]any{{"name": "flaky-test"}},
+					},
+					{
+						"number": 2,
+						"title":  "Issue 2",
+						"body":   "Body 2",
+						"labels": []map[string]any{{"name": "flaky-test"}},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(result)
+		} else if page == "2" {
+			// Second page (last page)
+			result := map[string]any{
+				"total_count": 3,
+				"items": []map[string]any{
+					{
+						"number": 3,
+						"title":  "Issue 3",
+						"body":   "Body 3",
+						"labels": []map[string]any{{"name": "flaky-test"}},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(result)
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	issues, err := gh.SearchIssues(context.Background(), "repo:owner/repo label:flaky-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have collected all 3 issues from both pages
+	if len(issues) != 3 {
+		t.Fatalf("expected 3 issues from 2 pages, got %d", len(issues))
+	}
+	if issues[0].Number != 1 || issues[1].Number != 2 || issues[2].Number != 3 {
+		t.Errorf("expected issues [1, 2, 3], got %v", []int{issues[0].Number, issues[1].Number, issues[2].Number})
+	}
+
+	// Verify we made requests to both pages
+	if len(requestedPages) != 2 {
+		t.Errorf("expected 2 page requests, got %d: %v", len(requestedPages), requestedPages)
+	}
+}
+
 func TestGetCheckRuns_UsesPerPage100(t *testing.T) {
 	var receivedPerPage int
 	mux := http.NewServeMux()


### PR DESCRIPTION
Fixes #73

Add pagination to SearchIssues to fetch all results

SearchIssues was passing nil options to client.Search.Issues(),
which defaults to returning only the first page (30 results). When
there are more than 30 open flaky issues, duplicate detection in
ProcessCIFailures may miss existing issues beyond the first page.

This change adds pagination with PerPage=100 (the GitHub Search API
maximum), looping through all pages until resp.NextPage is 0. This
ensures all matching issues are fetched for Claude-based duplicate
matching.

Also adds TestSearchIssues_Paginates to verify pagination works
correctly across multiple pages.

Fixes #73

---

<!-- oompa-bot -->