### PR TITLE
feat: apply critical evaluation to CI fix prompt

### DIFF
--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -142,7 +142,11 @@ Instructions:
    - IMPORTANT: Do NOT mention the PR changes, the PR number, or what the PR modifies in your explanation.
      Focus ONLY on describing the failure itself: what test failed, what the error was, and why it looks flaky or infrastructure-related.
      The explanation will be used to create a standalone flaky test issue, so it must make sense without any PR context.
-3. If the failure IS directly related to the PR changes:
+3. If the failure IS directly related to the PR changes, CRITICALLY EVALUATE the fix before applying it:
+   - Verify the failure is actually caused by the PR changes, not a flaky test or infrastructure issue
+   - If the fix involves changing test expectations, confirm the new behavior is correct rather than just making the test pass
+   - If the failure is in code the PR did not touch, treat it as UNRELATED (see step 2) even if it looks related
+   - Prefer minimal, targeted fixes over broad refactoring — do not change more code than necessary
    - Fix the code so that CI passes
    - Run "make lint" and "make test" locally to verify
    - CRITICAL: After you are done fixing, your FINAL text output MUST start with the word RELATED

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -175,6 +175,13 @@ func TestBuildCIFixPrompt(t *testing.T) {
 		"UNRELATED",
 		"RELATED",
 		"Do NOT push",
+		// Critical evaluation criteria
+		"CRITICALLY EVALUATE",
+		"Verify the failure is actually caused by the PR changes",
+		"changing test expectations",
+		"confirm the new behavior is correct",
+		"treat it as UNRELATED",
+		"minimal, targeted fixes",
 	}
 
 	for _, want := range checks {

--- a/specs/prompts.md
+++ b/specs/prompts.md
@@ -24,7 +24,12 @@ Tells Claude to:
 Tells Claude to:
 - First investigate whether CI failures are directly caused by PR changes
 - If UNRELATED: output starts with "UNRELATED" and an explanation
-- If RELATED: output starts with "RELATED" and Claude fixes the code
+- If RELATED: critically evaluate the fix before applying it:
+  - Verify the failure is actually caused by the PR changes (not a flaky test or infrastructure issue)
+  - If the fix involves changing test expectations, confirm the new behavior is correct rather than just making the test pass
+  - If the failure is in code the PR did not touch, treat it as UNRELATED (see step 2) even if it looks related
+  - Prefer minimal, targeted fixes over broad refactoring
+- Output starts with "RELATED" and Claude fixes the code
 - For multi-commit PRs: create fixup commits targeting the commit that introduced the issue
 - For single-commit PRs: stage changes but do NOT commit (agent amends)
 - Run lint/test to verify the fix


### PR DESCRIPTION
Fixes #101

## Summary

Add critical evaluation criteria to the CI fix prompt (`buildCIFixPrompt`), mirroring the approach already applied to the review response prompt in commit e986e9c.

## Changes

- Update `specs/prompts.md` to document the new critical evaluation criteria for `buildCIFixPrompt`
- Update `buildCIFixPrompt` in `pkg/agent/prompt.go` to instruct the agent to critically evaluate fixes before applying them:
  - Verify the failure is actually caused by PR changes (not flaky/infrastructure)
  - Confirm test expectation changes reflect correct behavior
  - Flag failures in untouched code as potentially unrelated
  - Prefer minimal, targeted fixes over broad refactoring
- Update `TestBuildCIFixPrompt` in `pkg/agent/prompt_test.go` to assert on the new prompt content

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #101

<!-- oompa-bot -->