### PR TITLE
fix: ProcessRebase should delegate to ProcessConflicts when rebase fails with conflicts

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -860,55 +860,16 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 	}
 
 	// Parallel phase: Claude invocations for conflict resolution
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task conflictTask) {
-		// Get commit count before invoking Claude
-		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
-		commitCountBefore := len(commitsBefore)
-
-		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch(), a.cfg.SignedOffBy)
-		_, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
-		if err != nil {
-			a.logger.Error("agent failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Could not resolve conflicts on commit %s automatically. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
-			return
-		}
-
-		// Verify that no unexpected new commits were created
-		commitsAfter := a.getPRCommits(ctx, task.work.WorktreePath)
-		commitCountAfter := len(commitsAfter)
-
-		if commitCountAfter > commitCountBefore {
-			a.logger.Warn("conflict resolution created new commits instead of resolving within rebase",
-				"pr", task.work.PRNumber,
-				"before", commitCountBefore,
-				"after", commitCountAfter,
-				"new_commits", commitCountAfter-commitCountBefore)
-
-			// Warn user - the improved prompt should prevent this, but if it happens, request human intervention
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("⚠️ Conflict resolution created %d unexpected new commit(s) instead of resolving within the rebase flow.\n\n"+
-					"Expected: %d commits (original structure preserved)\n"+
-					"Got: %d commits (new commits added)\n\n"+
-					"Please review the commit history and manually squash or rebase to preserve the original commit structure.\n\n%s",
-					commitCountAfter-commitCountBefore, commitCountBefore, commitCountAfter, botMarker))
-		}
-
-		// Push the rebased branch
-		if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
-			a.logger.Error("failed to push after conflict resolution", "pr", task.work.PRNumber, "error", err)
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Could not push conflict resolution for commit %s. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker))
-		} else {
-			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), botMarker))
-		}
-	})
+	a.resolveConflictsParallel(ctx, tasks)
 }
 
 // ProcessRebase rebases PRs that are behind the base branch but have no merge conflicts.
 // For PRs with actual merge conflicts (dirty state), use ProcessConflicts instead.
+// If a rebase fails due to conflicts, this delegates to the conflict resolution flow.
 func (a *Agent) ProcessRebase(ctx context.Context) {
+	// Sequential phase: check states, try automatic rebase, collect failed conflicts into tasks
+	var tasks []conflictTask
+
 	for _, work := range a.state.ActiveIssues {
 		if work.PRNumber == 0 || work.Status != StatusPROpen {
 			continue
@@ -954,9 +915,21 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 
 		_, stderr, rebaseErr := a.runner.Run(ctx, work.WorktreePath, "git", "rebase", a.originDefaultBranch())
 		if rebaseErr != nil {
-			// Rebase should not fail since there are no conflicts — abort and log
 			a.runner.Run(ctx, work.WorktreePath, "git", "rebase", "--abort") //nolint:errcheck // best-effort
-			a.logger.Error("rebase failed unexpectedly (no conflicts expected)", "pr", work.PRNumber, "stderr", string(stderr))
+
+			// Check if the rebase failed due to conflicts
+			if isConflictError(string(stderr)) {
+				a.logger.Info("rebase failed with conflicts, will invoke conflict resolution", "pr", work.PRNumber)
+				tasks = append(tasks, conflictTask{
+					work:         work,
+					headSHA:      headSHA,
+					rebaseErr:    rebaseErr,
+					rebaseStderr: string(stderr),
+				})
+			} else {
+				// Non-conflict rebase failure (e.g., corrupt repo state, hook failure)
+				a.logger.Error("rebase failed for non-conflict reason", "pr", work.PRNumber, "stderr", string(stderr))
+			}
 			continue
 		}
 
@@ -968,6 +941,9 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 				fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), botMarker))
 		}
 	}
+
+	// Parallel phase: invoke Claude for conflict resolution on collected tasks
+	a.resolveConflictsParallel(ctx, tasks)
 }
 
 // ProcessTriageJobs monitors periodic CI jobs for failures and investigates them.
