### PR TITLE
feat: add INFRASTRUCTURE classification to CI fix to skip flaky issue creation

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -689,14 +689,19 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		// Strip markdown formatting (bold, italic) before checking prefix
 		cleaned := strings.TrimLeft(strings.TrimSpace(result.Result), "*_")
 
-		// Check if the response contains UNRELATED or RELATED.
+		// Check if the response contains UNRELATED, INFRASTRUCTURE, or RELATED.
 		// The agent sometimes puts preamble text before the keyword (e.g.
 		// "Same infrastructure failure.\n\nUNRELATED — ..."), so scan the
 		// first few lines instead of requiring it as the very first word.
 		startsWithUnrelated := false
 		startsWithRelated := false
+		startsWithInfra := false
 		for _, line := range strings.SplitN(cleaned, "\n", 5) {
 			trimmed := strings.TrimLeft(strings.TrimSpace(line), "*_")
+			if strings.HasPrefix(trimmed, "INFRASTRUCTURE") {
+				startsWithInfra = true
+				break
+			}
 			if strings.HasPrefix(trimmed, "UNRELATED") {
 				startsWithUnrelated = true
 				break
@@ -707,8 +712,8 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			}
 		}
 
-		if !startsWithUnrelated && !startsWithRelated {
-			a.logger.Warn("agent response did not contain UNRELATED or RELATED in first 5 lines, skipping to avoid noise",
+		if !startsWithUnrelated && !startsWithRelated && !startsWithInfra {
+			a.logger.Warn("agent response did not contain UNRELATED, INFRASTRUCTURE, or RELATED in first 5 lines, skipping to avoid noise",
 				"pr", task.work.PRNumber,
 				"response_preview", truncateString(cleaned, 200))
 			task.work.CIFixAttempts++
@@ -717,15 +722,43 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			return
 		}
 
+		if startsWithInfra {
+			a.logger.Info("CI failure is an infrastructure issue", "pr", task.work.PRNumber)
+			// Extract explanation: everything after INFRASTRUCTURE in the full response,
+			// stripping any separator characters (e.g. "INFRASTRUCTURE: ..." or "INFRASTRUCTURE — ...").
+			idx := strings.Index(cleaned, "INFRASTRUCTURE")
+			explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "INFRASTRUCTURE"), " :—–-"))
+			comment := fmt.Sprintf("CI check `%s` failed on commit %s due to an infrastructure issue (not a flaky test).", task.failures[0].Name, shortSHA(task.headSHA))
+			if explanation != "" {
+				comment += "\n\n" + explanation
+			}
+			comment += "\n\n" + ciMarker(task.headSHA, task.failures[0].Name)
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
+				a.logger.Error("failed to post CI infrastructure comment", "pr", task.work.PRNumber, "error", err)
+				task.work.LastCIStatus = "investigation-inconclusive"
+				return
+			}
+			task.work.LastCIStatus = "infrastructure-failure"
+			task.work.LastCheckedCISHA = task.headSHA
+			// Do NOT create a flaky issue — infrastructure failures are transient
+			return
+		}
+
 		if startsWithUnrelated {
 			a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
-			// Extract explanation: everything after UNRELATED in the full response
+			// Extract explanation: everything after UNRELATED in the full response,
+			// stripping any separator characters (e.g. "UNRELATED: ..." or "UNRELATED — ...").
 			idx := strings.Index(cleaned, "UNRELATED")
-			explanation := strings.TrimPrefix(cleaned[idx:], "UNRELATED")
-			explanation = strings.TrimSpace(explanation)
-			comment := fmt.Sprintf("CI check `%s` failed on commit %s but appears unrelated to this PR's changes.\n\n%s\n\n%s", task.failures[0].Name, shortSHA(task.headSHA), explanation, ciMarker(task.headSHA, task.failures[0].Name))
+			explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "UNRELATED"), " :—–-"))
+			comment := fmt.Sprintf("CI check `%s` failed on commit %s but appears unrelated to this PR's changes.", task.failures[0].Name, shortSHA(task.headSHA))
+			if explanation != "" {
+				comment += "\n\n" + explanation
+			}
+			comment += "\n\n" + ciMarker(task.headSHA, task.failures[0].Name)
 			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
 				a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
+				task.work.LastCIStatus = "investigation-inconclusive"
+				return
 			}
 			task.work.LastCIStatus = "unrelated-failure"
 			task.work.LastCheckedCISHA = task.headSHA

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -877,6 +877,60 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_InfrastructureSkipsFlakyIssue(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "INFRASTRUCTURE Fedora koji server returned HTTP 502 Bad Gateway"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "Build-PR", Status: "completed", Conclusion: "failure", Output: "HTTP 502 Bad Gateway from koji.fedoraproject.org"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Building package...\nFetching from koji.fedoraproject.org...\nHTTP 502 Bad Gateway\nBuild failed",
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = true // Even with flaky issues enabled, INFRASTRUCTURE should skip
+	agent.state.ActiveIssues[42] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Check that NO flaky issue was created (infrastructure != flaky)
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues for INFRASTRUCTURE classification, got %d", len(gh.createdIssues))
+	}
+
+	// Check that exactly 1 comment was posted (the infrastructure notice)
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment (infrastructure notice), got %d", len(gh.addedComments))
+	}
+
+	// Verify the comment mentions infrastructure
+	if !strings.Contains(gh.addedComments[0], "infrastructure issue") {
+		t.Errorf("expected comment to mention infrastructure issue, got: %q", gh.addedComments[0])
+	}
+	if !strings.Contains(gh.addedComments[0], "Build-PR") {
+		t.Errorf("expected comment to mention the check name, got: %q", gh.addedComments[0])
+	}
+
+	// Verify state was updated correctly
+	work := agent.state.ActiveIssues[42]
+	if work.LastCIStatus != "infrastructure-failure" {
+		t.Errorf("expected LastCIStatus 'infrastructure-failure', got %q", work.LastCIStatus)
+	}
+	if work.CIFixAttempts != 0 {
+		t.Errorf("expected 0 CI fix attempts for infrastructure failure, got %d", work.CIFixAttempts)
+	}
+}
+
 func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED The test database connection times out intermittently"})
 	gh := &mockGitHubClient{

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -247,20 +247,31 @@ Instructions:
        missing changelog entry, label-based checks) — these should be fixed by adding the
        required files or content, NOT by removing labels or bypassing the check
    - A failure is UNRELATED if:
