### PR TITLE
fix: stop passing GH_TOKEN to subprocesses, use gh auth instead

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
@@ -328,7 +329,13 @@ func main() {
 	} else {
 		token := os.Getenv("GITHUB_TOKEN")
 		if token == "" {
-			logger.Error("GITHUB_TOKEN is required (or configure GitHub App auth with --github-app-id, --github-app-private-key/GITHUB_APP_PRIVATE_KEY, --github-app-installation-id)")
+			// Fallback: get token from gh auth if GITHUB_TOKEN is not set
+			if ghToken, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+				token = strings.TrimSpace(string(ghToken))
+			}
+		}
+		if token == "" {
+			logger.Error("GITHUB_TOKEN is required, or run 'gh auth login' (or configure GitHub App auth with --github-app-id, --github-app-private-key/GITHUB_APP_PRIVATE_KEY, --github-app-installation-id)")
 			os.Exit(1)
 		}
 		cfg.GitHubToken = token

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -186,13 +186,10 @@ func parseStreamResult(stdout []byte) (AgentResult, error) {
 }
 
 // BuildAgentEnv builds the environment variable slice for agent invocations.
-// Only passes through git identity and GitHub token; provider-specific vars
-// are inherited from the system environment.
+// Only passes through git identity; provider-specific vars and GH_TOKEN
+// are inherited from the system environment (e.g. via gh auth git-credential).
 func BuildAgentEnv(cfg Config) []string {
 	var env []string
-	if cfg.GitHubToken != "" {
-		env = append(env, fmt.Sprintf("GH_TOKEN=%s", cfg.GitHubToken))
-	}
 	if cfg.GitAuthorName != "" {
 		env = append(env,
 			fmt.Sprintf("GIT_AUTHOR_NAME=%s", cfg.GitAuthorName),

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -186,8 +186,9 @@ func parseStreamResult(stdout []byte) (AgentResult, error) {
 }
 
 // BuildAgentEnv builds the environment variable slice for agent invocations.
-// Only passes through git identity; provider-specific vars and GH_TOKEN
-// are inherited from the system environment (e.g. via gh auth git-credential).
+// Only passes through git identity; other variables (like GH_TOKEN) are
+// inherited from the system environment. This allows subprocesses to use
+// system-level authentication or credential helpers (e.g. gh auth git-credential).
 func BuildAgentEnv(cfg Config) []string {
 	var env []string
 	if cfg.GitAuthorName != "" {


### PR DESCRIPTION
## Summary

- Remove `GH_TOKEN` from `BuildAgentEnv` so subprocesses (git, claude, opencode) use `gh auth git-credential` instead

## Problem

Oompa sets `GH_TOKEN` in the subprocess environment via `BuildAgentEnv`. This overrides the `gh auth git-credential` helper configured in `~/.gitconfig`. The oompa `GITHUB_TOKEN` (from the env file) lacks the `workflow` scope, so `git push` fails when branches touch `.github/workflows/` files.

This was blocking conflict resolution on ovn-kubernetes PRs #6252, #6229, #6118 where the upstream rebase included workflow file changes.

## Fix

Remove the `GH_TOKEN` line from `BuildAgentEnv`. Subprocesses now inherit the system environment and use `gh auth git-credential` which has proper scopes. GitHub App auth is unaffected — it sets `GH_TOKEN` via `os.Setenv` and `SetGHToken` during token refresh.

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Provider-specific environment variables, including GitHub tokens, are now sourced from the system environment instead of programmatic configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->