@@ -1495,6 +1471,71 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// isConflictError returns true if the stderr from a git rebase contains conflict indicators.
+func isConflictError(stderr string) bool {
+	lowerStderr := strings.ToLower(stderr)
+	return strings.Contains(lowerStderr, "conflict") || strings.Contains(lowerStderr, "could not apply")
+}
+
+// resolveConflictsParallel invokes the coding agent to resolve conflicts for a list of tasks in parallel.
+func (a *Agent) resolveConflictsParallel(ctx context.Context, tasks []conflictTask) {
+	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task conflictTask) {
+		// Get commit count before invoking agent and validate capture
+		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
+		if commitsBefore == nil {
+			a.logger.Error("failed to capture commits before resolution", "pr", task.work.PRNumber)
+			return
+		}
+		commitCountBefore := len(commitsBefore)
+
+		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch(), a.cfg.SignedOffBy)
+		_, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
+		if err != nil {
+			a.logger.Error("agent failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("Could not resolve conflicts on commit %s automatically. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker)); err != nil {
+				a.logger.Error("failed to log error to github", "pr", task.work.PRNumber, "error", err)
+			}
+			return
+		}
+
+		// Verify that no unexpected new commits were created
+		commitsAfter := a.getPRCommits(ctx, task.work.WorktreePath)
+		commitCountAfter := len(commitsAfter)
+
+		if commitCountAfter > commitCountBefore {
+			a.logger.Warn("conflict resolution created new commits instead of resolving within rebase",
+				"pr", task.work.PRNumber,
+				"before", commitCountBefore,
+				"after", commitCountAfter,
+				"new_commits", commitCountAfter-commitCountBefore)
+
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("⚠️ Conflict resolution created %d unexpected new commit(s) instead of resolving within the rebase flow.\n\n"+
+					"Expected: %d commits (original structure preserved)\n"+
+					"Got: %d commits (new commits added)\n\n"+
+					"Please review the commit history and manually squash or rebase to preserve the original commit structure.\n\n%s",
+					commitCountAfter-commitCountBefore, commitCountBefore, commitCountAfter, botMarker)); err != nil {
+				a.logger.Error("failed to log warning to github", "pr", task.work.PRNumber, "error", err)
+			}
+		}
+
+		// Push the rebased branch
+		if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+			a.logger.Error("failed to push after conflict resolution", "pr", task.work.PRNumber, "error", err)
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("Could not push conflict resolution for commit %s. Human intervention needed.\n\n%s", shortSHA(task.headSHA), botMarker)); err != nil {
+				a.logger.Error("failed to log push error to github", "pr", task.work.PRNumber, "error", err)
+			}
+		} else {
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), botMarker)); err != nil {
+				a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
+			}
+		}
+	})
 }
 
 // markIssueFailed marks an issue as failed, unassigns the agent, and adds the ai-failed label.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -227,7 +227,7 @@ func (m *mockWorktreeManager) RemoveWorktree(_ context.Context, worktreePath str
 	return nil
 }
 
