### PR TITLE
Use flaking-test issue template format for CI flaky issues

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -590,7 +590,22 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 		// Strip markdown formatting (bold, italic) before checking prefix
 		cleaned := strings.TrimLeft(strings.TrimSpace(result.Result), "*_")
-		if strings.HasPrefix(cleaned, "UNRELATED") {
+
+		// Check if Claude followed the expected format (must start with UNRELATED or RELATED)
+		startsWithUnrelated := strings.HasPrefix(cleaned, "UNRELATED")
+		startsWithRelated := strings.HasPrefix(cleaned, "RELATED")
+
+		if !startsWithUnrelated && !startsWithRelated {
+			a.logger.Warn("Claude response did not start with UNRELATED or RELATED, skipping to avoid noise",
+				"pr", task.work.PRNumber,
+				"response_preview", truncateString(cleaned, 100))
+			task.work.CIFixAttempts++
+			task.work.LastCIStatus = "investigation-inconclusive"
+			task.work.LastCheckedCISHA = task.headSHA
+			return
+		}
+
+		if startsWithUnrelated {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 			explanation := strings.TrimPrefix(cleaned, "UNRELATED")
 			explanation = strings.TrimSpace(explanation)
@@ -1450,4 +1465,12 @@ func (a *Agent) isAllowedReviewer(user string) bool {
 		}
 	}
 	return false
+}
+
+// truncateString returns the first maxLen characters of s, with "..." appended if truncated.
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -649,14 +649,21 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				}
 
 				// No existing issue matched, create a new one
-				issueBody := fmt.Sprintf("A CI failure was detected that appears unrelated to PR changes.\n\n"+
-					"**Detected in PR**: #%d\n"+
-					"**Commit**: %s\n"+
-					"**Failed check**: %s\n\n"+
-					"**Analysis**:\n%s\n\n"+
-					"**Check output**:\n```\n%s\n```\n\n"+
+				issueBody := fmt.Sprintf("### Which jobs are flaking?\n\n"+
+					"%s\n\n"+
+					"Detected in PR #%d, commit %s.\n\n"+
+					"### Which tests are flaking?\n\n"+
+					"%s\n\n"+
+					"### Since when has it been flaking?\n\n"+
+					"%s\n\n"+
+					"### Reason for failure (if possible)\n\n"+
+					"%s\n\n"+
+					"### Anything else we need to know?\n\n"+
+					"Automatically created by [oompa](https://github.com/qinqon/oompa).\n\n"+
 					"%s",
-					task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name, explanation, task.failures[0].Output, botMarker)
+					task.failures[0].Name, task.work.PRNumber, shortSHA(task.headSHA),
+					task.failures[0].Name, time.Now().Format("2006-01-02"), explanation,
+					botMarker)
 				issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
 				if err != nil {
 					a.logger.Error("failed to create flaky CI issue", "error", err)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -700,6 +700,22 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 	if len(issue.Labels) != 1 || issue.Labels[0] != "flaky-test" {
 		t.Errorf("expected labels ['flaky-test'], got %v", issue.Labels)
 	}
+	// Check the body uses the flaking-test issue template format
+	if !strings.Contains(issue.Body, "### Which jobs are flaking?") {
+		t.Errorf("expected issue body to contain '### Which jobs are flaking?', got %q", issue.Body)
+	}
+	if !strings.Contains(issue.Body, "### Which tests are flaking?") {
+		t.Errorf("expected issue body to contain '### Which tests are flaking?', got %q", issue.Body)
+	}
+	if !strings.Contains(issue.Body, "### Since when has it been flaking?") {
+		t.Errorf("expected issue body to contain '### Since when has it been flaking?', got %q", issue.Body)
+	}
+	if !strings.Contains(issue.Body, "### Reason for failure (if possible)") {
+		t.Errorf("expected issue body to contain '### Reason for failure (if possible)', got %q", issue.Body)
+	}
+	if !strings.Contains(issue.Body, "Automatically created by [oompa]") {
+		t.Errorf("expected issue body to contain oompa attribution, got %q", issue.Body)
+	}
 
 	// Check that a comment was added to the PR
 	if len(gh.addedComments) != 2 {

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -125,6 +125,9 @@ Instructions:
 2. If the failure is NOT related to the PR changes:
    - Do NOT attempt to fix it, do NOT modify any files
    - Your output MUST start with the word UNRELATED followed by a brief explanation
+   - IMPORTANT: Do NOT mention the PR changes, the PR number, or what the PR modifies in your explanation.
+     Focus ONLY on describing the failure itself: what test failed, what the error was, and why it looks flaky or infrastructure-related.
+     The explanation will be used to create a standalone flaky test issue, so it must make sense without any PR context.
 3. If the failure IS directly related to the PR changes:
    - Your output MUST start with the word RELATED
    - Fix the code so that CI passes


### PR DESCRIPTION
## Summary

- Rewrites flaky CI issue body to follow the standard flaking-test template format with the 5 expected sections (`Which jobs`, `Which tests`, `Since when`, `Reason`, `Anything else`)
- Updates the CI fix prompt to instruct Claude not to mention PR changes in its UNRELATED explanation, since the explanation is used as a standalone flaky test report
- Adds test assertions verifying the new template sections are present in created issues

## Problem

Repositories like ovn-kubernetes have a structured issue template for flaking tests. Previously, oompa used a custom format that included Claude's analysis of PR changes in the issue body. This caused:

1. **Search pollution**: GitHub's full-text search matched keywords from the PR analysis (e.g. "kubevirt") making flaky issues appear in unrelated search filters
2. **Inconsistent format**: oompa-created issues looked out of place compared to human-created ones

## Example

**Before** (oompa format):
```
A CI failure was detected that appears unrelated to PR changes.

**Detected in PR**: #6252
**Commit**: 6103b76
**Failed check**: e2e (bgp-no-overlay-helm, ...)

**Analysis**:
This PR only modifies kubevirt_test.go...  ← leaks PR context into issue
```

**After** (repo template format):
```
### Which jobs are flaking?

e2e (bgp-no-overlay-helm, ...)

Detected in PR #6252, commit 6103b76.

### Which tests are flaking?

e2e (bgp-no-overlay-helm, ...)

### Since when has it been flaking?

2026-04-24

### Reason for failure (if possible)

The failing checks are e2e integration tests for BGP...  ← no PR context

### Anything else we need to know?

Automatically created by [oompa](https://github.com/qinqon/oompa).
```