-     * It is a flaky test or intermittent infrastructure failure (e.g. timeouts, network errors, resource limits)
+     * It is a flaky test that fails intermittently due to timing, race conditions, or test logic issues
      * It is an e2e/integration test failure and the PR only changes build files, docs, Makefiles, or configs
      * The failing test does not test any code path modified by this PR
      * The error message references components, services, or files not touched by this PR
+   - A failure is INFRASTRUCTURE if:
+     * It is a transient environment or infrastructure issue (e.g. HTTP 502/503, network timeout,
+       DNS failure, disk full, OOM kill, package mirror outage, GitHub Actions runner crash,
+       Docker registry unavailable, CDN outage)
+     * These are NOT flaky tests — they are temporary outages that resolve themselves
    - When in doubt, say UNRELATED — it is better to skip a fixable failure than to waste time on an unfixable one
 
-3. If UNRELATED:
+3. If UNRELATED (flaky test, not infrastructure):
    - Do NOT attempt to fix it, do NOT modify any files
    - Your output MUST start with the word UNRELATED followed by a brief explanation
    - IMPORTANT: Do NOT mention the PR changes, the PR number, or what the PR modifies in your explanation.
-     Focus ONLY on describing the failure itself: what test failed, what the error was, and why it looks flaky or infrastructure-related.
+     Focus ONLY on describing the failure itself: what test failed, what the error was, and why it looks flaky.
      The explanation will be used to create a standalone flaky test issue, so it must make sense without any PR context.
 
-4. If RELATED, fix with verification:
+4. If INFRASTRUCTURE (transient environment issue):
+   - Do NOT attempt to fix it, do NOT modify any files
+   - Your output MUST start with the word INFRASTRUCTURE followed by a brief explanation
+   - IMPORTANT: Do NOT mention the PR changes, the PR number, or what the PR modifies in your explanation.
+     Focus ONLY on describing the infrastructure failure: what service/system was unavailable, what the error was.
+
+5. If RELATED, fix with verification:
    - Prefer minimal, targeted fixes over broad refactoring — do not change more code than
      necessary. Fixing a CI failure does NOT mean also renaming variables, adding docstrings,
      or refactoring adjacent code. Touch only what caused the failure.
@@ -302,7 +313,7 @@ Instructions:
 	prompt.WriteString(`
 Do NOT push or rebase — the agent handles that automatically.
 
-REMINDER: Your FINAL text output MUST start with either UNRELATED or RELATED.
+REMINDER: Your FINAL text output MUST start with either UNRELATED, INFRASTRUCTURE, or RELATED.
 This is how the automation determines what to do next. Any other format will
 cause your work to be discarded.`)
 

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -270,6 +270,7 @@ func TestBuildCIFixPrompt(t *testing.T) {
 		"handler.go",
 		"UNRELATED",
 		"RELATED",
+		"INFRASTRUCTURE",
 		"Do NOT push",
 		// Investigation and evaluation criteria
 		"INVESTIGATE the failure systematically",
@@ -279,6 +280,10 @@ func TestBuildCIFixPrompt(t *testing.T) {
 		"confirm the new behavior is correct",
 		"minimal, targeted fixes",
 		"maximum 3 attempts",
+		// INFRASTRUCTURE classification criteria
+		"transient environment or infrastructure issue",
+		"HTTP 502/503",
+		"temporary outages that resolve themselves",
 	}
 
 	for _, want := range checks {


### PR DESCRIPTION
Fixes #116

## Summary

Add INFRASTRUCTURE as a third CI failure classification so that
transient environment issues (HTTP 502/503, network timeouts, disk
full, runner crashes, CDN outages) get a PR comment but do NOT
trigger flaky test issue creation.

## Changes

- Updated `buildCIFixPrompt` in `pkg/agent/prompt.go` to include
  INFRASTRUCTURE as a classification option alongside RELATED and
  UNRELATED, with criteria for identifying infrastructure failures
- Updated the response parser in `pkg/agent/loop.go`
  (`ProcessCIFailures` parallel phase) to detect INFRASTRUCTURE
  in the first 5 lines, post a PR comment mentioning infrastructure
  issue, set `LastCIStatus` to `"infrastructure-failure"`, and skip
  flaky issue creation
- Updated REMINDER text to include INFRASTRUCTURE
- Added `TestProcessCIFailures_InfrastructureSkipsFlakyIssue` in
  `pkg/agent/loop_test.go` to verify INFRASTRUCTURE handling
- Updated `TestBuildCIFixPrompt` in `pkg/agent/prompt_test.go` to
  check for INFRASTRUCTURE-related content in the prompt

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #116

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CI failure triage to distinguish infrastructure/environment outages from flaky tests.
  * Agent now classifies failures as `INFRASTRUCTURE` when services are unavailable.
  * Infrastructure failures post dedicated issue comments instead of creating flaky-issue tracking.

* **Tests**
  * Added validation for infrastructure failure classification and handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->