### PR TITLE
Image builder is broken

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,20 @@ jobs:
           path: .agentready/
           retention-days: 30
 
+  image-build:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Containerfile
+          push: false
+
   image:
     runs-on: ubuntu-latest
     needs: test

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 # Stage 1: Build the Go binary
-FROM golang:1.25 AS builder
+ARG GO_VERSION=1.26.0
+FROM golang:${GO_VERSION} AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
@@ -20,8 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go (matches kubernetes-nmstate requirements)
-ARG GO_VERSION=1.25.0
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+ARG GO_VERSION
+ARG TARGETARCH
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH:-amd64}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install gh CLI


### PR DESCRIPTION
Fixes #109

## Summary

Fix broken image build caused by Go version mismatch and add a CI job
to build the container image on PRs so breakage is caught before merge.

## Changes

- Update Containerfile builder stage from `golang:1.25` to `golang:1.26`
  to match `go.mod` requirement (`go 1.26`)
- Update runtime Go installation from `1.25.0` to `1.26.0`
- Add `image-build` job to CI workflow that builds the container image
  (without pushing) on pull requests

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #109

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated container image build validation for pull requests.
  * Updated Go runtime version to 1.26 in container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->