### PR TITLE
fix: detect and push when Claude commits directly during review

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -423,11 +423,14 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	// Parallel phase: run Claude, amend/push, post fallback replies
 	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task reviewTask) {
 		// Capture local HEAD before Claude runs so we can detect if Claude committed directly
-		headBefore, _, _ := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+		headBefore, _, err := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+		if err != nil {
+			a.logger.Warn("failed to get HEAD before Claude", "pr", task.work.PRNumber, "error", err)
+		}
 		headSHABefore := strings.TrimSpace(string(headBefore))
 
 		prompt := buildReviewResponsePrompt(*task.work, task.humanComments, task.humanReviews, a.cfg.Owner, a.cfg.Repo)
-		_, err := runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
+		_, err = runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
 		if err != nil {
 			a.logger.Error("claude failed to address review", "pr", task.work.PRNumber, "error", err)
 			return
@@ -444,9 +447,9 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		} else {
 			// No uncommitted changes — Claude may have committed or amended directly.
 			// Check if HEAD changed since before Claude ran.
-			headAfter, _, _ := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+			headAfter, _, revErr := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
 			headSHAAfter := strings.TrimSpace(string(headAfter))
-			if headSHAAfter != headSHABefore {
+			if revErr == nil && headSHABefore != "" && headSHAAfter != headSHABefore {
 				a.logger.Info("Claude committed directly, pushing", "pr", task.work.PRNumber)
 				hasChanges = true
 				if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -422,6 +422,10 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 
 	// Parallel phase: run Claude, amend/push, post fallback replies
 	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task reviewTask) {
+		// Capture local HEAD before Claude runs so we can detect if Claude committed directly
+		headBefore, _, _ := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+		headSHABefore := strings.TrimSpace(string(headBefore))
+
 		prompt := buildReviewResponsePrompt(*task.work, task.humanComments, task.humanReviews, a.cfg.Owner, a.cfg.Repo)
 		_, err := runClaude(ctx, a.runner, task.work.WorktreePath, prompt, a.cfg, a.logger, true)
 		if err != nil {
@@ -436,6 +440,18 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 				a.logger.Error("failed to amend commit", "pr", task.work.PRNumber, "error", err)
 			} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 				a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
+			}
+		} else {
+			// No uncommitted changes — Claude may have committed or amended directly.
+			// Check if HEAD changed since before Claude ran.
+			headAfter, _, _ := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
+			headSHAAfter := strings.TrimSpace(string(headAfter))
+			if headSHAAfter != headSHABefore {
+				a.logger.Info("Claude committed directly, pushing", "pr", task.work.PRNumber)
+				hasChanges = true
+				if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+					a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Fix a bug where `ProcessReviewComments` failed to push changes when Claude created new commits or amended directly instead of leaving uncommitted changes
- Capture local HEAD SHA before invoking Claude, compare afterwards, and push if it changed

## Problem

When Claude addresses review comments, it sometimes creates new commits or amends the existing commit directly (despite being told not to). `ProcessReviewComments` only checked `hasUncommittedChanges()` — when Claude committed directly, there were no uncommitted changes, so nothing got pushed. The review fixes stayed local forever.

This was observed on PR #85 where Claude created 2 commits to address Gemini Code Assist review feedback, but oompa never pushed them.

## Fix

Capture `git rev-parse HEAD` before running Claude and compare it after. If HEAD changed but there are no uncommitted changes, Claude committed directly — push the result. This mirrors the detection logic already present in `ProcessCIFailures` (added in PR #78).

## Testing

- `go test ./...` passes
- `golangci-lint run ./...` passes
- No behavioral change for the normal case (uncommitted changes still get amended and pushed)

Fixes the unpushed review fixes observed on PR #85.

<!-- oompa-bot -->