### PR TITLE
feat: detect CI failures reported as commit statuses (Prow support)

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -38,6 +38,7 @@ type GitHubClient interface {
 	IsPRBehind(ctx context.Context, owner, repo string, prNumber int) (bool, error)
 	CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (int, error)
 	SearchIssues(ctx context.Context, query string) ([]Issue, error)
+	GetCommitStatuses(ctx context.Context, owner, repo, ref string) ([]CheckRun, error)
 	ListWorkflowRuns(ctx context.Context, owner, repo, workflowID string, status string, limit int) ([]WorkflowRun, error)
 	ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error)
 	GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error)
@@ -266,6 +267,41 @@ func (g *GoGitHubClient) GetCheckRuns(ctx context.Context, owner, repo, ref stri
 			Conclusion: r.GetConclusion(),
 			Output:     output,
 		})
+	}
+	return runs, nil
+}
+
+// GetCommitStatuses queries the Combined Status API and returns failures as
+// CheckRun values. Commit-status entries have ID==0 (no check-run ID exists)
+// and Output contains the status description and target_url (a link to logs,
+// e.g. Prow job page) rather than log text. Callers must not pass ID==0 to
+// GetCheckRunLog.
+func (g *GoGitHubClient) GetCommitStatuses(ctx context.Context, owner, repo, ref string) ([]CheckRun, error) {
+	var runs []CheckRun
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		status, resp, err := g.client.Repositories.GetCombinedStatus(ctx, owner, repo, ref, opts)
+		if err != nil {
+			return nil, fmt.Errorf("getting combined status: %w", err)
+		}
+		for _, s := range status.Statuses {
+			if s.GetState() == "failure" || s.GetState() == "error" {
+				output := s.GetTargetURL()
+				if desc := s.GetDescription(); desc != "" {
+					output = desc + "\n" + output
+				}
+				runs = append(runs, CheckRun{
+					Name:       s.GetContext(),
+					Status:     "completed",
+					Conclusion: "failure",
+					Output:     output,
+				})
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 	return runs, nil
 }

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -506,6 +506,96 @@ func TestSearchIssues_FiltersPullRequests(t *testing.T) {
 	}
 }
 
+func TestGetCommitStatuses_ReturnsFailures(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits/abc123/status", func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"state": "failure",
+			"statuses": []map[string]any{
+				{
+					"context":     "pull-kubernetes-nmstate-unit-test",
+					"state":       "failure",
+					"description": "Build failed.",
+					"target_url":  "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-unit-test/1234",
+				},
+				{
+					"context":    "pull-kubernetes-nmstate-e2e",
+					"state":      "success",
+					"target_url": "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-e2e/1235",
+				},
+				{
+					"context":    "pull-kubernetes-nmstate-lint",
+					"state":      "error",
+					"target_url": "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-lint/1236",
+				},
+				{
+					"context":    "pull-kubernetes-nmstate-build",
+					"state":      "pending",
+					"target_url": "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-build/1237",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
+
+	gh := setupTestClient(t, mux)
+	runs, err := gh.GetCommitStatuses(context.Background(), "owner", "repo", "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should only return failure and error states (not success or pending)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 failed statuses, got %d", len(runs))
+	}
+	if runs[0].Name != "pull-kubernetes-nmstate-unit-test" {
+		t.Errorf("expected name 'pull-kubernetes-nmstate-unit-test', got %q", runs[0].Name)
+	}
+	if runs[0].Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", runs[0].Status)
+	}
+	if runs[0].Conclusion != "failure" {
+		t.Errorf("expected conclusion 'failure', got %q", runs[0].Conclusion)
+	}
+	// Output should include description + target_url
+	expectedOutput := "Build failed.\nhttps://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-unit-test/1234"
+	if runs[0].Output != expectedOutput {
+		t.Errorf("expected output with description and URL, got %q", runs[0].Output)
+	}
+	if runs[1].Name != "pull-kubernetes-nmstate-lint" {
+		t.Errorf("expected name 'pull-kubernetes-nmstate-lint', got %q", runs[1].Name)
+	}
+	// Second entry has no description, should only have target_url
+	if runs[1].Output != "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/pull-kubernetes-nmstate-lint/1236" {
+		t.Errorf("expected output with URL only (no description), got %q", runs[1].Output)
+	}
+}
+
+func TestGetCommitStatuses_NoFailures(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits/abc123/status", func(w http.ResponseWriter, r *http.Request) {
+		result := map[string]any{
+			"state": "success",
+			"statuses": []map[string]any{
+				{
+					"context":    "ci/test",
+					"state":      "success",
+					"target_url": "https://example.com/logs",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
+
+	gh := setupTestClient(t, mux)
+	runs, err := gh.GetCommitStatuses(context.Background(), "owner", "repo", "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("expected 0 failed statuses, got %d", len(runs))
+	}
+}
+
 func TestGetCheckRuns_UsesPerPage100(t *testing.T) {
 	var receivedPerPage int
 	mux := http.NewServeMux()

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -190,6 +190,10 @@ func (f *fakeGitHubClient) GetCheckRuns(_ context.Context, _, _, ref string) ([]
 	return append([]CheckRun{}, f.state.checkRuns...), nil
 }
 
+func (f *fakeGitHubClient) GetCommitStatuses(_ context.Context, _, _, _ string) ([]CheckRun, error) {
+	return nil, nil
+}
+
 func (f *fakeGitHubClient) GetCheckRunLog(_ context.Context, _, _ string, _ int64) (string, error) {
 	return "", nil
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -555,6 +555,15 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
+		// Also query commit statuses (e.g. Prow) and merge into results
+		statusFailures, err := a.gh.GetCommitStatuses(ctx, a.cfg.Owner, a.cfg.Repo, headSHA)
+		if err != nil {
+			a.logger.Warn("failed to get commit statuses", "pr", work.PRNumber, "error", err)
+			// Non-fatal: continue with check runs only
+		} else {
+			runs = append(runs, statusFailures...)
+		}
+
 		// Collect completed failures — act immediately without waiting for all checks
 		var failures []CheckRun
 		for _, r := range runs {
@@ -571,7 +580,13 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		// Threshold of 50 chars filters out generic GitHub Actions boilerplate
 		// (e.g., "Process completed with exit code 1") that doesn't provide
 		// enough context for meaningful analysis.
+		// Skip entries with ID==0: these are commit-status entries (e.g. Prow)
+		// where Output contains a target_url, not log text, and no check-run
+		// log is available via the GitHub Actions API.
 		for i, f := range failures {
+			if f.ID == 0 {
+				continue
+			}
 			trimmed := strings.TrimSpace(f.Output)
 			if len(trimmed) < 50 {
 				log, err := a.gh.GetCheckRunLog(ctx, a.cfg.Owner, a.cfg.Repo, f.ID)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -11,26 +11,27 @@ import (
 
 // mockGitHubClient implements GitHubClient for testing.
 type mockGitHubClient struct {
-	issues          []Issue
-	prComments      []ReviewComment
-	issueComments   []ReviewComment
-	prState         string
-	prs             []PR
-	addedComments   []string
-	addedLabels     []string
-	removedLabels   []string
-	addedReactions  []string
-	checkRuns       []CheckRun
-	checkRunLogs    map[int64]string // maps check run ID to full log content
-	prHeadSHAs      []string         // returns these in sequence; if empty returns "abc123"
-	prsAfterNCalls  int              // only return PRs after this many ListPRsByHead calls
-	prsCallCount    int
-	mergeableState  string        // mergeable state to return from GetPRMergeable (default: "clean")
-	prBehind        bool          // whether IsPRBehind returns true
-	createdIssues   []Issue       // tracks issues created via CreateIssue
-	nextIssueNumber int           // next issue number to return (defaults to 1)
-	searchResults   []Issue       // results to return from SearchIssues
-	workflowRuns    []WorkflowRun // workflow runs to return from ListWorkflowRuns
+	issues           []Issue
+	prComments       []ReviewComment
+	issueComments    []ReviewComment
+	prState          string
+	prs              []PR
+	addedComments    []string
+	addedLabels      []string
+	removedLabels    []string
+	addedReactions   []string
+	checkRuns        []CheckRun
+	commitStatuses   []CheckRun       // commit status failures (returned by GetCommitStatuses)
+	checkRunLogs     map[int64]string  // maps check run ID to full log content
+	prHeadSHAs       []string          // returns these in sequence; if empty returns "abc123"
+	prsAfterNCalls   int               // only return PRs after this many ListPRsByHead calls
+	prsCallCount     int
+	mergeableState   string            // mergeable state to return from GetPRMergeable (default: "clean")
+	prBehind         bool              // whether IsPRBehind returns true
+	createdIssues    []Issue           // tracks issues created via CreateIssue
+	nextIssueNumber  int               // next issue number to return (defaults to 1)
+	searchResults    []Issue           // results to return from SearchIssues
+	workflowRuns     []WorkflowRun     // workflow runs to return from ListWorkflowRuns
 
 	listIssuesErr error
 }
@@ -93,6 +94,10 @@ func (m *mockGitHubClient) AddPRCommentReaction(_ context.Context, _, _ string, 
 
 func (m *mockGitHubClient) GetCheckRuns(_ context.Context, _, _, _ string) ([]CheckRun, error) {
 	return m.checkRuns, nil
+}
+
+func (m *mockGitHubClient) GetCommitStatuses(_ context.Context, _, _, _ string) ([]CheckRun, error) {
+	return m.commitStatuses, nil
 }
 
 func (m *mockGitHubClient) GetCheckRunLog(_ context.Context, _, _ string, checkRunID int64) (string, error) {
@@ -1701,5 +1706,96 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 
 	if len(issue.Labels) != 1 || issue.Labels[0] != "ci-flake" {
 		t.Errorf("expected label 'ci-flake', got %v", issue.Labels)
+	}
+}
+
+func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed CI"})
+	gh := &mockGitHubClient{
+		// No check run failures
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "DCO", Status: "completed", Conclusion: "success"},
+		},
+		// Commit status failures (Prow)
+		commitStatuses: []CheckRun{
+			{Name: "pull-kubernetes-nmstate-unit-test", Status: "completed", Conclusion: "failure", Output: "https://prow.ci.kubevirt.io/logs/1234"},
+		},
+		prHeadSHAs: []string{"sha-before", "sha-after"},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	claudeCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			claudeCalls++
+		}
+	}
+	if claudeCalls != 1 {
+		t.Fatalf("expected 1 claude call for commit status failure, got %d", claudeCalls)
+	}
+	if agent.state.ActiveIssues[42].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[42].CIFixAttempts)
+	}
+}
+
+func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed both failures"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "github-actions-test", Status: "completed", Conclusion: "failure", Output: "test failed"},
+		},
+		commitStatuses: []CheckRun{
+			{Name: "pull-unit-test", Status: "completed", Conclusion: "failure", Output: "https://prow.ci/logs/1234"},
+		},
+		prHeadSHAs: []string{"sha-before", "sha-after"},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should have invoked Claude with both failures merged into the prompt
+	var claudePrompt string
+	claudeCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			claudeCalls++
+			// The prompt is the last positional argument
+			if len(c.Args) > 0 {
+				claudePrompt = c.Args[len(c.Args)-1]
+			}
+		}
+	}
+	if claudeCalls != 1 {
+		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
+	}
+	if !strings.Contains(claudePrompt, "github-actions-test") {
+		t.Errorf("expected prompt to contain check run failure 'github-actions-test', got: %s", truncateString(claudePrompt, 200))
+	}
+	if !strings.Contains(claudePrompt, "pull-unit-test") {
+		t.Errorf("expected prompt to contain commit status failure 'pull-unit-test', got: %s", truncateString(claudePrompt, 200))
 	}
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -67,13 +67,16 @@ type PRReview struct {
 	SubmittedAt time.Time
 }
 
-// CheckRun represents a GitHub Actions check run.
+// CheckRun represents a GitHub Actions check run or a commit status entry.
+// For check runs: ID is the check-run/job ID, Output contains log text.
+// For commit statuses (e.g. Prow): ID is 0, Output contains the target_url.
+// Callers must check ID != 0 before calling GetCheckRunLog.
 type CheckRun struct {
 	ID         int64
 	Name       string
 	Status     string // queued, in_progress, completed
 	Conclusion string // success, failure, neutral, cancelled, skipped, timed_out, action_required
-	Output     string // summary/text from the check run
+	Output     string // summary/text from the check run, or target_url for commit statuses
 }
 
 // JobRun represents a CI job run (periodic or triggered).


### PR DESCRIPTION
Fixes #99

## Summary

Extend CI failure detection to also query the GitHub Commit Status API, enabling oompa to detect failures from CI systems like Prow that report results as commit statuses rather than check runs.

## Changes

- Add `GetCommitStatuses` method to `GitHubClient` interface and `GoGitHubClient` implementation that queries `GET /repos/:owner/:repo/commits/:sha/status`
- In `ProcessCIFailures`, after calling `GetCheckRuns`, also call `GetCommitStatuses` and merge failures from both sources into the `failures` slice
- Map commit status fields to `CheckRun` struct: `context` -> `Name`, `failure`/`error` state -> `Conclusion == "failure"`, `target_url` -> `Output`
- Add `GetCommitStatuses` to all mock/fake GitHub clients in test files
- Add unit tests: `TestGetCommitStatuses_ReturnsFailures`, `TestGetCommitStatuses_NoFailures`, `TestProcessCIFailures_DetectsCommitStatusFailures`, `TestProcessCIFailures_MergesCheckRunsAndCommitStatuses`

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes

## Related Issues

Fixes #99

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- The agent now monitors Prow and other external commit status checks alongside GitHub checks, providing more complete CI failure detection.
- Status information from multiple sources is automatically combined to improve failure visibility and enable better diagnosis of CI issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->