### PR TITLE
Fix: avoid noisy comments when Claude doesn't follow CI response format

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -590,7 +590,22 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 		// Strip markdown formatting (bold, italic) before checking prefix
 		cleaned := strings.TrimLeft(strings.TrimSpace(result.Result), "*_")
-		if strings.HasPrefix(cleaned, "UNRELATED") {
+
+		// Check if Claude followed the expected format (must start with UNRELATED or RELATED)
+		startsWithUnrelated := strings.HasPrefix(cleaned, "UNRELATED")
+		startsWithRelated := strings.HasPrefix(cleaned, "RELATED")
+
+		if !startsWithUnrelated && !startsWithRelated {
+			a.logger.Warn("Claude response did not start with UNRELATED or RELATED, skipping to avoid noise",
+				"pr", task.work.PRNumber,
+				"response_preview", truncateString(cleaned, 100))
+			task.work.CIFixAttempts++
+			task.work.LastCIStatus = "investigation-inconclusive"
+			task.work.LastCheckedCISHA = task.headSHA
+			return
+		}
+
+		if startsWithUnrelated {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
@@ -1450,4 +1465,12 @@ func (a *Agent) isAllowedReviewer(user string) bool {
 		}
 	}
 	return false
+}
+
+// truncateString returns the first maxLen characters of s, with "..." appended if truncated.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }


### PR DESCRIPTION
## Problem

When Claude investigates CI failures, it's instructed to start its response with either `UNRELATED` or `RELATED`. However, Claude sometimes fails to follow this format correctly.

When this happens, oompa would:
1. Assume the failure was `RELATED` (since it didn't start with `UNRELATED`)
2. Look for code changes to push
3. Find no changes (because Claude didn't actually generate a fix)
4. Post a noisy comment: "CI is failing on commit X. Investigated but could not push a fix."

**Example:** In PR ovn-kubernetes/ovn-kubernetes#6252, Claude analyzed the CI failure and correctly determined it was unrelated, but didn't start the response with `UNRELATED`. This resulted in a misleading comment that added noise without providing value.

## Solution

This PR adds validation to ensure Claude's response starts with either `UNRELATED` or `RELATED`. If neither prefix is present:
- Log a warning with a preview of the response
- Skip posting any comment to avoid noise  
- Update state to `investigation-inconclusive`

This prevents misleading "could not push a fix" comments when Claude provides analysis but doesn't follow the expected format.

## Changes

- Added format validation before processing CI investigation responses
- Added `truncateString` helper for logging response previews
- Added new state value `investigation-inconclusive` to track these cases

## Test Plan

Manual testing:
1. Claude provides response without `UNRELATED` or `RELATED` prefix
2. Verify no comment is posted to the PR
3. Verify warning is logged with response preview
4. Verify state is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)