### PR TITLE
feat: add --triage-lookback flag to triage all failed CI runs within a time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ When using GitHub App auth, the agent pushes branches directly to the upstream r
 | `--create-flaky-issues` | `OOMPA_CREATE_FLAKY_ISSUES` | `false` | Create issues for unrelated CI failures (opt-in) |
 | `--flaky-label` | `OOMPA_FLAKY_LABEL` | `flaky-test` | Label to apply to flaky CI issues |
 | `--triage-jobs` | `OOMPA_TRIAGE_JOBS` | — | Comma-separated CI job URLs to monitor for periodic job triage |
+| `--triage-lookback` | `OOMPA_TRIAGE_LOOKBACK` | `0` (latest only) | Time window to check for failed triage runs (e.g. `24h`, `12h`) |
 | `--max-workers` | `OOMPA_MAX_WORKERS` | `1` | Maximum parallel agent invocations |
 | `--exit-on-new-version` | `OOMPA_EXIT_ON_NEW_VERSION` | — | Exit when a new release is available (`owner/repo`) |
 | `--dry-run` | — | `false` | Log actions without executing them |

--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -59,6 +59,17 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion string) {
 
 	var triageJobs string
 	flag.StringVar(&triageJobs, "triage-jobs", os.Getenv("OOMPA_TRIAGE_JOBS"), "Comma-separated CI job URLs to monitor for periodic job triage")
+	triageLookback := time.Duration(0)
+	if raw := os.Getenv("OOMPA_TRIAGE_LOOKBACK"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid OOMPA_TRIAGE_LOOKBACK %q: %v\n", raw, err)
+			os.Exit(1)
+		}
+		triageLookback = d
+	}
+	flag.DurationVar(&cfg.TriageLookback, "triage-lookback", triageLookback,
+		"Time window to check for failed triage runs (e.g. 24h, 12h)")
 
 	var logFile string
 	flag.StringVar(&logFile, "log-file", os.Getenv("OOMPA_LOG_FILE"), "Log file path (default: stderr)")

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -28,7 +28,8 @@ type Config struct {
 	FlakyLabel        string   // label applied to flaky CI issues (default: "flaky-test")
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
-	TriageJobs        []string // CI job URLs to monitor for periodic job triage
+	TriageJobs        []string       // CI job URLs to monitor for periodic job triage
+	TriageLookback    time.Duration  // time window to check for failed triage runs (0 = latest only)
 	Agent             string   // coding agent backend: "claudecode" or "opencode"
 	AgentModel        string   // model override for OpenCode (empty = default)
 	Version           string   // build version (commit SHA) for comment watermarks

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1062,11 +1062,22 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 	a.resolveConflictsParallel(ctx, tasks)
 }
 
+// triageLookbackRunLimit is the maximum number of runs to fetch when scanning a lookback window.
+const triageLookbackRunLimit = 50
+
+// triageRunTask pairs a CI source with a run for parallel investigation.
+type triageRunTask struct {
+	ciSource CIJobSource
+	run      JobRun
+}
+
 // ProcessTriageJobs monitors periodic CI jobs for failures and investigates them.
 func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 	if len(a.cfg.TriageJobs) == 0 {
 		return
 	}
+
+	var tasks []triageRunTask
 
 	for _, jobURL := range a.cfg.TriageJobs {
 		a.logger.Debug("processing triage job", "url", jobURL)
@@ -1078,8 +1089,13 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 			continue
 		}
 
-		// Fetch the latest run(s)
-		runs, err := ciSource.ListRecentRuns(ctx, 5)
+		// Fetch more runs when scanning a time window
+		limit := 5
+		if a.cfg.TriageLookback > 0 {
+			limit = triageLookbackRunLimit
+		}
+
+		runs, err := ciSource.ListRecentRuns(ctx, limit)
 		if err != nil {
 			a.logger.Error("failed to list recent runs", "job", ciSource.JobName(), "error", err)
 			continue
@@ -1090,89 +1106,115 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 			continue
 		}
 
