### PR TITLE
fix: CI fix prompt and amend strategy improvements

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -679,7 +679,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			return
 		}
 
-		// Claude said RELATED — check if there are fixup commits or uncommitted changes
+		// Claude said RELATED — check if there are fixup commits, amended commits, or uncommitted changes
 		pushed := false
 		hasFixupCommits := a.hasFixupCommits(ctx, task.work.WorktreePath)
 		hasUncommitted := a.hasUncommittedChanges(ctx, task.work.WorktreePath)
@@ -694,16 +694,21 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				pushed = true
 			}
 		} else if hasUncommitted {
-			// Only amend HEAD if this is a single-commit PR
-			// For multi-commit PRs, Claude should have created fixup commits
-			if len(task.commits) > 1 {
-				a.logger.Error("CI fix produced uncommitted changes for multi-commit PR but no fixup commits", "pr", task.work.PRNumber, "commits", len(task.commits))
-				// Don't amend HEAD — this would attach the fix to the wrong commit
+			// Claude left uncommitted changes — amend them into HEAD as fallback
+			if err := a.gitAmendAll(ctx, task.work.WorktreePath); err != nil {
+				a.logger.Error("failed to amend commit for CI fix", "pr", task.work.PRNumber, "error", err)
+			} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+				a.logger.Error("failed to push CI fix", "pr", task.work.PRNumber, "error", err)
 			} else {
-				// For single-commit PRs, amending HEAD is correct
-				if err := a.gitAmendAll(ctx, task.work.WorktreePath); err != nil {
-					a.logger.Error("failed to amend commit for CI fix", "pr", task.work.PRNumber, "error", err)
-				} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+				pushed = true
+			}
+		} else {
+			// No fixups and no uncommitted changes — Claude may have amended
+			// the commit directly. Check if HEAD differs from the remote SHA.
+			localSHA, _, err := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+			if err == nil && strings.TrimSpace(string(localSHA)) != task.headSHA {
+				a.logger.Info("Claude amended commit directly, pushing", "pr", task.work.PRNumber)
+				if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 					a.logger.Error("failed to push CI fix", "pr", task.work.PRNumber, "error", err)
 				} else {
 					pushed = true

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -129,9 +129,12 @@ Instructions:
      Focus ONLY on describing the failure itself: what test failed, what the error was, and why it looks flaky or infrastructure-related.
      The explanation will be used to create a standalone flaky test issue, so it must make sense without any PR context.
 3. If the failure IS directly related to the PR changes:
-   - Your output MUST start with the word RELATED
    - Fix the code so that CI passes
    - Run "make lint" and "make test" locally to verify
+   - CRITICAL: After you are done fixing, your FINAL text output MUST start with the word RELATED
+     followed by a brief summary of what you fixed. This prefix is mandatory — the automation
+     parses it to determine next steps. If you forget to start with RELATED, your entire fix
+     will be discarded.
    `
 
 	signoff := ""

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -144,13 +144,17 @@ Instructions:
 
 	if len(commits) > 1 {
 		prompt += `   - IMPORTANT: This PR has multiple commits. You MUST identify which specific commit introduced the breaking change
-   - After fixing the code, create a fixup commit targeting the commit that introduced the issue:
+   - After fixing the code, amend your fix into the commit that introduced the issue:
      git add <fixed-files>
-     git commit --fixup <SHA-of-commit-that-introduced-issue>
-   - Do NOT use "git commit --amend" as that would incorrectly amend the last commit` + signoff + `
+     git commit --amend --no-edit
+   - If the breaking commit is NOT the HEAD commit, use fixup instead:
+     git add <fixed-files>
+     git commit --fixup <SHA-of-commit-that-introduced-issue>` + signoff + `
 `
 	} else {
-		prompt += `   - After fixing the code, stage your changes with "git add" but do NOT commit
+		prompt += `   - After fixing the code, amend your fix into the commit:
+     git add <fixed-files>
+     git commit --amend --no-edit` + signoff + `
 `
 	}
 

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -189,13 +189,13 @@ func TestBuildCIFixPrompt(t *testing.T) {
 		t.Error("prompt missing Signed-off-by when provided for multi-commit PR")
 	}
 
-	// Single-commit PR should NOT include signed-off-by instruction (no new commits created)
+	// Single-commit PR should also include signed-off-by (amend rewrites the commit)
 	singleCommit := []Commit{
 		{SHA: "abc123def456", Subject: "Fix handler"},
 	}
 	prompt = buildCIFixPrompt(work, failures, diff, singleCommit, "Test User <test@example.com>")
-	if strings.Contains(prompt, "Signed-off-by:") {
-		t.Error("prompt should NOT include Signed-off-by for single-commit PR (no new commits)")
+	if !strings.Contains(prompt, "Signed-off-by: Test User <test@example.com>") {
+		t.Error("prompt missing Signed-off-by for single-commit PR (amend rewrites commit)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reinforce the RELATED/UNRELATED prefix requirement so Claude doesn't forget it after long fix sessions
- Instruct Claude to amend CI fixes directly into the proper commit instead of leaving uncommitted changes
- Detect when Claude has already amended a commit and push it directly

## Problem

Two issues observed while babysitting openperouter PR #313:

1. **Lost fix ($2.16 wasted)**: Claude spent 75 turns fixing 3 CI failures but started its final output with "Perfect! I've identified and fixed..." instead of the required `RELATED` prefix. The format validation correctly discarded the response, but all the work was lost.

2. **Wrong commit strategy**: For single-commit PRs, Claude was told to only `git add` without committing, then the agent would amend. This is fragile -- Claude should amend directly into the right commit.

## Changes

### Prompt (`prompt.go`)
- Move the `RELATED` prefix instruction to **after** the fix steps, mark it as `CRITICAL`, and warn that the fix will be discarded without it
- Single-commit PRs: tell Claude to `git commit --amend --no-edit`
- Multi-commit PRs: tell Claude to amend HEAD if the breaking commit is HEAD, otherwise `git commit --fixup <sha>`
- Include `Signed-off-by` for both cases (amend rewrites the commit)

### Agent (`loop.go`)
- Add detection for Claude-amended commits: if no fixup commits and no uncommitted changes but local HEAD differs from remote SHA, just push
- Simplify the uncommitted changes fallback (amend regardless of commit count)

### Test (`prompt_test.go`)
- Update test to expect `Signed-off-by` in single-commit PR prompts (amend rewrites the commit message)