### PR TITLE
fix: skip flaky issue creation when check run logs are empty

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -567,13 +567,17 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
-		// Fetch logs for each failing check
+		// Fetch logs for each failing check when output is missing or too short.
+		// Threshold of 50 chars filters out generic GitHub Actions boilerplate
+		// (e.g., "Process completed with exit code 1") that doesn't provide
+		// enough context for meaningful analysis.
 		for i, f := range failures {
-			if f.Output == "" {
+			trimmed := strings.TrimSpace(f.Output)
+			if len(trimmed) < 50 {
 				log, err := a.gh.GetCheckRunLog(ctx, a.cfg.Owner, a.cfg.Repo, f.ID)
 				if err != nil {
 					a.logger.Warn("failed to get check run log", "check", f.Name, "error", err)
-				} else {
+				} else if log != "" {
 					failures[i].Output = log
 				}
 			}
@@ -644,6 +648,18 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 			// Create a flaky CI issue if configured
 			if a.cfg.CreateFlakyIssues {
+				// Skip flaky issue creation if check run output is still too short after
+				// attempting to fetch full logs. Without sufficient output, Claude cannot
+				// meaningfully match against existing issues or describe the root cause.
+				trimmedOutput := strings.TrimSpace(task.failures[0].Output)
+				if len(trimmedOutput) < 50 {
+					a.logger.Warn("skipping flaky issue creation: check run output is empty or too short",
+						"pr", task.work.PRNumber,
+						"check", task.failures[0].Name,
+						"output_length", len(trimmedOutput))
+					return
+				}
+
 				issueTitle := fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
 
 				// Search for existing open issues with the flaky label

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -21,11 +21,12 @@ type mockGitHubClient struct {
 	removedLabels   []string
 	addedReactions  []string
 	checkRuns       []CheckRun
-	prHeadSHAs      []string // returns these in sequence; if empty returns "abc123"
-	prsAfterNCalls  int      // only return PRs after this many ListPRsByHead calls
+	checkRunLogs    map[int64]string // maps check run ID to full log content
+	prHeadSHAs      []string         // returns these in sequence; if empty returns "abc123"
+	prsAfterNCalls  int              // only return PRs after this many ListPRsByHead calls
 	prsCallCount    int
-	mergeableState  string  // mergeable state to return from GetPRMergeable (default: "clean")
-	prBehind        bool    // whether IsPRBehind returns true
+	mergeableState  string        // mergeable state to return from GetPRMergeable (default: "clean")
+	prBehind        bool          // whether IsPRBehind returns true
 	createdIssues   []Issue       // tracks issues created via CreateIssue
 	nextIssueNumber int           // next issue number to return (defaults to 1)
 	searchResults   []Issue       // results to return from SearchIssues
@@ -94,7 +95,12 @@ func (m *mockGitHubClient) GetCheckRuns(_ context.Context, _, _, _ string) ([]Ch
 	return m.checkRuns, nil
 }
 
-func (m *mockGitHubClient) GetCheckRunLog(_ context.Context, _, _ string, _ int64) (string, error) {
+func (m *mockGitHubClient) GetCheckRunLog(_ context.Context, _, _ string, checkRunID int64) (string, error) {
+	if m.checkRunLogs != nil {
+		if log, ok := m.checkRunLogs[checkRunID]; ok {
+			return log, nil
+		}
+	}
 	return "", nil
 }
 
@@ -672,6 +678,9 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 		checkRuns: []CheckRun{
 			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
 		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
 	}
 	runner := &mockCommandRunner{stdout: claudeResult}
 	wt := &mockWorktreeManager{}
@@ -729,6 +738,9 @@ func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 		checkRuns: []CheckRun{
 			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
 		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
 	}
 	runner := &mockCommandRunner{stdout: claudeResult}
 	wt := &mockWorktreeManager{}
@@ -763,6 +775,9 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{
 			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
 		},
 		searchResults: []Issue{
 			{Number: 50, Title: "Flaky CI: integration-tests", Labels: []string{"flaky-test"}},
@@ -805,6 +820,9 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{
 			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
 		},
 		searchResults: []Issue{}, // No existing issues
 	}
@@ -849,6 +867,9 @@ func TestProcessCIFailures_CreatesIssueWhenClaudeSaysNone(t *testing.T) {
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{
 			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
 		},
 		searchResults: []Issue{
 			{Number: 50, Title: "Some other flaky test", Labels: []string{"flaky-test"}},


### PR DESCRIPTION
Fixes #88

## Summary

This PR fixes an issue where oompa creates duplicate flaky CI issues when check run logs are empty. When the GitHub API returns empty check run output, Claude cannot meaningfully determine if the failure matches an existing issue or describe the root cause, leading to duplicate issues.

## Changes

- Added validation in `ProcessCIFailures` to check if check run output is empty or too short (< 50 chars) before creating flaky issues
- When output is insufficient, the code now logs a warning and skips flaky issue creation
- PR comments about unrelated CI failures are still posted (existing behavior preserved)

## Testing

- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #88

<!-- oompa-bot -->