-		// Process the most recent run
-		latestRun := runs[0]
-
-		// Skip if already investigated
-		if a.state.IsRunInvestigated(ciSource.JobName(), latestRun.ID) {
-			a.logger.Debug("run already investigated", "job", ciSource.JobName(), "runID", latestRun.ID)
-			continue
+		// Determine which runs to process
+		var cutoff time.Time
+		if a.cfg.TriageLookback > 0 {
+			cutoff = time.Now().Add(-a.cfg.TriageLookback)
 		}
 
-		// Skip if the run passed
-		if latestRun.Status == "success" {
-			a.logger.Info("run passed, skipping", "job", ciSource.JobName(), "runID", latestRun.ID)
-			a.state.MarkRunInvestigated(ciSource.JobName(), latestRun.ID)
-			continue
+		runsToProcess := runs
+		if cutoff.IsZero() {
+			// Default: only the most recent run
+			runsToProcess = runs[:1]
 		}
 
-		a.logger.Info("investigating failed run", "job", ciSource.JobName(), "runID", latestRun.ID, "status", latestRun.Status)
-
-		// Fetch build log
-		buildLog, err := ciSource.FetchLog(ctx, latestRun.ID)
-		if err != nil {
-			a.logger.Error("failed to fetch build log", "job", ciSource.JobName(), "runID", latestRun.ID, "error", err)
-			continue
-		}
-
-		// Truncate log if too large (keep last 50KB to focus on recent failures)
-		const maxLogSize = 50000
-		if len(buildLog) > maxLogSize {
-			buildLog = "...\n[Log truncated, showing last 50KB]\n...\n\n" + buildLog[len(buildLog)-maxLogSize:]
-		}
-
-		// Create a worktree on the default branch for read-only codebase access
-		branchName := fmt.Sprintf("triage/%s", latestRun.ID)
-
-		// Ensure repo is cloned
-		if err := a.worktrees.EnsureRepoCloned(ctx); err != nil {
-			a.logger.Error("failed to ensure repo cloned", "error", err)
-			continue
-		}
-
-		// Create worktree on default branch
-		worktreePath, err := a.worktrees.CreateWorktree(ctx, branchName)
-		if err != nil {
-			a.logger.Error("failed to create triage worktree", "error", err)
-			continue
-		}
-
-		// Checkout the default branch (CreateWorktree creates a new branch, we want default)
-		a.runner.Run(ctx, worktreePath, "git", "checkout", a.defaultBranch()) //nolint:errcheck // best-effort
-
-		// Build the triage prompt
-		prompt := buildPeriodicCITriagePrompt(ciSource.JobName(), latestRun.ID, buildLog, a.cfg.Owner, a.cfg.Repo)
-
-		// Run agent in the worktree
-		a.logger.Info("running agent for CI triage", "job", ciSource.JobName(), "runID", latestRun.ID)
-		result, err := a.codeAgent.Run(ctx, a.runner, worktreePath, prompt, a.logger, false)
-		if err != nil {
-			a.logger.Error("agent failed during CI triage", "job", ciSource.JobName(), "runID", latestRun.ID, "error", err)
-			_ = a.worktrees.RemoveWorktree(ctx, worktreePath)
-			continue
-		}
-
-		analysis := result.Result
-		a.logger.Info("CI triage analysis complete", "job", ciSource.JobName(), "runID", latestRun.ID)
-		a.logger.Debug("analysis output", "output", analysis)
-
-		// If --create-flaky-issues is set, create a GitHub issue with the analysis
-		if a.cfg.CreateFlakyIssues {
-			a.logger.Info("creating issue for CI failure", "job", ciSource.JobName(), "runID", latestRun.ID)
-
-			// Search for existing issues about this job to avoid duplicates
-			searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open in:title %q", a.cfg.Owner, a.cfg.Repo, ciSource.JobName())
-			existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
-			if err != nil {
-				a.logger.Warn("failed to search for existing issues", "error", err)
+		for _, run := range runsToProcess {
+			// Stop once we hit runs older than the lookback window (runs are sorted descending)
+			if !cutoff.IsZero() && run.Timestamp.Before(cutoff) {
+				break
 			}
 
-			if len(existingIssues) > 0 {
-				a.logger.Info("found existing issue for this job, skipping issue creation", "job", ciSource.JobName(), "issue", existingIssues[0].Number)
-			} else {
-				// Create a new issue
-				title := fmt.Sprintf("CI Failure: %s", ciSource.JobName())
-				body := fmt.Sprintf(`Periodic CI job **%s** failed in run [%s](%s).
+			// Skip if already investigated
+			if a.state.IsRunInvestigated(ciSource.JobName(), run.ID) {
+				a.logger.Debug("run already investigated", "job", ciSource.JobName(), "runID", run.ID)
+				continue
+			}
+
+			// Skip if the run passed (mark as investigated)
+			if run.Status == "success" {
+				a.logger.Info("run passed, skipping", "job", ciSource.JobName(), "runID", run.ID)
+				a.state.MarkRunInvestigated(ciSource.JobName(), run.ID)
+				continue
+			}
+
+			a.logger.Info("investigating failed run", "job", ciSource.JobName(), "runID", run.ID, "status", run.Status)
+			tasks = append(tasks, triageRunTask{ciSource: ciSource, run: run})
+		}
+	}
+
+	// Investigate collected failed runs in parallel
+	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task triageRunTask) {
+		a.investigateTriageRun(ctx, task.ciSource, task.run)
+	})
+}
+
+// investigateTriageRun handles the investigation of a single failed CI run.
+func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, run JobRun) {
+	// Fetch build log
+	buildLog, err := ciSource.FetchLog(ctx, run.ID)
+	if err != nil {
+		a.logger.Error("failed to fetch build log", "job", ciSource.JobName(), "runID", run.ID, "error", err)
+		return
+	}
+
+	// Truncate log if too large (keep last 50KB to focus on recent failures)
+	const maxLogSize = 50000
+	if len(buildLog) > maxLogSize {
+		buildLog = "...\n[Log truncated, showing last 50KB]\n...\n\n" + buildLog[len(buildLog)-maxLogSize:]
+	}
+
+	// Create a worktree on the default branch for read-only codebase access
+	branchName := fmt.Sprintf("triage/%s", run.ID)
+
+	// Ensure repo is cloned
+	if err := a.worktrees.EnsureRepoCloned(ctx); err != nil {
+		a.logger.Error("failed to ensure repo cloned", "error", err)
+		return
+	}
+
+	// Create worktree on default branch
+	worktreePath, err := a.worktrees.CreateWorktree(ctx, branchName)
+	if err != nil {
+		a.logger.Error("failed to create triage worktree", "error", err)
+		return
+	}
+
+	// Checkout the default branch (CreateWorktree creates a new branch, we want default)
+	a.runner.Run(ctx, worktreePath, "git", "checkout", a.defaultBranch()) //nolint:errcheck // best-effort
+
+	// Build the triage prompt
+	prompt := buildPeriodicCITriagePrompt(ciSource.JobName(), run.ID, buildLog, a.cfg.Owner, a.cfg.Repo)
+
+	// Run agent in the worktree
+	a.logger.Info("running agent for CI triage", "job", ciSource.JobName(), "runID", run.ID)
+	result, err := a.codeAgent.Run(ctx, a.runner, worktreePath, prompt, a.logger, false)
+	if err != nil {
+		a.logger.Error("agent failed during CI triage", "job", ciSource.JobName(), "runID", run.ID, "error", err)
+		_ = a.worktrees.RemoveWorktree(ctx, worktreePath)
+		return
+	}
+
+	analysis := result.Result
+	a.logger.Info("CI triage analysis complete", "job", ciSource.JobName(), "runID", run.ID)
+	a.logger.Debug("analysis output", "output", analysis)
+
+	// If --create-flaky-issues is set, create a GitHub issue with the analysis
+	if a.cfg.CreateFlakyIssues {
+		a.logger.Info("creating issue for CI failure", "job", ciSource.JobName(), "runID", run.ID)
+
+		// Search for existing issues about this job to avoid duplicates
+		searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open in:title %q", a.cfg.Owner, a.cfg.Repo, ciSource.JobName())
+		existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
+		if err != nil {
+			a.logger.Warn("failed to search for existing issues", "error", err)
+		}
+
+		if len(existingIssues) > 0 {
+			a.logger.Info("found existing issue for this job, skipping issue creation", "job", ciSource.JobName(), "issue", existingIssues[0].Number)
+		} else {
+			// Create a new issue
+			title := fmt.Sprintf("CI Failure: %s", ciSource.JobName())
+			body := fmt.Sprintf(`Periodic CI job **%s** failed in run [%s](%s).
 
 ## Analysis
 
@@ -1180,24 +1222,23 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 
 ---
 *This issue was automatically created by oompa based on CI failure analysis.*
-<!-- oompa-triage -->`, ciSource.JobName(), latestRun.ID, latestRun.LogURL, analysis)
+<!-- oompa-triage -->`, ciSource.JobName(), run.ID, run.LogURL, analysis)
 
-				issueNumber, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, title, body, []string{a.cfg.FlakyLabel})
-				if err != nil {
-					a.logger.Error("failed to create issue", "error", err)
-				} else {
-					a.logger.Info("created issue for CI failure", "job", ciSource.JobName(), "issue", issueNumber)
-				}
+			issueNumber, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, title, body, []string{a.cfg.FlakyLabel})
+			if err != nil {
+				a.logger.Error("failed to create issue", "error", err)
+			} else {
+				a.logger.Info("created issue for CI failure", "job", ciSource.JobName(), "issue", issueNumber)
 			}
 		}
+	}
 
-		// Mark the run as investigated
-		a.state.MarkRunInvestigated(ciSource.JobName(), latestRun.ID)
+	// Mark the run as investigated
+	a.state.MarkRunInvestigated(ciSource.JobName(), run.ID)
 
-		// Clean up the triage worktree
-		if err := a.worktrees.RemoveWorktree(ctx, worktreePath); err != nil {
-			a.logger.Warn("failed to remove triage worktree", "path", worktreePath, "error", err)
-		}
+	// Clean up the triage worktree
+	if err := a.worktrees.RemoveWorktree(ctx, worktreePath); err != nil {
+		a.logger.Warn("failed to remove triage worktree", "path", worktreePath, "error", err)
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1800,45 +1800,71 @@ func TestProcessTriageJobs_NoJobsConfigured(t *testing.T) {
 }
 
 func TestProcessTriageJobs_SkipsAlreadyInvestigated(t *testing.T) {
-	gh := &mockGitHubClient{}
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 100, Status: "completed", Conclusion: "failure", CreatedAt: time.Now()},
+		},
+	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
 	state := NewState()
 
-	// Mark run as already investigated
-	state.MarkRunInvestigated("periodic-knmstate-e2e-handler-k8s-latest", "1234567890")
+	// Pre-mark run as already investigated
+	state.MarkRunInvestigated("owner/repo/ci.yml", "100")
 
 	cfg := Config{
-		Owner:      "nmstate",
-		Repo:       "kubernetes-nmstate",
-		TriageJobs: []string{"https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-latest/"},
+		Owner:      "owner",
+		Repo:       "repo",
+		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
 	}
 
-	NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a.ProcessTriageJobs(context.Background())
 
-	// Note: This test would need a real HTTP server to mock GCS API responses
-	// For now, we test the state checking logic directly
-	if !state.IsRunInvestigated("periodic-knmstate-e2e-handler-k8s-latest", "1234567890") {
-		t.Error("expected run to be marked as investigated")
+	// Should still be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+		t.Error("expected run to remain marked as investigated")
+	}
+	// Should not create any worktrees (no investigation triggered)
+	if len(wtm.createdBranches) > 0 {
+		t.Errorf("expected no worktrees created for already-investigated run, got %d", len(wtm.createdBranches))
+	}
+	// Should not have created any issues
+	if len(gh.createdIssues) > 0 {
+		t.Errorf("expected no issues created, got %d", len(gh.createdIssues))
 	}
 }
 
 func TestProcessTriageJobs_SkipsSuccessfulRuns(t *testing.T) {
-	// This test verifies the logic in ProcessTriageJobs that skips successful runs
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 200, Status: "completed", Conclusion: "success", CreatedAt: time.Now()},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
 	state := NewState()
 
-	// Simulate a successful run
-	jobName := "test-job"
-	runID := "success-run"
-	status := "success"
-
-	// The agent should mark successful runs as investigated without creating issues
-	if status == "success" {
-		state.MarkRunInvestigated(jobName, runID)
+	cfg := Config{
+		Owner:      "owner",
+		Repo:       "repo",
+		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
 	}
 
-	if !state.IsRunInvestigated(jobName, runID) {
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a.ProcessTriageJobs(context.Background())
+
+	// Successful run should be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected successful run to be marked as investigated")
+	}
+	// Should not create any worktrees (no investigation needed for success)
+	if len(wtm.createdBranches) > 0 {
+		t.Errorf("expected no worktrees created for successful run, got %d", len(wtm.createdBranches))
+	}
+	// Should not have created any issues
+	if len(gh.createdIssues) > 0 {
+		t.Errorf("expected no issues created, got %d", len(gh.createdIssues))
 	}
 }
 
@@ -1892,6 +1918,190 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 
 	if len(issue.Labels) != 1 || issue.Labels[0] != "ci-flake" {
 		t.Errorf("expected label 'ci-flake', got %v", issue.Labels)
+	}
+}
+
+func TestProcessTriageJobs_DefaultOnlyChecksLatest(t *testing.T) {
+	// When TriageLookback is not set (zero), only the most recent run is checked.
+	triageResult := streamResultJSON(AgentResult{Result: "Root cause: network timeout"})
+	now := time.Now()
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 300, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/300"},
+			{ID: 200, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-2 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/200"},
+			{ID: 100, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-3 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/100"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: triageResult}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+	cfg := Config{
+		Owner:      "owner",
+		Repo:       "repo",
+		FlakyLabel: "flaky-test",
+		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
+		// TriageLookback: 0 (default — only check latest)
+	}
+
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "Root cause: network timeout"}},
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Should only investigate 1 run (the latest)
+	if codeAgent.callCount != 1 {
+		t.Errorf("expected 1 agent call (latest run only), got %d", codeAgent.callCount)
+	}
+
+	// Only the latest run should be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+		t.Error("expected run 300 to be marked as investigated")
+	}
+	if state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+		t.Error("expected run 200 to NOT be marked as investigated")
+	}
+	if state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+		t.Error("expected run 100 to NOT be marked as investigated")
+	}
+}
+
+func TestProcessTriageJobs_LookbackInvestigatesAllFailedRuns(t *testing.T) {
+	// When TriageLookback is set, all failed runs within the window are investigated.
+	now := time.Now()
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 300, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/300"},
+			{ID: 200, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-2 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/200"},
+			{ID: 100, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-25 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/100"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+	cfg := Config{
+		Owner:          "owner",
+		Repo:           "repo",
+		FlakyLabel:     "flaky-test",
+		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
+		TriageLookback: 24 * time.Hour, // look back 24 hours
+	}
+
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "Failure analysis 1"}},
+			{result: AgentResult{Result: "Failure analysis 2"}},
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Should investigate 2 runs (300 and 200 are within 24h; 100 is older)
+	if codeAgent.callCount != 2 {
+		t.Errorf("expected 2 agent calls (runs within lookback window), got %d", codeAgent.callCount)
+	}
+
+	// Runs within window should be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+		t.Error("expected run 300 to be marked as investigated")
+	}
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+		t.Error("expected run 200 to be marked as investigated")
+	}
+	// Run older than lookback should NOT be investigated
+	if state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+		t.Error("expected run 100 to NOT be marked as investigated (too old)")
+	}
+}
+
+func TestProcessTriageJobs_LookbackSkipsSuccessfulRuns(t *testing.T) {
+	// Successful runs within the lookback window should be marked as investigated
+	// but not trigger agent calls.
+	now := time.Now()
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 300, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/300"},
+			{ID: 200, Status: "completed", Conclusion: "success", CreatedAt: now.Add(-2 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/200"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+	cfg := Config{
+		Owner:          "owner",
+		Repo:           "repo",
+		FlakyLabel:     "flaky-test",
+		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
+		TriageLookback: 24 * time.Hour,
+	}
+
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "Failure analysis"}},
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Only 1 agent call for the failed run
+	if codeAgent.callCount != 1 {
+		t.Errorf("expected 1 agent call (only failed runs), got %d", codeAgent.callCount)
+	}
+
+	// Both runs should be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+		t.Error("expected failed run 300 to be marked as investigated")
+	}
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+		t.Error("expected passed run 200 to be marked as investigated")
+	}
+}
+
+func TestProcessTriageJobs_LookbackSkipsAlreadyInvestigated(t *testing.T) {
+	// Already-investigated runs should be skipped in lookback mode.
+	now := time.Now()
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 300, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/300"},
+			{ID: 200, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-2 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/200"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+
+	// Pre-mark run 200 as already investigated
+	state.MarkRunInvestigated("owner/repo/ci.yml", "200")
+
+	cfg := Config{
+		Owner:          "owner",
+		Repo:           "repo",
+		FlakyLabel:     "flaky-test",
+		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
+		TriageLookback: 24 * time.Hour,
+	}
+
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "Failure analysis"}},
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Only 1 agent call (run 200 was already investigated)
+	if codeAgent.callCount != 1 {
+		t.Errorf("expected 1 agent call (skip already investigated), got %d", codeAgent.callCount)
+	}
+
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+		t.Error("expected run 300 to be marked as investigated")
 	}
 }
 


### PR DESCRIPTION
Fixes #114

## Summary

Add `--triage-lookback` flag that allows triaging all failed CI runs within a configurable time window, instead of only checking the most recent run.

## Changes

- Add `TriageLookback time.Duration` to `Config` struct in `pkg/agent/config.go`
- Add `--triage-lookback` flag (env: `OOMPA_TRIAGE_LOOKBACK`) in `cmd/oompa/main.go`
- Refactor `ProcessTriageJobs` in `pkg/agent/loop.go` to iterate over all runs within the lookback window when set, preserving default behavior (latest only) when not set
- Extract `investigateTriageRun` helper method to reduce nesting
- Add 4 new tests covering default mode, lookback mode, success skipping, and already-investigated skipping
- Update README flags table with the new flag

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #114

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--triage-lookback` CLI flag and `OOMPA_TRIAGE_LOOKBACK` environment variable to specify a time window for evaluating failed runs. Defaults to checking only the latest failure; configure with a duration value to include all failures within that timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->