### PR TITLE
fix: improve flaky issue dedup with title pre-check and root-cause matching

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -757,28 +757,54 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 				if err != nil {
 					a.logger.Warn("failed to search for existing flaky issues", "error", err)
 				} else if len(existingIssues) > 0 {
-					// Ask the agent if any existing issue matches this failure.
-					// Use the check run output for matching, falling back to the
-					// agent's explanation when the output is empty/short.
-					matchOutput := task.failures[0].Output
-					if len(strings.TrimSpace(matchOutput)) < 50 {
-						matchOutput = explanation
+					// Fast path: exact title match skips LLM matching entirely.
+					// This handles the most common duplicate case (same check name)
+					// and prevents duplicates when the same check fails on multiple
+					// PRs in the same poll cycle.
+					for _, existing := range existingIssues {
+						if existing.Title == issueTitle {
+							issueNum = existing.Number
+							a.logger.Info("exact title match for existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
+							break
+						}
 					}
-					matchPrompt := buildFlakyMatchPrompt(task.failures[0].Name, matchOutput, existingIssues)
-					matchResult, matchErr := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, matchPrompt, a.logger, false)
-					if matchErr != nil {
-						a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
-					} else {
+
+					// If no exact title match, ask the agent for root-cause matching.
+					if issueNum == 0 {
+						// Use the check run output for matching, falling back to the
+						// agent's explanation when the output is empty/short.
+						matchOutput := task.failures[0].Output
+						if len(strings.TrimSpace(matchOutput)) < 50 {
+							matchOutput = explanation
+						}
+						matchPrompt := buildFlakyMatchPrompt(task.failures[0].Name, matchOutput, existingIssues)
+						matchResult, matchErr := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, matchPrompt, a.logger, false)
+						if matchErr != nil {
+							a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
+						} else {
 						matchResponse := strings.TrimSpace(matchResult.Result)
 						if matchedNum, ok := parseFlakyMatch(matchResponse); ok {
-							issueNum = matchedNum
-							a.logger.Info("agent matched existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
-							if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-								fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, a.botComment())); err != nil {
-								a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
+							for _, existing := range existingIssues {
+								if existing.Number == matchedNum {
+									issueNum = matchedNum
+									break
+								}
 							}
-							return
+							if issueNum > 0 {
+								a.logger.Info("agent matched existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
+							} else {
+								a.logger.Warn("agent returned MATCH for unknown issue", "matched_issue", matchedNum, "check", task.failures[0].Name)
+							}
 						}
+						}
+					}
+
+					if issueNum > 0 {
+						if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+							fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, a.botComment())); err != nil {
+							a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
+						}
+						return
 					}
 				}
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -925,7 +925,8 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
 		},
 		searchResults: []Issue{
-			{Number: 50, Title: "Flaky CI: integration-tests", Labels: []string{"flaky-test"}},
+			// Title does NOT match exactly — use a different title to exercise LLM path
+			{Number: 50, Title: "Flaky CI: db-integration", Labels: []string{"flaky-test"}},
 		},
 	}
 	runner := &mockCommandRunner{claudeResults: [][]byte{ciResult, matchResult}}
@@ -957,6 +958,61 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 	// Verify the duplicate reference comment
 	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #50") {
 		t.Errorf("expected duplicate reference comment, got: %q", gh.addedComments[1])
+	}
+}
+
+func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
+	// When an existing issue has an exact title match ("Flaky CI: <check-name>"),
+	// the agent should skip LLM matching entirely and use the existing issue.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The Fedora koji server returned 502 Bad Gateway"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "Build-PR", Status: "completed", Conclusion: "failure", Output: "Error: 502 Bad Gateway from koji.fedoraproject.org"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Building package...\nFetching from koji.fedoraproject.org...\nHTTP 502 Bad Gateway\nBuild failed",
+		},
+		searchResults: []Issue{
+			{Number: 99, Title: "Flaky CI: Build-PR", Body: "koji infrastructure failure", Labels: []string{"flaky-test"}},
+		},
+	}
+	// Only one Claude result needed (for CI investigation). No match result needed
+	// because the title pre-check should prevent the LLM matching call.
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should NOT have created a new issue
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues (title pre-check should match), got %d", len(gh.createdIssues))
+	}
+
+	// Only 1 claude call (CI investigation), NOT 2 (CI + matching)
+	claudeCalls := countClaudeCalls(runner.calls)
+	if claudeCalls != 1 {
+		t.Errorf("expected 1 claude call (CI investigation only, no LLM matching), got %d", claudeCalls)
+	}
+
+	// Should have 2 comments: unrelated notice + duplicate reference
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+	}
+
+	// Verify the duplicate reference points to issue #99
+	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #99") {
+		t.Errorf("expected duplicate reference to issue #99, got: %q", gh.addedComments[1])
 	}
 }
 

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -405,8 +405,14 @@ Existing open issues:
 
 	prompt.WriteString(`
 Instructions:
-- Compare the failing check name and output against each existing issue
-- A match means the same test or same root cause, even if titles differ
+- Compare the failing check against each existing issue by ROOT CAUSE, not error message
+- A match means the same underlying problem, even with different error messages. Examples:
+  * Different HTTP errors from the same server (502, 503, ConnectionReset) = same cause
+  * Same test name failing with different timing or assertion = same cause
+  * Same CI job failing at the same build step = same cause
+  * Different tests failing due to the same infrastructure outage = same cause
+- Focus on: Which component/service failed? Which CI step? Which test area?
+- Do NOT require exact error message matches
 - If you find a match, respond with ONLY: MATCH <issue-number>
 - If no issue matches, respond with ONLY: NONE
 - Do NOT modify any files or run any commands`)

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -351,3 +351,34 @@ func TestBuildPeriodicCITriagePrompt(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildFlakyMatchPrompt_RootCauseInstructions(t *testing.T) {
+	existingIssues := []Issue{
+		{Number: 50, Title: "Flaky CI: Build-PR", Body: "koji 502 error"},
+	}
+
+	prompt := buildFlakyMatchPrompt("Build-PR", "HTTP 503 from koji.fedoraproject.org", existingIssues)
+
+	checks := []string{
+		"Build-PR",
+		"HTTP 503 from koji.fedoraproject.org",
+		"Issue #50",
+		"Flaky CI: Build-PR",
+		// Root-cause matching instructions
+		"ROOT CAUSE",
+		"not error message",
+		"same underlying problem",
+		"Different HTTP errors from the same server",
+		"same cause",
+		"Which component/service failed",
+		"Do NOT require exact error message matches",
+		"MATCH",
+		"NONE",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #112

## Summary

Improve flaky CI issue deduplication by adding a fast title-based
pre-check and updating the LLM matching prompt to focus on root cause
rather than exact error messages.

## Changes

- Add exact title pre-check in `ProcessCIFailures` before LLM matching:
  when an existing issue has the title "Flaky CI: <check-name>", skip
  the agent call entirely and reference the existing issue
- Update `buildFlakyMatchPrompt` instructions to focus on root-cause
  matching (e.g., different HTTP errors from the same server are the
  same cause)
- Add `TestProcessCIFailures_TitlePreCheckSkipsLLMMatching` test
- Add `TestBuildFlakyMatchPrompt_RootCauseInstructions` test
- Update existing `TestProcessCIFailures_SkipsDuplicateFlakyIssue` to
  exercise the LLM path (different title) rather than the title match

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #112

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate flaky CI issue detection with direct title matching before AI analysis
  * Enhanced issue matching to compare by underlying root cause rather than exact error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->