-func newTestAgent(gh *mockGitHubClient, runner *mockCommandRunner, wt *mockWorktreeManager) *Agent {
+func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt *mockWorktreeManager) *Agent {
 	return &Agent{
 		gh:        gh,
 		runner:    runner,
@@ -1384,6 +1384,101 @@ func TestProcessRebase_SkipsDirty(t *testing.T) {
 			t.Errorf("ProcessRebase should not run git commands for dirty PR, got: git %v", c.Args)
 		}
 	}
+}
+
+func TestProcessRebase_InvokesConflictResolutionWhenRebaseFails(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "behind",
+	}
+	// Create a custom runner that returns conflict error for rebase
+	baseMock := &mockCommandRunner{}
+	runner := &conflictRebaseRunner{
+		mockCommandRunner: baseMock,
+	}
+	wt := &mockWorktreeManager{}
+	codeAgent := &mockCodeAgent{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = codeAgent
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessRebase(context.Background())
+
+	// Should have called git rebase and git rebase --abort
+	var rebaseCalls, abortCalls int
+	for _, c := range baseMock.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
+			if len(c.Args) > 1 && c.Args[1] == "--abort" {
+				abortCalls++
+			} else {
+				rebaseCalls++
+			}
+		}
+	}
+
+	if rebaseCalls == 0 {
+		t.Error("expected git rebase to be called")
+	}
+	if abortCalls == 0 {
+		t.Error("expected git rebase --abort to be called after conflict")
+	}
+
+	// Should have invoked the code agent for conflict resolution
+	if !codeAgent.called {
+		t.Error("expected code agent to be called for conflict resolution")
+	}
+	if !strings.Contains(codeAgent.lastPrompt, "merge conflicts") {
+		t.Errorf("expected conflict resolution prompt, got: %s", codeAgent.lastPrompt)
+	}
+}
+
+// conflictRebaseRunner is a test helper that returns conflict errors for git rebase
+type conflictRebaseRunner struct {
+	*mockCommandRunner
+}
+
+func (r *conflictRebaseRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	// Call the base mock to record the call
+	stdout, _, _ = r.mockCommandRunner.Run(ctx, workDir, name, args...)
+
+	// Return conflict error for "git rebase" (but not "git rebase --abort")
+	if name == "git" && len(args) > 0 && args[0] == "rebase" {
+		isAbort := false
+		for _, arg := range args {
+			if arg == "--abort" {
+				isAbort = true
+				break
+			}
+		}
+		if !isAbort {
+			return nil, []byte("error: could not apply 3a35b4e... Migrate remaining features"), fmt.Errorf("rebase failed")
+		}
+	}
+
+	return stdout, nil, nil
+}
+
+// mockCodeAgent is a test double for CodeAgent
+type mockCodeAgent struct {
+	called     bool
+	lastPrompt string
+	result     AgentResult
+	err        error
+}
+
+func (m *mockCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string, logger *slog.Logger, resume bool) (AgentResult, error) {
+	m.called = true
+	m.lastPrompt = prompt
+	if m.err != nil {
+		return AgentResult{}, m.err
+	}
+	return m.result, nil
 }
 
 func TestProcessConflicts_SkipsCleanPR(t *testing.T) {


### PR DESCRIPTION
Fixes #91

## Summary

When `ProcessRebase` detects a PR is behind the base branch and attempts an automatic rebase, if the rebase fails due to merge conflicts, it now delegates to the conflict resolution flow instead of just logging an error and moving on.

## Changes

- Modified `ProcessRebase` in `pkg/agent/loop.go` to detect conflict errors in rebase stderr
- Added `isConflictError` helper function to identify conflict indicators in git output
- When conflicts are detected, `ProcessRebase` now collects failed rebases as `conflictTask` items
- Conflict resolution tasks are processed in parallel using the same Claude-assisted rebase flow as `ProcessConflicts`
- Added comprehensive test `TestProcessRebase_InvokesConflictResolutionWhenRebaseFails` to verify the new behavior
- Added test helper types `conflictRebaseRunner` and `mockCodeAgent` for testing

## Testing

- [x] Added unit test for conflict delegation behavior
- [ ] `go test ./...` passes (will be verified by CI)
- [ ] `go vet ./...` passes (will be verified by CI)
- [ ] Manual testing: The fix addresses the issue observed on ovn-kubernetes PRs #6252, #6229, and #6118 where PRs behind main with conflicts were stuck in a rebase failure loop

## Related Issues

Fixes #91

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved handling of git rebase failures with automatic conflict detection.
  * Rebase conflicts now trigger automated resolution attempts executed in parallel with commit tracking.
  * Issue comments report conflict resolution outcomes and alert on unexpected changes.

* **Tests**
  * Comprehensive tests added for rebase conflict detection and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->