### PR TITLE
feat: multi-project YAML config file with single-process orchestration

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -103,6 +103,16 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 
 	flag.Parse()
 
+	// Parse --reviewers (needed in both single-repo and config-file mode)
+	if reviewers != "" {
+		for r := range strings.SplitSeq(reviewers, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				cfg.Reviewers = append(cfg.Reviewers, r)
+			}
+		}
+	}
+
 	// In config-file mode, --repo is not required
 	if configPath != "" {
 		cfg.CloneDir = strings.TrimSuffix(cfg.CloneDir, "/")
@@ -165,15 +175,6 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 	}
 
 	cfg.LogFile = logFile
-
-	if reviewers != "" {
-		for r := range strings.SplitSeq(reviewers, ",") {
-			r = strings.TrimSpace(r)
-			if r != "" {
-				cfg.Reviewers = append(cfg.Reviewers, r)
-			}
-		}
-	}
 
 	if watchPRs != "" {
 		for s := range strings.SplitSeq(watchPRs, ",") {
@@ -375,7 +376,7 @@ func setupAuth(cfg *agent.Config, logger *slog.Logger) (ghClient *agent.GoGitHub
 		}
 		if token == "" {
 			logger.Error("GITHUB_TOKEN is required, or run 'gh auth login' (or configure GitHub App auth with --github-app-id, --github-app-private-key/GITHUB_APP_PRIVATE_KEY, --github-app-installation-id)")
-			os.Exit(1)
+			os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional early exit in CLI startup
 		}
 		cfg.GitHubToken = token
 		os.Setenv("GH_TOKEN", token)
@@ -584,7 +585,7 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 
 	if len(entries) == 0 {
 		logger.Error("no role entries generated from config file")
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional early exit in CLI startup
 	}
 
 	logger.Info("starting oompa (multi-project mode)",

--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -12,6 +12,8 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/qinqon/oompa/pkg/agent"
@@ -24,17 +26,10 @@ func envOrDefault(key, def string) string {
 	return def
 }
 
-func parseIntEnv(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
-	}
-	return def
-}
-
-func parseConfig() (cfg agent.Config, exitOnNewVersion string) {
+func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 	cfg = agent.Config{}
+
+	flag.StringVar(&configPath, "config", envOrDefault("OOMPA_CONFIG", ""), "Path to YAML config file for multi-project mode")
 
 	var repoFlag string
 	flag.StringVar(&repoFlag, "repo", envOrDefault("OOMPA_REPO", ""), "GitHub repo as owner/repo (e.g. ovn-kubernetes/ovn-kubernetes)")
@@ -81,7 +76,6 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion string) {
 	flag.BoolVar(&cfg.CreateFlakyIssues, "create-flaky-issues", envOrDefault("OOMPA_CREATE_FLAKY_ISSUES", "") == "true", "Create issues for unrelated CI failures (opt-in)")
 	flag.StringVar(&cfg.FlakyLabel, "flaky-label", envOrDefault("OOMPA_FLAKY_LABEL", "flaky-test"), "Label to apply to flaky CI issues")
 	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("OOMPA_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
-	flag.IntVar(&cfg.MaxWorkers, "max-workers", parseIntEnv("OOMPA_MAX_WORKERS", 1), "Maximum parallel Claude invocations (default 1 = sequential)")
 
 	var forkFlag string
 	flag.StringVar(&forkFlag, "fork", envOrDefault("OOMPA_FORK", ""), "Fork repo as owner/repo for pushing (e.g. qinqon/ovn-kubernetes)")
@@ -109,9 +103,28 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion string) {
 
 	flag.Parse()
 
-	// Parse --repo owner/repo
+	// In config-file mode, --repo is not required
+	if configPath != "" {
+		cfg.CloneDir = strings.TrimSuffix(cfg.CloneDir, "/")
+		cfg.LogFile = logFile
+		cfg.GitHubAppID = ghAppID
+		cfg.GitHubAppInstallationID = ghAppInstallationID
+		if key := os.Getenv("GITHUB_APP_PRIVATE_KEY"); key != "" {
+			cfg.GitHubAppPrivateKey = []byte(key)
+		} else if ghAppPrivateKeyPath != "" {
+			keyBytes, err := os.ReadFile(ghAppPrivateKeyPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to read private key file %s: %v\n", ghAppPrivateKeyPath, err)
+				os.Exit(1)
+			}
+			cfg.GitHubAppPrivateKey = keyBytes
+		}
+		return cfg, exitOnNewVersion, configPath
+	}
+
+	// Single-repo mode: --repo is required
 	if repoFlag == "" {
-		fmt.Fprintln(os.Stderr, "--repo is required (format: owner/repo)")
+		fmt.Fprintln(os.Stderr, "--repo is required (format: owner/repo) or use --config for multi-project mode")
 		os.Exit(1)
 	}
 	if parts := strings.SplitN(repoFlag, "/", 2); len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -224,7 +237,7 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion string) {
 		}
 	}
 
-	return cfg, exitOnNewVersion //nolint:nakedret // named results used for gocritic
+	return cfg, exitOnNewVersion, "" //nolint:nakedret // named results used for gocritic
 }
 
 func parseDuration(s string) time.Duration {
@@ -292,46 +305,30 @@ func shouldExitForNewVersion(ctx context.Context, ghClient *agent.GoGitHubClient
 	return false
 }
 
-func main() {
-	cfg, exitOnNewVersion := parseConfig()
-
-	// Validate agent backend
-	if cfg.Agent != "claudecode" && cfg.Agent != "opencode" {
-		fmt.Fprintf(os.Stderr, "invalid --agent %q: must be claudecode or opencode\n", cfg.Agent)
-		os.Exit(1)
+// setupGCPCredentials writes inline GCP credentials to a temp file if provided.
+func setupGCPCredentials(logger *slog.Logger) func() {
+	gcpJSON := os.Getenv("GCP_CREDENTIALS_JSON")
+	if gcpJSON == "" {
+		return func() {}
 	}
-
-	// Validate --agent-model is only used with opencode
-	if cfg.AgentModel != "" && cfg.Agent != "opencode" {
-		fmt.Fprintln(os.Stderr, "--agent-model can only be used with --agent opencode")
-		os.Exit(1)
+	f, err := os.CreateTemp("", "gcp-credentials-*.json")
+	if err != nil {
+		logger.Error("failed to create temp file for GCP credentials", "error", err)
+		os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional early exit in CLI startup
 	}
-
-	logger, closeLog := setupLogger(cfg.LogLevel, cfg.LogFile)
-	defer closeLog()
-
-	// If GCP credentials JSON is provided inline, write to a temp file
-	// so GOOGLE_APPLICATION_CREDENTIALS can reference it.
-	if gcpJSON := os.Getenv("GCP_CREDENTIALS_JSON"); gcpJSON != "" {
-		f, err := os.CreateTemp("", "gcp-credentials-*.json")
-		if err != nil {
-			logger.Error("failed to create temp file for GCP credentials", "error", err)
-			os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional early exit in CLI startup
-		}
-		defer os.Remove(f.Name())
-		if _, err := f.Write([]byte(gcpJSON)); err != nil {
-			f.Close()
-			logger.Error("failed to write GCP credentials", "error", err)
-			os.Exit(1)
-		}
+	if _, err := f.Write([]byte(gcpJSON)); err != nil {
 		f.Close()
-		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", f.Name())
+		logger.Error("failed to write GCP credentials", "error", err)
+		os.Exit(1)
 	}
+	f.Close()
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", f.Name())
+	return func() { os.Remove(f.Name()) }
+}
 
-	useAppAuth := cfg.GitHubAppID != 0 && len(cfg.GitHubAppPrivateKey) > 0 && cfg.GitHubAppInstallationID != 0
-
-	var ghClient *agent.GoGitHubClient
-	var tokenFunc func(context.Context) (string, error)
+// setupAuth configures GitHub authentication and returns the client, token func, and updated config.
+func setupAuth(cfg *agent.Config, logger *slog.Logger) (ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool) {
+	useAppAuth = cfg.GitHubAppID != 0 && len(cfg.GitHubAppPrivateKey) > 0 && cfg.GitHubAppInstallationID != 0
 
 	if useAppAuth {
 		appAuth, err := agent.NewGitHubAppAuth(cfg.GitHubAppID, cfg.GitHubAppInstallationID, cfg.GitHubAppPrivateKey)
@@ -354,7 +351,6 @@ func main() {
 			cfg.SignedOffBy = fmt.Sprintf("%s <%s>", appAuth.Name, appAuth.Email)
 		}
 
-		// Get an initial token for GH_TOKEN and git credential helpers
 		token, err := appAuth.TokenFunc(context.Background())
 		if err != nil {
 			logger.Error("failed to get initial installation token", "error", err)
@@ -367,7 +363,6 @@ func main() {
 	} else {
 		token := os.Getenv("GITHUB_TOKEN")
 		if token == "" {
-			// Fallback: get token from gh auth if GITHUB_TOKEN is not set
 			const ghTokenTimeout = 10 * time.Second
 			ctx, cancel := context.WithTimeout(context.Background(), ghTokenTimeout)
 			defer cancel()
@@ -387,7 +382,6 @@ func main() {
 
 		ghClient = agent.NewGoGitHubClient(token)
 		if cfg.GitHubUser != "" && cfg.GitAuthorName != "" && cfg.GitAuthorEmail != "" {
-			// Identity provided via flags/env vars (e.g. GitHub Actions with app installation token)
 			if cfg.ForkOwner != "" {
 				cfg.GitHubHeadOwner = cfg.ForkOwner
 			} else {
@@ -399,7 +393,7 @@ func main() {
 			logger.Info("using provided identity", "login", cfg.GitHubUser, "signed-off-by", cfg.SignedOffBy)
 		} else if login, name, email, err := ghClient.GetAuthenticatedUser(context.Background()); err == nil {
 			cfg.GitHubUser = login
-			cfg.GitHubHeadOwner = login // PAT pushes to user's fork
+			cfg.GitHubHeadOwner = login
 			cfg.GitAuthorName = name
 			cfg.GitAuthorEmail = email
 			if cfg.SignedOffBy == "" {
@@ -412,16 +406,27 @@ func main() {
 		}
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
+	return ghClient, tokenFunc, useAppAuth
+}
 
-	// Build initial state from GitHub
-	logger.Info("rebuilding state from GitHub...")
-	state := agent.BuildStateFromGitHub(ctx, ghClient, cfg, cfg.CloneDir, logger)
-	logger.Info("state rebuilt", "active-issues", len(state.ActiveIssues))
+// selectCodeAgent returns the appropriate CodeAgent implementation.
+func selectCodeAgent(cfg agent.Config, logger *slog.Logger) agent.CodeAgent {
+	switch cfg.Agent {
+	case "claudecode":
+		return &agent.ClaudeCodeAgent{}
+	case "opencode":
+		return &agent.OpenCodeAgent{Model: cfg.AgentModel}
+	default:
+		logger.Error("unsupported agent backend", "agent", cfg.Agent)
+		os.Exit(1)
+		return nil
+	}
+}
 
+// buildAgentForConfig creates a fully wired Agent for a given config.
+func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool, logger *slog.Logger) *agent.Agent {
 	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", cfg.Owner, cfg.Repo)
-	forkURL := repoURL // default: same-repo workflow
+	forkURL := repoURL
 	if cfg.ForkOwner != "" {
 		forkRepoName := cfg.ForkRepo
 		if forkRepoName == "" {
@@ -439,42 +444,39 @@ func main() {
 		wtm.SetGitIdentity(cfg.GitAuthorName, cfg.GitAuthorEmail)
 	}
 
-	// Select the coding agent backend
-	var codeAgent agent.CodeAgent
-	switch cfg.Agent {
-	case "claudecode":
-		codeAgent = &agent.ClaudeCodeAgent{}
-	case "opencode":
-		codeAgent = &agent.OpenCodeAgent{Model: cfg.AgentModel}
-	default:
-		logger.Error("unsupported agent backend", "agent", cfg.Agent)
-		os.Exit(1)
-	}
+	codeAgent := selectCodeAgent(cfg, logger)
 
-	// Wrap the GitHub client for dry-run mode (logs writes instead of executing)
 	var agentGH agent.GitHubClient = ghClient
 	if cfg.DryRun {
 		agentGH = agent.NewDryRunGitHubClient(ghClient, logger)
 	}
 
-	a := agent.NewAgent(
-		agentGH,
-		runner,
-		wtm,
-		state,
-		cfg,
-		logger,
-		codeAgent,
-	)
+	state := agent.BuildStateFromGitHub(context.Background(), ghClient, cfg, cfg.CloneDir, logger)
 
+	a := agent.NewAgent(agentGH, runner, wtm, state, cfg, logger, codeAgent)
 	if tokenFunc != nil {
 		a.SetTokenFunc(tokenFunc)
 	}
 
-	// Parse exit-on-new-version flag and set version for comment watermarks
-	var exitOnNewVersionOwner, exitOnNewVersionRepo string
+	return a
+}
+
+func main() {
+	cfg, exitOnNewVersion, configPath := parseConfig()
+
+	logger, closeLog := setupLogger(cfg.LogLevel, cfg.LogFile)
+	defer closeLog()
+
+	cleanupGCP := setupGCPCredentials(logger)
+	defer cleanupGCP()
+
+	ghClient, tokenFunc, useAppAuth := setupAuth(&cfg, logger)
+
 	commitSHA := getCommitSHA()
 	cfg.Version = commitSHA
+
+	// Parse exit-on-new-version
+	var exitOnNewVersionOwner, exitOnNewVersionRepo string
 	if exitOnNewVersion != "" {
 		if parts := strings.SplitN(exitOnNewVersion, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 			exitOnNewVersionOwner = parts[0]
@@ -490,14 +492,39 @@ func main() {
 		}
 	}
 
-	logger.Info("starting oompa",
+	if configPath != "" {
+		// Multi-project mode
+		runMultiProject(cfg, configPath, ghClient, tokenFunc, useAppAuth, exitOnNewVersionOwner, exitOnNewVersionRepo, commitSHA, logger)
+	} else {
+		// Single-repo mode (backward compatible)
+		runSingleRepo(cfg, ghClient, tokenFunc, useAppAuth, exitOnNewVersionOwner, exitOnNewVersionRepo, commitSHA, logger)
+	}
+}
+
+// runSingleRepo runs the original single-repo mode.
+func runSingleRepo(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool, exitOwner, exitRepo, commitSHA string, logger *slog.Logger) {
+	// Validate agent backend
+	if cfg.Agent != "claudecode" && cfg.Agent != "opencode" {
+		fmt.Fprintf(os.Stderr, "invalid --agent %q: must be claudecode or opencode\n", cfg.Agent)
+		os.Exit(1)
+	}
+	if cfg.AgentModel != "" && cfg.Agent != "opencode" {
+		fmt.Fprintln(os.Stderr, "--agent-model can only be used with --agent opencode")
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	logger.Info("starting oompa (single-repo mode)",
 		"owner", cfg.Owner,
 		"repo", cfg.Repo,
 		"label", cfg.Label,
 		"poll-interval", cfg.PollInterval,
 		"dry-run", cfg.DryRun,
-		"auth-mode", map[bool]string{true: "github-app", false: "pat"}[useAppAuth],
 	)
+
+	a := buildAgentForConfig(cfg, ghClient, tokenFunc, useAppAuth, logger)
 
 	runLoop(ctx, a, logger)
 
@@ -515,9 +542,173 @@ func main() {
 			return
 		case <-ticker.C:
 			runLoop(ctx, a, logger)
-			if exitOnNewVersionOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOnNewVersionOwner, exitOnNewVersionRepo, commitSHA, logger) {
+			if exitOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOwner, exitRepo, commitSHA, logger) {
 				return
 			}
+		}
+	}
+}
+
+// runMultiProject runs the multi-project orchestrator with per-role goroutines.
+func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool, exitOwner, exitRepo, commitSHA string, logger *slog.Logger) {
+	fc, err := agent.LoadFileConfig(configPath)
+	if err != nil {
+		logger.Error("failed to load config file", "path", configPath, "error", err)
+		os.Exit(1)
+	}
+
+	// Apply file-level overrides to global config
+	if fc.LogLevel != "" {
+		globalCfg.LogLevel = fc.LogLevel
+		// Re-create logger with new level
+		var closeLog func()
+		logger, closeLog = setupLogger(globalCfg.LogLevel, globalCfg.LogFile)
+		defer closeLog()
+	}
+
+	// Override exit-on-new-version from file config
+	if fc.ExitOnNewVersion != "" && exitOwner == "" {
+		if parts := strings.SplitN(fc.ExitOnNewVersion, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			exitOwner = parts[0]
+			exitRepo = parts[1]
+			if commitSHA == "" {
+				logger.Warn("exit-on-new-version set but no VCS revision found (dev build), version check disabled")
+			} else {
+				logger.Info("version check enabled", "repo", fc.ExitOnNewVersion, "current-sha", commitSHA)
+			}
+		}
+	}
+
+	baseCloneDir := globalCfg.CloneDir
+	entries := agent.BuildRoleEntries(fc, baseCloneDir, globalCfg)
+
+	if len(entries) == 0 {
+		logger.Error("no role entries generated from config file")
+		os.Exit(1)
+	}
+
+	logger.Info("starting oompa (multi-project mode)",
+		"projects", len(fc.Projects),
+		"goroutines", len(entries),
+		"config", configPath,
+	)
+
+	// Two-signal graceful shutdown:
+	// First signal: cancel context → goroutines finish current cycle → clean exit
+	// Second signal: force exit immediately
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		logger.Info("received signal, initiating graceful shutdown", "signal", sig)
+		cancel()
+
+		sig = <-sigCh
+		logger.Error("received second signal, forcing exit", "signal", sig)
+		os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional force exit
+	}()
+
+	var wg sync.WaitGroup
+
+	for _, entry := range entries {
+		wg.Add(1)
+		roleLogger := agent.NewRoleLogger(logger, entry)
+
+		// Capture for goroutine
+		entry := entry
+
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					roleLogger.Error("panic recovered in role goroutine", "panic", r)
+				}
+			}()
+
+			a := buildAgentForConfig(entry.Config, ghClient, tokenFunc, useAppAuth, roleLogger)
+
+			roleLogger.Info("role goroutine started")
+
+			if entry.Role == "triage" && entry.Schedule != "" {
+				// Triage with scheduling: sleep until next run time
+				runScheduledTriage(ctx, a, entry, roleLogger, ghClient, exitOwner, exitRepo, commitSHA)
+			} else {
+				// Standard poll loop
+				runRoleLoop(ctx, a, entry, roleLogger, ghClient, exitOwner, exitRepo, commitSHA, cancel)
+			}
+
+			roleLogger.Info("role goroutine stopped")
+		}()
+	}
+
+	wg.Wait()
+	logger.Info("all role goroutines stopped, exiting")
+}
+
+// runRoleLoop runs the poll loop for a single role goroutine.
+func runRoleLoop(ctx context.Context, a *agent.Agent, entry agent.RoleEntry, logger *slog.Logger, ghClient *agent.GoGitHubClient, exitOwner, exitRepo, commitSHA string, cancel context.CancelFunc) {
+	runLoop(ctx, a, logger)
+
+	if entry.Config.OneShot {
+		return
+	}
+
+	ticker := time.NewTicker(entry.Config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runLoop(ctx, a, logger)
+			if exitOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOwner, exitRepo, commitSHA, logger) {
+				cancel() // cancel the shared context → all goroutines stop
+				return
+			}
+		}
+	}
+}
+
+// runScheduledTriage runs triage on a schedule instead of a fixed poll interval.
+func runScheduledTriage(ctx context.Context, a *agent.Agent, entry agent.RoleEntry, logger *slog.Logger, ghClient *agent.GoGitHubClient, exitOwner, exitRepo, commitSHA string) {
+	for {
+		next, err := agent.ParseSchedule(entry.Schedule, time.Now())
+		if err != nil {
+			logger.Error("failed to parse schedule, falling back to poll interval", "error", err)
+			// Fall back to standard poll interval
+			timer := time.NewTimer(entry.Config.PollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		} else {
+			sleepDuration := time.Until(next)
+			logger.Info("next triage run scheduled", "next", next.Format(time.RFC3339), "sleep", sleepDuration.Round(time.Second))
+			timer := time.NewTimer(sleepDuration)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+
+		// Run the triage
+		runLoop(ctx, a, logger)
+
+		if entry.Config.OneShot {
+			return
+		}
+
+		// Check for new version after each triage run
+		if exitOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOwner, exitRepo, commitSHA, logger) {
+			return
 		}
 	}
 }

--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -634,7 +634,7 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 
 			if entry.Role == "triage" && entry.Schedule != "" {
 				// Triage with scheduling: sleep until next run time
-				runScheduledTriage(ctx, a, entry, roleLogger, ghClient, exitOwner, exitRepo, commitSHA)
+				runScheduledTriage(ctx, a, entry, roleLogger, ghClient, exitOwner, exitRepo, commitSHA, cancel)
 			} else {
 				// Standard poll loop
 				runRoleLoop(ctx, a, entry, roleLogger, ghClient, exitOwner, exitRepo, commitSHA, cancel)
@@ -674,7 +674,7 @@ func runRoleLoop(ctx context.Context, a *agent.Agent, entry agent.RoleEntry, log
 }
 
 // runScheduledTriage runs triage on a schedule instead of a fixed poll interval.
-func runScheduledTriage(ctx context.Context, a *agent.Agent, entry agent.RoleEntry, logger *slog.Logger, ghClient *agent.GoGitHubClient, exitOwner, exitRepo, commitSHA string) {
+func runScheduledTriage(ctx context.Context, a *agent.Agent, entry agent.RoleEntry, logger *slog.Logger, ghClient *agent.GoGitHubClient, exitOwner, exitRepo, commitSHA string, cancel context.CancelFunc) {
 	for {
 		next, err := agent.ParseSchedule(entry.Schedule, time.Now())
 		if err != nil {
@@ -708,6 +708,7 @@ func runScheduledTriage(ctx context.Context, a *agent.Agent, entry agent.RoleEnt
 
 		// Check for new version after each triage run
 		if exitOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOwner, exitRepo, commitSHA, logger) {
+			cancel() // cancel the shared context → all goroutines stop
 			return
 		}
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,53 @@
+# Oompa multi-project configuration
+#
+# Usage: oompa --config config.yaml
+#
+# This file defines multiple projects in a single oompa process.
+# Each project/role runs as an independent goroutine with its own
+# Agent and structured logger.
+#
+# Settings use two-tier inheritance: project-level defaults apply
+# to all roles unless overridden per-role.
+
+# Global settings
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+poll-interval: 2m
+log-level: debug
+exit-on-new-version: qinqon/oompa
+
+projects:
+  - repo: ovn-kubernetes/ovn-kubernetes
+    # Project-level defaults — inherited by all roles
+    create-flaky-issues: true
+    flaky-label: kind/ci-flake
+    prs:
+      - watch: [6252, 6229, 6118, 6306]
+        reactions: [ci, conflicts, rebase]
+        # inherits create-flaky-issues: true from project
+
+  - repo: openperouter/openperouter
+    prs:
+      - watch: [313, 304]
+        reactions: [ci, conflicts, rebase]
+        skip-comment: [ci-unrelated, ci-infrastructure]
+
+  - repo: nmstate/kubernetes-nmstate
+    fork: qinqon/kubernetes-nmstate
+    issues:
+      - only-assigned: true
+    triage:
+      - jobs:
+          - https://prow.example.com/nightly
+        schedule: "09:00 Europe/Madrid"
+        create-flaky-issues: true
+        flaky-label: ci-flake
+
+  - repo: openshift/hypershift
+    prs:
+      - watch: [8365]
+        reactions: [ci, conflicts, rebase]
+
+  - repo: qinqon/oompa
+    issues:
+      - label: good-for-ai

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,6 @@ github.com/google/go-github/v84 v84.0.0 h1:I/0Xn5IuChMe8TdmI2bbim5nyhaRFJ7DEdzmD
 github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXukJBn73xsiYrRRQ=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
 	FlakyLabel        string   // label applied to flaky CI issues (default: "flaky-test")
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
-	MaxWorkers        int      // maximum concurrent Claude invocations (1 = sequential, default)
 	TriageJobs        []string       // CI job URLs to monitor for periodic job triage
 	TriageLookback    time.Duration  // time window to check for failed triage runs (0 = latest only)
 	Agent             string   // coding agent backend: "claudecode" or "opencode"

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -1,0 +1,476 @@
+package agent
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileConfig represents the top-level YAML configuration file.
+type FileConfig struct {
+	Agent            string          `yaml:"agent"`
+	AgentModel       string          `yaml:"agent-model"`
+	PollInterval     string          `yaml:"poll-interval"`
+	LogLevel         string          `yaml:"log-level"`
+	ExitOnNewVersion string          `yaml:"exit-on-new-version"`
+	DryRun           bool            `yaml:"dry-run"`
+	OneShot          bool            `yaml:"one-shot"`
+	Projects         []ProjectConfig `yaml:"projects"`
+}
+
+// ProjectConfig represents a single project in the YAML config.
+type ProjectConfig struct {
+	Repo   string `yaml:"repo"` // "owner/repo"
+	Fork   string `yaml:"fork"` // "owner/repo" for fork
+
+	// Project-level defaults (inherited by roles unless overridden)
+	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
+	FlakyLabel        string   `yaml:"flaky-label"`
+	SkipComment       []string `yaml:"skip-comment"`
+	SkipFix           *bool    `yaml:"skip-fix"`
+	Reactions         []string `yaml:"reactions"`
+	Label             string   `yaml:"label"`
+	OnlyAssigned      *bool    `yaml:"only-assigned"`
+
+	// Role arrays
+	PRs    []PRsRoleConfig    `yaml:"prs"`
+	Issues []IssuesRoleConfig `yaml:"issues"`
+	Triage []TriageRoleConfig `yaml:"triage"`
+}
+
+// PRsRoleConfig represents a single PRs role entry.
+type PRsRoleConfig struct {
+	Watch             []int    `yaml:"watch"`
+	Reactions         []string `yaml:"reactions"`
+	SkipComment       []string `yaml:"skip-comment"`
+	SkipFix           *bool    `yaml:"skip-fix"`
+	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
+	FlakyLabel        string   `yaml:"flaky-label"`
+}
+
+// IssuesRoleConfig represents a single Issues role entry.
+type IssuesRoleConfig struct {
+	Label             string   `yaml:"label"`
+	OnlyAssigned      *bool    `yaml:"only-assigned"`
+	SkipFix           *bool    `yaml:"skip-fix"`
+	SkipComment       []string `yaml:"skip-comment"`
+	Fork              string   `yaml:"fork"`
+	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
+	FlakyLabel        string   `yaml:"flaky-label"`
+}
+
+// TriageRoleConfig represents a single Triage role entry.
+type TriageRoleConfig struct {
+	Jobs              []string `yaml:"jobs"`
+	Schedule          string   `yaml:"schedule"`
+	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
+	FlakyLabel        string   `yaml:"flaky-label"`
+	SkipComment       []string `yaml:"skip-comment"`
+	SkipFix           *bool    `yaml:"skip-fix"`
+}
+
+// LoadFileConfig reads and parses a YAML config file, returning the validated FileConfig.
+func LoadFileConfig(path string) (*FileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var cfg FileConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	if err := validateFileConfig(&cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// validateFileConfig validates the parsed config for required fields and correct values.
+func validateFileConfig(cfg *FileConfig) error {
+	if len(cfg.Projects) == 0 {
+		return fmt.Errorf("no projects defined")
+	}
+
+	if cfg.Agent != "" && cfg.Agent != "claudecode" && cfg.Agent != "opencode" {
+		return fmt.Errorf("invalid agent %q: must be claudecode or opencode", cfg.Agent)
+	}
+
+	if cfg.AgentModel != "" && cfg.Agent != "opencode" {
+		return fmt.Errorf("agent-model can only be used with agent: opencode")
+	}
+
+	if cfg.PollInterval != "" {
+		if _, err := time.ParseDuration(cfg.PollInterval); err != nil {
+			return fmt.Errorf("invalid poll-interval %q: %w", cfg.PollInterval, err)
+		}
+	}
+
+	validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true, "rebase": true}
+	validComments := map[string]bool{
+		"ci-unrelated": true, "ci-infrastructure": true, "ci-related": true,
+		"conflict": true, "rebase": true, "flaky": true, "issue-in-progress": true,
+	}
+
+	for i, p := range cfg.Projects {
+		if p.Repo == "" {
+			return fmt.Errorf("project %d: repo is required", i)
+		}
+		parts := strings.SplitN(p.Repo, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("project %d: repo must be owner/repo, got %q", i, p.Repo)
+		}
+
+		if p.Fork != "" {
+			forkParts := strings.SplitN(p.Fork, "/", 2)
+			if len(forkParts) != 2 || forkParts[0] == "" || forkParts[1] == "" {
+				return fmt.Errorf("project %d: fork must be owner/repo, got %q", i, p.Fork)
+			}
+		}
+
+		// Validate project-level reactions
+		for _, r := range p.Reactions {
+			if !validReactions[r] {
+				return fmt.Errorf("project %d: invalid reaction %q", i, r)
+			}
+		}
+
+		// Validate project-level skip-comment
+		for _, c := range p.SkipComment {
+			if !validComments[c] {
+				return fmt.Errorf("project %d: invalid skip-comment %q", i, c)
+			}
+		}
+
+		if len(p.PRs) == 0 && len(p.Issues) == 0 && len(p.Triage) == 0 {
+			return fmt.Errorf("project %d (%s): at least one role (prs, issues, triage) is required", i, p.Repo)
+		}
+
+		for j, pr := range p.PRs {
+			if len(pr.Watch) == 0 {
+				return fmt.Errorf("project %d (%s): prs[%d]: watch is required", i, p.Repo, j)
+			}
+			for _, r := range pr.Reactions {
+				if !validReactions[r] {
+					return fmt.Errorf("project %d (%s): prs[%d]: invalid reaction %q", i, p.Repo, j, r)
+				}
+			}
+			for _, c := range pr.SkipComment {
+				if !validComments[c] {
+					return fmt.Errorf("project %d (%s): prs[%d]: invalid skip-comment %q", i, p.Repo, j, c)
+				}
+			}
+		}
+
+		for j, issue := range p.Issues {
+			for _, c := range issue.SkipComment {
+				if !validComments[c] {
+					return fmt.Errorf("project %d (%s): issues[%d]: invalid skip-comment %q", i, p.Repo, j, c)
+				}
+			}
+			if issue.Fork != "" {
+				forkParts := strings.SplitN(issue.Fork, "/", 2)
+				if len(forkParts) != 2 || forkParts[0] == "" || forkParts[1] == "" {
+					return fmt.Errorf("project %d (%s): issues[%d]: fork must be owner/repo, got %q", i, p.Repo, j, issue.Fork)
+				}
+			}
+		}
+
+		for j, triage := range p.Triage {
+			if len(triage.Jobs) == 0 {
+				return fmt.Errorf("project %d (%s): triage[%d]: jobs is required", i, p.Repo, j)
+			}
+			for _, c := range triage.SkipComment {
+				if !validComments[c] {
+					return fmt.Errorf("project %d (%s): triage[%d]: invalid skip-comment %q", i, p.Repo, j, c)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// boolOr returns the value of ptr if non-nil, otherwise the fallback.
+func boolOr(ptr *bool, fallback bool) bool {
+	if ptr != nil {
+		return *ptr
+	}
+	return fallback
+}
+
+// stringOr returns s if non-empty, otherwise the fallback.
+func stringOr(s, fallback string) string {
+	if s != "" {
+		return s
+	}
+	return fallback
+}
+
+// stringsOr returns s if non-nil, otherwise the fallback.
+func stringsOr(s, fallback []string) []string {
+	if s != nil {
+		return s
+	}
+	return fallback
+}
+
+// boolPtr returns a pointer to b.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// RoleEntry describes a single role goroutine to run. Built from FileConfig by
+// expanding projects and roles with two-tier inheritance applied.
+type RoleEntry struct {
+	Config Config // Agent config with all values resolved
+	Role   string // "prs", "issues", "triage"
+
+	// Triage scheduling (only for role == "triage")
+	Schedule string
+}
+
+// BuildRoleEntries expands a FileConfig into a flat list of RoleEntry values,
+// one per goroutine. Two-tier inheritance is applied: project-level defaults
+// are used unless the role-level value overrides them.
+func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []RoleEntry {
+	var entries []RoleEntry
+
+	// Global defaults from FileConfig
+	agent := stringOr(fc.Agent, globalCfg.Agent)
+	agentModel := stringOr(fc.AgentModel, globalCfg.AgentModel)
+	pollInterval := globalCfg.PollInterval
+	if fc.PollInterval != "" {
+		if d, err := time.ParseDuration(fc.PollInterval); err == nil {
+			pollInterval = d
+		}
+	}
+	logLevel := stringOr(fc.LogLevel, globalCfg.LogLevel)
+
+	for _, p := range fc.Projects {
+		repoParts := strings.SplitN(p.Repo, "/", 2)
+		owner, repo := repoParts[0], repoParts[1]
+
+		// Parse project-level fork
+		var projForkOwner, projForkRepo string
+		if p.Fork != "" {
+			forkParts := strings.SplitN(p.Fork, "/", 2)
+			projForkOwner = forkParts[0]
+			projForkRepo = forkParts[1]
+		}
+
+		// Project-level defaults
+		projCreateFlaky := boolOr(p.CreateFlakyIssues, false)
+		projFlakyLabel := stringOr(p.FlakyLabel, "flaky-test")
+		projSkipComment := p.SkipComment
+		projSkipFix := boolOr(p.SkipFix, false)
+		projReactions := p.Reactions
+		projLabel := stringOr(p.Label, "good-for-ai")
+		projOnlyAssigned := boolOr(p.OnlyAssigned, false)
+
+		// Base config for this project (shared fields)
+		baseCfg := Config{
+			Owner:             owner,
+			Repo:              repo,
+			CloneDir:          fmt.Sprintf("%s/%s/%s", baseCloneDir, owner, repo),
+			PollInterval:      pollInterval,
+			LogLevel:          logLevel,
+			DryRun:            fc.DryRun || globalCfg.DryRun,
+			OneShot:           fc.OneShot || globalCfg.OneShot,
+			Agent:             agent,
+			AgentModel:        agentModel,
+			ForkOwner:         projForkOwner,
+			ForkRepo:          projForkRepo,
+			// These are inherited from the global config (set by main from auth)
+			GitHubToken:     globalCfg.GitHubToken,
+			GitHubUser:      globalCfg.GitHubUser,
+			GitHubHeadOwner: globalCfg.GitHubHeadOwner,
+			GitAuthorName:   globalCfg.GitAuthorName,
+			GitAuthorEmail:  globalCfg.GitAuthorEmail,
+			SignedOffBy:     globalCfg.SignedOffBy,
+			Reviewers:       globalCfg.Reviewers,
+			Version:         globalCfg.Version,
+			// GitHub App auth (shared)
+			GitHubAppID:             globalCfg.GitHubAppID,
+			GitHubAppPrivateKey:     globalCfg.GitHubAppPrivateKey,
+			GitHubAppInstallationID: globalCfg.GitHubAppInstallationID,
+		}
+
+		// Resolve GitHubHeadOwner per project
+		if projForkOwner != "" {
+			baseCfg.GitHubHeadOwner = projForkOwner
+		}
+
+		// PRs role entries
+		for _, pr := range p.PRs {
+			cfg := baseCfg
+			cfg.WatchPRs = pr.Watch
+			cfg.Reactions = stringsOr(pr.Reactions, projReactions)
+			cfg.SkipComments = stringsOr(pr.SkipComment, projSkipComment)
+			cfg.SkipFix = boolOr(pr.SkipFix, projSkipFix)
+			cfg.CreateFlakyIssues = boolOr(pr.CreateFlakyIssues, projCreateFlaky)
+			cfg.FlakyLabel = stringOr(pr.FlakyLabel, projFlakyLabel)
+			entries = append(entries, RoleEntry{Config: cfg, Role: "prs"})
+		}
+
+		// Issues role entries
+		for _, issue := range p.Issues {
+			cfg := baseCfg
+			cfg.Label = stringOr(issue.Label, projLabel)
+			cfg.OnlyAssigned = boolOr(issue.OnlyAssigned, projOnlyAssigned)
+			cfg.SkipFix = boolOr(issue.SkipFix, projSkipFix)
+			cfg.SkipComments = stringsOr(issue.SkipComment, projSkipComment)
+			cfg.CreateFlakyIssues = boolOr(issue.CreateFlakyIssues, projCreateFlaky)
+			cfg.FlakyLabel = stringOr(issue.FlakyLabel, projFlakyLabel)
+			// Issues can override fork
+			if issue.Fork != "" {
+				forkParts := strings.SplitN(issue.Fork, "/", 2)
+				cfg.ForkOwner = forkParts[0]
+				cfg.ForkRepo = forkParts[1]
+				cfg.GitHubHeadOwner = forkParts[0]
+			}
+			entries = append(entries, RoleEntry{Config: cfg, Role: "issues"})
+		}
+
+		// Triage role entries
+		for _, triage := range p.Triage {
+			cfg := baseCfg
+			cfg.TriageJobs = triage.Jobs
+			cfg.CreateFlakyIssues = boolOr(triage.CreateFlakyIssues, projCreateFlaky)
+			cfg.FlakyLabel = stringOr(triage.FlakyLabel, projFlakyLabel)
+			cfg.SkipComments = stringsOr(triage.SkipComment, projSkipComment)
+			cfg.SkipFix = boolOr(triage.SkipFix, projSkipFix)
+			entries = append(entries, RoleEntry{
+				Config:   cfg,
+				Role:     "triage",
+				Schedule: triage.Schedule,
+			})
+		}
+	}
+
+	return entries
+}
+
+// ParseSchedule parses a schedule string like "09:00 Europe/Madrid" or
+// "09:00 Monday Europe/Madrid" and returns the next occurrence.
+// Supported formats:
+//   - "HH:MM TZ"           — daily at HH:MM in timezone TZ
+//   - "HH:MM Weekday TZ"   — weekly on Weekday at HH:MM in timezone TZ
+func ParseSchedule(schedule string, now time.Time) (time.Time, error) {
+	parts := strings.Fields(schedule)
+	if len(parts) < 2 {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: expected 'HH:MM timezone' or 'HH:MM weekday timezone'", schedule)
+	}
+
+	timePart := parts[0]
+	var weekday *time.Weekday
+	var tzName string
+
+	if len(parts) == 2 {
+		// "HH:MM TZ" — daily
+		tzName = parts[1]
+	} else if len(parts) == 3 {
+		// "HH:MM Weekday TZ" — weekly
+		wd, err := parseWeekday(parts[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid schedule %q: %w", schedule, err)
+		}
+		weekday = &wd
+		tzName = parts[2]
+	} else {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: too many parts", schedule)
+	}
+
+	loc, err := time.LoadLocation(tzName)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: unknown timezone %q: %w", schedule, tzName, err)
+	}
+
+	hourMin := strings.SplitN(timePart, ":", 2)
+	if len(hourMin) != 2 {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: time must be HH:MM", schedule)
+	}
+
+	var hour, min int
+	if _, err := fmt.Sscanf(hourMin[0], "%d", &hour); err != nil || hour < 0 || hour > 23 {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: invalid hour", schedule)
+	}
+	if _, err := fmt.Sscanf(hourMin[1], "%d", &min); err != nil || min < 0 || min > 59 {
+		return time.Time{}, fmt.Errorf("invalid schedule %q: invalid minute", schedule)
+	}
+
+	nowLocal := now.In(loc)
+	next := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), hour, min, 0, 0, loc)
+
+	if weekday != nil {
+		// Weekly: advance to the next matching weekday
+		daysUntil := (int(*weekday) - int(next.Weekday()) + 7) % 7
+		if daysUntil == 0 && !next.After(nowLocal) {
+			daysUntil = 7
+		}
+		next = next.AddDate(0, 0, daysUntil)
+	} else {
+		// Daily: if the time has passed today, advance to tomorrow
+		if !next.After(nowLocal) {
+			next = next.AddDate(0, 0, 1)
+		}
+	}
+
+	return next, nil
+}
+
+// parseWeekday parses a weekday name (case-insensitive).
+func parseWeekday(s string) (time.Weekday, error) {
+	switch strings.ToLower(s) {
+	case "sunday":
+		return time.Sunday, nil
+	case "monday":
+		return time.Monday, nil
+	case "tuesday":
+		return time.Tuesday, nil
+	case "wednesday":
+		return time.Wednesday, nil
+	case "thursday":
+		return time.Thursday, nil
+	case "friday":
+		return time.Friday, nil
+	case "saturday":
+		return time.Saturday, nil
+	default:
+		return 0, fmt.Errorf("unknown weekday %q", s)
+	}
+}
+
+// NewRoleLogger creates a structured logger scoped to a role entry.
+// Always includes project (owner/repo) and role. Per-role context fields
+// (watch_prs, triage_jobs, label) are added when present.
+func NewRoleLogger(base *slog.Logger, entry RoleEntry) *slog.Logger {
+	project := fmt.Sprintf("%s/%s", entry.Config.Owner, entry.Config.Repo)
+	logger := base.With("project", project, "role", entry.Role)
+
+	switch entry.Role {
+	case "prs":
+		if len(entry.Config.WatchPRs) > 0 {
+			logger = logger.With("watch_prs", entry.Config.WatchPRs)
+		}
+	case "issues":
+		if entry.Config.Label != "" {
+			logger = logger.With("label", entry.Config.Label)
+		}
+	case "triage":
+		if len(entry.Config.TriageJobs) > 0 {
+			logger = logger.With("triage_jobs", entry.Config.TriageJobs)
+		}
+		if entry.Schedule != "" {
+			logger = logger.With("schedule", entry.Schedule)
+		}
+	}
+
+	return logger
+}

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -102,8 +102,16 @@ func validateFileConfig(cfg *FileConfig) error {
 		return fmt.Errorf("invalid agent %q: must be claudecode or opencode", cfg.Agent)
 	}
 
-	if cfg.AgentModel != "" && cfg.Agent != "opencode" {
-		return fmt.Errorf("agent-model can only be used with agent: opencode")
+	if cfg.AgentModel != "" {
+		// agent-model is only valid with opencode. When agent is omitted in the
+		// file config, it defaults to the global config (typically claudecode),
+		// so we require agent to be explicitly set to opencode.
+		if cfg.Agent == "" {
+			return fmt.Errorf("agent-model requires agent to be explicitly set to opencode")
+		}
+		if cfg.Agent != "opencode" {
+			return fmt.Errorf("agent-model can only be used with agent: opencode")
+		}
 	}
 
 	if cfg.PollInterval != "" {
@@ -185,6 +193,11 @@ func validateFileConfig(cfg *FileConfig) error {
 		for j, triage := range p.Triage {
 			if len(triage.Jobs) == 0 {
 				return fmt.Errorf("project %d (%s): triage[%d]: jobs is required", i, p.Repo, j)
+			}
+			if triage.Schedule != "" {
+				if _, err := ParseSchedule(triage.Schedule, time.Now()); err != nil {
+					return fmt.Errorf("project %d (%s): triage[%d]: %w", i, p.Repo, j, err)
+				}
 			}
 			for _, c := range triage.SkipComment {
 				if !validComments[c] {

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
 	"os"
@@ -24,8 +25,8 @@ type FileConfig struct {
 
 // ProjectConfig represents a single project in the YAML config.
 type ProjectConfig struct {
-	Repo   string `yaml:"repo"` // "owner/repo"
-	Fork   string `yaml:"fork"` // "owner/repo" for fork
+	Repo string `yaml:"repo"` // "owner/repo"
+	Fork string `yaml:"fork"` // "owner/repo" for fork
 
 	// Project-level defaults (inherited by roles unless overridden)
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
@@ -81,7 +82,9 @@ func LoadFileConfig(path string) (*FileConfig, error) {
 	}
 
 	var cfg FileConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
@@ -234,11 +237,6 @@ func stringsOr(s, fallback []string) []string {
 	return fallback
 }
 
-// boolPtr returns a pointer to b.
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 // RoleEntry describes a single role goroutine to run. Built from FileConfig by
 // expanding projects and roles with two-tier inheritance applied.
 type RoleEntry struct {
@@ -289,17 +287,17 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 
 		// Base config for this project (shared fields)
 		baseCfg := Config{
-			Owner:             owner,
-			Repo:              repo,
-			CloneDir:          fmt.Sprintf("%s/%s/%s", baseCloneDir, owner, repo),
-			PollInterval:      pollInterval,
-			LogLevel:          logLevel,
-			DryRun:            fc.DryRun || globalCfg.DryRun,
-			OneShot:           fc.OneShot || globalCfg.OneShot,
-			Agent:             agent,
-			AgentModel:        agentModel,
-			ForkOwner:         projForkOwner,
-			ForkRepo:          projForkRepo,
+			Owner:        owner,
+			Repo:         repo,
+			CloneDir:     fmt.Sprintf("%s/%s/%s", baseCloneDir, owner, repo),
+			PollInterval: pollInterval,
+			LogLevel:     logLevel,
+			DryRun:       fc.DryRun || globalCfg.DryRun,
+			OneShot:      fc.OneShot || globalCfg.OneShot,
+			Agent:        agent,
+			AgentModel:   agentModel,
+			ForkOwner:    projForkOwner,
+			ForkRepo:     projForkRepo,
 			// These are inherited from the global config (set by main from auth)
 			GitHubToken:     globalCfg.GitHubToken,
 			GitHubUser:      globalCfg.GitHubUser,
@@ -385,10 +383,11 @@ func ParseSchedule(schedule string, now time.Time) (time.Time, error) {
 	var weekday *time.Weekday
 	var tzName string
 
-	if len(parts) == 2 {
+	switch len(parts) {
+	case 2:
 		// "HH:MM TZ" — daily
 		tzName = parts[1]
-	} else if len(parts) == 3 {
+	case 3:
 		// "HH:MM Weekday TZ" — weekly
 		wd, err := parseWeekday(parts[1])
 		if err != nil {
@@ -396,7 +395,7 @@ func ParseSchedule(schedule string, now time.Time) (time.Time, error) {
 		}
 		weekday = &wd
 		tzName = parts[2]
-	} else {
+	default:
 		return time.Time{}, fmt.Errorf("invalid schedule %q: too many parts", schedule)
 	}
 
@@ -410,16 +409,16 @@ func ParseSchedule(schedule string, now time.Time) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("invalid schedule %q: time must be HH:MM", schedule)
 	}
 
-	var hour, min int
+	var hour, minute int
 	if _, err := fmt.Sscanf(hourMin[0], "%d", &hour); err != nil || hour < 0 || hour > 23 {
 		return time.Time{}, fmt.Errorf("invalid schedule %q: invalid hour", schedule)
 	}
-	if _, err := fmt.Sscanf(hourMin[1], "%d", &min); err != nil || min < 0 || min > 59 {
+	if _, err := fmt.Sscanf(hourMin[1], "%d", &minute); err != nil || minute < 0 || minute > 59 {
 		return time.Time{}, fmt.Errorf("invalid schedule %q: invalid minute", schedule)
 	}
 
 	nowLocal := now.In(loc)
-	next := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), hour, min, 0, 0, loc)
+	next := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), hour, minute, 0, 0, loc)
 
 	if weekday != nil {
 		// Weekly: advance to the next matching weekday
@@ -428,11 +427,9 @@ func ParseSchedule(schedule string, now time.Time) (time.Time, error) {
 			daysUntil = 7
 		}
 		next = next.AddDate(0, 0, daysUntil)
-	} else {
+	} else if !next.After(nowLocal) {
 		// Daily: if the time has passed today, advance to tomorrow
-		if !next.After(nowLocal) {
-			next = next.AddDate(0, 0, 1)
-		}
+		next = next.AddDate(0, 0, 1)
 	}
 
 	return next, nil

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -94,7 +94,7 @@ projects: []
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -111,7 +111,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -126,7 +126,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -143,7 +143,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -160,7 +160,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -178,7 +178,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -196,7 +196,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -211,7 +211,7 @@ func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
 		Projects: []ProjectConfig{
 			{
 				Repo:              "owner/repo",
-				CreateFlakyIssues: boolPtr(true),
+				CreateFlakyIssues: new(true),
 				FlakyLabel:        "kind/flaky",
 				SkipComment:       []string{"ci-unrelated"},
 				PRs: []PRsRoleConfig{
@@ -221,8 +221,8 @@ func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
 					},
 					{
 						Watch:             []int{300},
-						CreateFlakyIssues: boolPtr(false), // Override
-						FlakyLabel:        "override",     // Override
+						CreateFlakyIssues: new(false),                    // Override
+						FlakyLabel:        "override",                    // Override
 						SkipComment:       []string{"ci-infrastructure"}, // Override
 					},
 				},
@@ -342,7 +342,7 @@ func TestBuildRoleEntries_ForkInheritance(t *testing.T) {
 				Fork: "myfork/repo",
 				PRs:  []PRsRoleConfig{{Watch: []int{1}}},
 				Issues: []IssuesRoleConfig{
-					{Label: "ai"},                                // Inherits project fork
+					{Label: "ai"}, // Inherits project fork
 					{Label: "special", Fork: "otherfork/myrepo"}, // Overrides fork
 				},
 			},
@@ -539,7 +539,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -557,7 +557,7 @@ func TestLoadFileConfig_FileNotFound(t *testing.T) {
 func TestLoadFileConfig_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte("{{invalid yaml"), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte("{{invalid yaml"), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -576,7 +576,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -594,7 +594,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -612,7 +612,7 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err == nil {
@@ -630,10 +630,29 @@ projects:
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
 
 	_, err := LoadFileConfig(path)
 	if err != nil {
 		t.Fatalf("unexpected error for valid schedule: %v", err)
+	}
+}
+
+func TestLoadFileConfig_UnknownKeysRejected(t *testing.T) {
+	yaml := `
+agent: opencode
+unknown-field: some-value
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for unknown YAML key")
 	}
 }

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -1,0 +1,585 @@
+package agent
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadFileConfig_Valid(t *testing.T) {
+	yaml := `
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+poll-interval: 2m
+log-level: debug
+exit-on-new-version: qinqon/oompa
+projects:
+  - repo: ovn-kubernetes/ovn-kubernetes
+    create-flaky-issues: true
+    flaky-label: kind/ci-flake
+    prs:
+      - watch: [6252, 6229]
+        reactions: [ci, conflicts, rebase]
+  - repo: qinqon/oompa
+    issues:
+      - label: good-for-ai
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fc.Agent != "opencode" {
+		t.Errorf("expected agent 'opencode', got %q", fc.Agent)
+	}
+	if fc.AgentModel != "google-vertex-anthropic/claude-opus-4-6@default" {
+		t.Errorf("unexpected agent-model %q", fc.AgentModel)
+	}
+	if fc.PollInterval != "2m" {
+		t.Errorf("expected poll-interval '2m', got %q", fc.PollInterval)
+	}
+	if fc.LogLevel != "debug" {
+		t.Errorf("expected log-level 'debug', got %q", fc.LogLevel)
+	}
+	if fc.ExitOnNewVersion != "qinqon/oompa" {
+		t.Errorf("unexpected exit-on-new-version %q", fc.ExitOnNewVersion)
+	}
+	if len(fc.Projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(fc.Projects))
+	}
+
+	// First project
+	p := fc.Projects[0]
+	if p.Repo != "ovn-kubernetes/ovn-kubernetes" {
+		t.Errorf("unexpected repo %q", p.Repo)
+	}
+	if p.CreateFlakyIssues == nil || !*p.CreateFlakyIssues {
+		t.Error("expected create-flaky-issues to be true")
+	}
+	if p.FlakyLabel != "kind/ci-flake" {
+		t.Errorf("unexpected flaky-label %q", p.FlakyLabel)
+	}
+	if len(p.PRs) != 1 {
+		t.Fatalf("expected 1 prs entry, got %d", len(p.PRs))
+	}
+	if len(p.PRs[0].Watch) != 2 || p.PRs[0].Watch[0] != 6252 {
+		t.Errorf("unexpected watch list %v", p.PRs[0].Watch)
+	}
+
+	// Second project
+	p2 := fc.Projects[1]
+	if p2.Repo != "qinqon/oompa" {
+		t.Errorf("unexpected repo %q", p2.Repo)
+	}
+	if len(p2.Issues) != 1 {
+		t.Fatalf("expected 1 issues entry, got %d", len(p2.Issues))
+	}
+	if p2.Issues[0].Label != "good-for-ai" {
+		t.Errorf("unexpected label %q", p2.Issues[0].Label)
+	}
+}
+
+func TestLoadFileConfig_NoProjects(t *testing.T) {
+	yaml := `
+agent: opencode
+projects: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for empty projects")
+	}
+}
+
+func TestLoadFileConfig_InvalidRepo(t *testing.T) {
+	yaml := `
+projects:
+  - repo: invalid
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid repo format")
+	}
+}
+
+func TestLoadFileConfig_NoRoles(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error when no roles defined")
+	}
+}
+
+func TestLoadFileConfig_PRsWithoutWatch(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    prs:
+      - reactions: [ci]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for prs without watch list")
+	}
+}
+
+func TestLoadFileConfig_TriageWithoutJobs(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - schedule: "09:00 Europe/Madrid"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for triage without jobs")
+	}
+}
+
+func TestLoadFileConfig_InvalidReaction(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    prs:
+      - watch: [1]
+        reactions: [invalid]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid reaction")
+	}
+}
+
+func TestLoadFileConfig_InvalidAgent(t *testing.T) {
+	yaml := `
+agent: badagent
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid agent")
+	}
+}
+
+func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Agent:        "opencode",
+		PollInterval: "5m",
+		Projects: []ProjectConfig{
+			{
+				Repo:              "owner/repo",
+				CreateFlakyIssues: boolPtr(true),
+				FlakyLabel:        "kind/flaky",
+				SkipComment:       []string{"ci-unrelated"},
+				PRs: []PRsRoleConfig{
+					{
+						Watch: []int{100, 200},
+						// Inherits project-level create-flaky-issues, flaky-label, skip-comment
+					},
+					{
+						Watch:             []int{300},
+						CreateFlakyIssues: boolPtr(false), // Override
+						FlakyLabel:        "override",     // Override
+						SkipComment:       []string{"ci-infrastructure"}, // Override
+					},
+				},
+				Issues: []IssuesRoleConfig{
+					{Label: "ai-label"},
+				},
+			},
+		},
+	}
+
+	globalCfg := Config{
+		Agent:    "claudecode", // Should be overridden by file config
+		LogLevel: "info",
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", globalCfg)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// First PRs entry inherits project defaults
+	e1 := entries[0]
+	if e1.Role != "prs" {
+		t.Errorf("expected role 'prs', got %q", e1.Role)
+	}
+	if e1.Config.Owner != "owner" || e1.Config.Repo != "repo" {
+		t.Errorf("unexpected owner/repo %s/%s", e1.Config.Owner, e1.Config.Repo)
+	}
+	if len(e1.Config.WatchPRs) != 2 || e1.Config.WatchPRs[0] != 100 {
+		t.Errorf("unexpected watch PRs %v", e1.Config.WatchPRs)
+	}
+	if !e1.Config.CreateFlakyIssues {
+		t.Error("expected inherited create-flaky-issues=true")
+	}
+	if e1.Config.FlakyLabel != "kind/flaky" {
+		t.Errorf("expected inherited flaky-label 'kind/flaky', got %q", e1.Config.FlakyLabel)
+	}
+	if len(e1.Config.SkipComments) != 1 || e1.Config.SkipComments[0] != "ci-unrelated" {
+		t.Errorf("expected inherited skip-comment, got %v", e1.Config.SkipComments)
+	}
+	if e1.Config.Agent != "opencode" {
+		t.Errorf("expected agent 'opencode' from file config, got %q", e1.Config.Agent)
+	}
+
+	// Second PRs entry overrides project defaults
+	e2 := entries[1]
+	if e2.Config.CreateFlakyIssues {
+		t.Error("expected overridden create-flaky-issues=false")
+	}
+	if e2.Config.FlakyLabel != "override" {
+		t.Errorf("expected overridden flaky-label 'override', got %q", e2.Config.FlakyLabel)
+	}
+	if len(e2.Config.SkipComments) != 1 || e2.Config.SkipComments[0] != "ci-infrastructure" {
+		t.Errorf("expected overridden skip-comment, got %v", e2.Config.SkipComments)
+	}
+
+	// Issues entry
+	e3 := entries[2]
+	if e3.Role != "issues" {
+		t.Errorf("expected role 'issues', got %q", e3.Role)
+	}
+	if e3.Config.Label != "ai-label" {
+		t.Errorf("expected label 'ai-label', got %q", e3.Config.Label)
+	}
+}
+
+func TestBuildRoleEntries_MultipleProjectsAndRoles(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo: "org1/repo1",
+				PRs:  []PRsRoleConfig{{Watch: []int{1}}},
+			},
+			{
+				Repo:   "org2/repo2",
+				Issues: []IssuesRoleConfig{{Label: "ai"}},
+				Triage: []TriageRoleConfig{{Jobs: []string{"https://ci.example.com/job"}, Schedule: "09:00 UTC"}},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Check each entry's project is correct
+	if entries[0].Config.Owner != "org1" || entries[0].Config.Repo != "repo1" {
+		t.Error("entry 0 has wrong owner/repo")
+	}
+	if entries[1].Config.Owner != "org2" || entries[1].Config.Repo != "repo2" {
+		t.Error("entry 1 has wrong owner/repo")
+	}
+	if entries[2].Config.Owner != "org2" || entries[2].Config.Repo != "repo2" {
+		t.Error("entry 2 has wrong owner/repo")
+	}
+
+	// Check clone dirs are per-project
+	if entries[0].Config.CloneDir != "/tmp/work/org1/repo1" {
+		t.Errorf("unexpected clone dir %q", entries[0].Config.CloneDir)
+	}
+	if entries[1].Config.CloneDir != "/tmp/work/org2/repo2" {
+		t.Errorf("unexpected clone dir %q", entries[1].Config.CloneDir)
+	}
+
+	// Check triage entry has schedule
+	if entries[2].Schedule != "09:00 UTC" {
+		t.Errorf("expected schedule '09:00 UTC', got %q", entries[2].Schedule)
+	}
+}
+
+func TestBuildRoleEntries_ForkInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo: "upstream/repo",
+				Fork: "myfork/repo",
+				PRs:  []PRsRoleConfig{{Watch: []int{1}}},
+				Issues: []IssuesRoleConfig{
+					{Label: "ai"},                                // Inherits project fork
+					{Label: "special", Fork: "otherfork/myrepo"}, // Overrides fork
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// PRs entry inherits project fork
+	if entries[0].Config.ForkOwner != "myfork" || entries[0].Config.ForkRepo != "repo" {
+		t.Errorf("PRs: expected fork myfork/repo, got %s/%s", entries[0].Config.ForkOwner, entries[0].Config.ForkRepo)
+	}
+	if entries[0].Config.GitHubHeadOwner != "myfork" {
+		t.Errorf("PRs: expected head owner 'myfork', got %q", entries[0].Config.GitHubHeadOwner)
+	}
+
+	// First issues entry inherits project fork
+	if entries[1].Config.ForkOwner != "myfork" {
+		t.Errorf("Issues[0]: expected fork owner 'myfork', got %q", entries[1].Config.ForkOwner)
+	}
+
+	// Second issues entry overrides fork
+	if entries[2].Config.ForkOwner != "otherfork" || entries[2].Config.ForkRepo != "myrepo" {
+		t.Errorf("Issues[1]: expected fork otherfork/myrepo, got %s/%s", entries[2].Config.ForkOwner, entries[2].Config.ForkRepo)
+	}
+	if entries[2].Config.GitHubHeadOwner != "otherfork" {
+		t.Errorf("Issues[1]: expected head owner 'otherfork', got %q", entries[2].Config.GitHubHeadOwner)
+	}
+}
+
+func TestParseSchedule_Daily(t *testing.T) {
+	// Set a known time: Wednesday 2024-01-10 14:00 UTC
+	now := time.Date(2024, 1, 10, 14, 0, 0, 0, time.UTC)
+
+	// Schedule for 15:00 UTC — should be today since it's in the future
+	next, err := ParseSchedule("15:00 UTC", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2024, 1, 10, 15, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+
+	// Schedule for 13:00 UTC — should be tomorrow since it's in the past
+	next, err = ParseSchedule("13:00 UTC", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected = time.Date(2024, 1, 11, 13, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestParseSchedule_Weekly(t *testing.T) {
+	// Wednesday 2024-01-10 14:00 UTC
+	now := time.Date(2024, 1, 10, 14, 0, 0, 0, time.UTC)
+
+	// Schedule for Monday 09:00 UTC — should be next Monday (2024-01-15)
+	next, err := ParseSchedule("09:00 Monday UTC", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+
+	// Schedule for Wednesday 09:00 UTC — time has passed today, should be next Wednesday
+	next, err = ParseSchedule("09:00 Wednesday UTC", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected = time.Date(2024, 1, 17, 9, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+
+	// Schedule for Wednesday 15:00 UTC — hasn't happened yet today, should be today
+	next, err = ParseSchedule("15:00 Wednesday UTC", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected = time.Date(2024, 1, 10, 15, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestParseSchedule_InvalidFormats(t *testing.T) {
+	tests := []string{
+		"",
+		"09:00",
+		"invalid UTC",
+		"09:00 Invalid/Timezone",
+		"09:00 Flurpday UTC",
+		"25:00 UTC",
+		"09:60 UTC",
+	}
+
+	now := time.Now()
+	for _, s := range tests {
+		_, err := ParseSchedule(s, now)
+		if err == nil {
+			t.Errorf("expected error for schedule %q", s)
+		}
+	}
+}
+
+func TestNewRoleLogger_PRs(t *testing.T) {
+	base := slog.Default()
+	entry := RoleEntry{
+		Config: Config{Owner: "org", Repo: "repo", WatchPRs: []int{1, 2, 3}},
+		Role:   "prs",
+	}
+
+	logger := NewRoleLogger(base, entry)
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestNewRoleLogger_Issues(t *testing.T) {
+	base := slog.Default()
+	entry := RoleEntry{
+		Config: Config{Owner: "org", Repo: "repo", Label: "good-for-ai"},
+		Role:   "issues",
+	}
+
+	logger := NewRoleLogger(base, entry)
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestNewRoleLogger_Triage(t *testing.T) {
+	base := slog.Default()
+	entry := RoleEntry{
+		Config:   Config{Owner: "org", Repo: "repo", TriageJobs: []string{"https://ci.example.com/job"}},
+		Role:     "triage",
+		Schedule: "09:00 UTC",
+	}
+
+	logger := NewRoleLogger(base, entry)
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestIssueKey(t *testing.T) {
+	key := IssueKey("owner", "repo", 42)
+	if key != "owner/repo#42" {
+		t.Errorf("expected 'owner/repo#42', got %q", key)
+	}
+}
+
+func TestBuildRoleEntries_GlobalOverrides(t *testing.T) {
+	fc := &FileConfig{
+		DryRun:  true,
+		OneShot: true,
+		Projects: []ProjectConfig{
+			{
+				Repo: "owner/repo",
+				PRs:  []PRsRoleConfig{{Watch: []int{1}}},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	if !entries[0].Config.DryRun {
+		t.Error("expected dry-run to propagate from file config")
+	}
+	if !entries[0].Config.OneShot {
+		t.Error("expected one-shot to propagate from file config")
+	}
+}
+
+func TestLoadFileConfig_InvalidSkipComment(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    skip-comment:
+      - invalid-category
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid skip-comment")
+	}
+}
+
+func TestLoadFileConfig_FileNotFound(t *testing.T) {
+	_, err := LoadFileConfig("/nonexistent/path.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadFileConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte("{{invalid yaml"), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestLoadFileConfig_AgentModelWithoutOpenCode(t *testing.T) {
+	yaml := `
+agent: claudecode
+agent-model: some-model
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for agent-model with claudecode")
+	}
+}

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -583,3 +583,57 @@ projects:
 		t.Fatal("expected error for agent-model with claudecode")
 	}
 }
+
+func TestLoadFileConfig_AgentModelWithoutAgentSet(t *testing.T) {
+	yaml := `
+agent-model: some-model
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for agent-model without explicit agent")
+	}
+}
+
+func TestLoadFileConfig_InvalidSchedule(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        schedule: "09:00 Invalid/Timezone"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid schedule timezone")
+	}
+}
+
+func TestLoadFileConfig_ValidSchedule(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        schedule: "09:00 UTC"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck
+
+	_, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error for valid schedule: %v", err)
+	}
+}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -420,7 +420,7 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work, ok := agent.state.ActiveIssues[42]
+	work, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if !ok {
 		t.Fatal("issue 42 should be in state after processing")
 	}
@@ -468,8 +468,8 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 	}
 
 	// Verify lastCommentID was updated
-	if agent.state.ActiveIssues[42].LastCommentID != commentID {
-		t.Errorf("expected lastCommentID %d, got %d", commentID, agent.state.ActiveIssues[42].LastCommentID)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID != commentID {
+		t.Errorf("expected lastCommentID %d, got %d", commentID, agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID)
 	}
 
 	// Verify Claude was invoked again
@@ -501,12 +501,12 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 	}
 
 	// === Phase 4: PR merged, cleanup ===
-	worktreePath := agent.state.ActiveIssues[42].WorktreePath
+	worktreePath := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].WorktreePath
 	gh.mergePR(work.PRNumber)
 
 	agent.CleanupDone(ctx)
 
-	if _, exists := agent.state.ActiveIssues[42]; exists {
+	if _, exists := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; exists {
 		t.Error("issue 42 should be removed from state after merge")
 	}
 
@@ -541,7 +541,7 @@ func TestIntegration_ClaudeFailure(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 
 	// Verify failure state
-	work := agent.state.ActiveIssues[99]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 99)]
 	if work == nil {
 		t.Fatal("issue 99 should be in state")
 	}
@@ -601,7 +601,7 @@ func TestIntegration_ClosedPRRetriggers(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work := agent.state.ActiveIssues[10]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 10)]
 	if work == nil || work.PRNumber == 0 {
 		t.Fatal("PR should be tracked")
 	}
@@ -617,14 +617,14 @@ func TestIntegration_ClosedPRRetriggers(t *testing.T) {
 
 	agent.CleanupDone(ctx)
 
-	if _, exists := agent.state.ActiveIssues[10]; exists {
+	if _, exists := agent.state.ActiveIssues[IssueKey("owner", "repo", 10)]; exists {
 		t.Error("issue should be removed after PR closed")
 	}
 
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work = agent.state.ActiveIssues[10]
+	work = agent.state.ActiveIssues[IssueKey("owner", "repo", 10)]
 	if work == nil {
 		t.Fatal("issue 10 should be re-processed after closed PR")
 	}
@@ -663,7 +663,7 @@ func TestIntegration_ReviewerWhitelist(t *testing.T) {
 	}
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
-	prNum := agent.state.ActiveIssues[50].PRNumber
+	prNum := agent.state.ActiveIssues[IssueKey("owner", "repo", 50)].PRNumber
 
 	// Non-whitelisted user comments — should be ignored
 	gh.addReviewComment(prNum, "random-bot", "do something", "fix.go", 1)
@@ -737,7 +737,7 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work := agent.state.ActiveIssues[77]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 77)]
 	if work == nil {
 		t.Fatal("issue 77 should be in state")
 	}
@@ -749,20 +749,20 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 
 	// First fix attempt
 	agent.ProcessCIFailures(ctx)
-	if agent.state.ActiveIssues[77].CIFixAttempts != 1 {
-		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[77].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts)
 	}
 
 	// CI still fails — second attempt
 	agent.ProcessCIFailures(ctx)
-	if agent.state.ActiveIssues[77].CIFixAttempts != 2 {
-		t.Errorf("expected 2 CI fix attempts, got %d", agent.state.ActiveIssues[77].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts != 2 {
+		t.Errorf("expected 2 CI fix attempts, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts)
 	}
 
 	// CI still fails — third attempt
 	agent.ProcessCIFailures(ctx)
-	if agent.state.ActiveIssues[77].CIFixAttempts != 3 {
-		t.Errorf("expected 3 CI fix attempts, got %d", agent.state.ActiveIssues[77].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts != 3 {
+		t.Errorf("expected 3 CI fix attempts, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts)
 	}
 
 	// Fourth attempt — should be blocked, comment posted
@@ -803,8 +803,8 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 		{ID: 2, Name: "test", Status: "completed", Conclusion: "success"},
 	})
 	// Reset attempts to simulate a fresh state after human fix
-	agent.state.ActiveIssues[77].CIFixAttempts = 0
-	agent.state.ActiveIssues[77].LastCIStatus = ""
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts = 0
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].LastCIStatus = ""
 
 	runner.mu.Lock()
 	callsBefore = len(runner.calls)
@@ -857,7 +857,7 @@ func TestIntegration_SyncWorktreePullsManualCommits(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work := agent.state.ActiveIssues[88]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 88)]
 	if work == nil {
 		t.Fatal("issue 88 should be in state")
 	}
@@ -922,7 +922,7 @@ func TestIntegration_CIFailureAfterNewPush(t *testing.T) {
 	agent.ProcessNewIssues(ctx)
 	runner.onClaudeRun = nil
 
-	work := agent.state.ActiveIssues[91]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 91)]
 	if work == nil {
 		t.Fatal("issue 91 should be in state")
 	}
@@ -935,8 +935,8 @@ func TestIntegration_CIFailureAfterNewPush(t *testing.T) {
 
 	// First CI fix attempt
 	agent.ProcessCIFailures(ctx)
-	if agent.state.ActiveIssues[91].CIFixAttempts != 1 {
-		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[91].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 91)].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 91)].CIFixAttempts)
 	}
 
 	// Simulate a new push to the PR (force push or new commit by human/external process)
@@ -951,12 +951,12 @@ func TestIntegration_CIFailureAfterNewPush(t *testing.T) {
 	agent.ProcessCIFailures(ctx)
 
 	// Verify that attempts counter was reset to 0 and then incremented to 1 (fresh investigation)
-	if agent.state.ActiveIssues[91].CIFixAttempts != 1 {
-		t.Errorf("expected CI fix attempts to be reset to 1 after new push, got %d", agent.state.ActiveIssues[91].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 91)].CIFixAttempts != 1 {
+		t.Errorf("expected CI fix attempts to be reset to 1 after new push, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 91)].CIFixAttempts)
 	}
 
 	// Verify the agent investigated the new SHA
-	work = agent.state.ActiveIssues[91]
+	work = agent.state.ActiveIssues[IssueKey("owner", "repo", 91)]
 	currentSHA, _ := ghClient.GetPRHeadSHA(ctx, "owner", "repo", prNum)
 	if work.LastCheckedCISHA != currentSHA {
 		t.Errorf("expected LastCheckedCISHA to be updated to %s, got %s", currentSHA, work.LastCheckedCISHA)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -102,8 +102,12 @@ func (a *Agent) RefreshToken(ctx context.Context) error {
 
 // runSequential executes a function on each item sequentially.
 // Each role entry runs within its own goroutine, so no worker pool is needed.
+// Stops early if the context is cancelled (e.g. during graceful shutdown).
 func runSequential[T any](ctx context.Context, items []T, fn func(context.Context, T)) {
 	for _, item := range items {
+		if ctx.Err() != nil {
+			return
+		}
 		fn(ctx, item)
 	}
 }
@@ -633,7 +637,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		// Priority: INFRASTRUCTURE > UNRELATED > RELATED (check in this order
 		// so RELATED doesn't match the "UNRELATED" substring).
 		foundKeyword := ""
-		for _, line := range strings.Split(cleaned, "\n") {
+		for line := range strings.SplitSeq(cleaned, "\n") {
 			trimmed := strings.TrimLeft(strings.TrimSpace(line), "*_-—:>")
 			switch {
 			case strings.HasPrefix(trimmed, "INFRASTRUCTURE"):
@@ -769,20 +773,20 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 						if matchErr != nil {
 							a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
 						} else {
-						matchResponse := strings.TrimSpace(matchResult.Result)
-						if matchedNum, ok := parseFlakyMatch(matchResponse); ok {
-							for _, existing := range existingIssues {
-								if existing.Number == matchedNum {
-									issueNum = matchedNum
-									break
+							matchResponse := strings.TrimSpace(matchResult.Result)
+							if matchedNum, ok := parseFlakyMatch(matchResponse); ok {
+								for _, existing := range existingIssues {
+									if existing.Number == matchedNum {
+										issueNum = matchedNum
+										break
+									}
+								}
+								if issueNum > 0 {
+									a.logger.Info("agent matched existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
+								} else {
+									a.logger.Warn("agent returned MATCH for unknown issue", "matched_issue", matchedNum, "check", task.failures[0].Name)
 								}
 							}
-							if issueNum > 0 {
-								a.logger.Info("agent matched existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
-							} else {
-								a.logger.Warn("agent returned MATCH for unknown issue", "matched_issue", matchedNum, "check", task.failures[0].Name)
-							}
-						}
 						}
 					}
 
@@ -1418,8 +1422,8 @@ func parseFlakyMatch(response string) (int, bool) {
 func parseFailingTest(explanation string) string {
 	for line := range strings.SplitSeq(explanation, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "FAILING_TEST:") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "FAILING_TEST:"))
+		if after, ok := strings.CutPrefix(line, "FAILING_TEST:"); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 	return ""
@@ -1759,12 +1763,10 @@ func (a *Agent) resolveConflictsParallel(ctx context.Context, tasks []conflictTa
 			// Post a hidden marker so deduplication skips this SHA on the next cycle
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
 				fmt.Sprintf("<!-- oompa-bot rebase:%s -->", shortSHA(task.headSHA)))
-		} else {
-			if !a.ShouldSkipComment("conflict") {
-				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-					fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), a.botComment())); err != nil {
-					a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
-				}
+		} else if !a.ShouldSkipComment("conflict") {
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), a.botComment())); err != nil {
+				a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
 			}
 		}
 	})

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -101,35 +100,12 @@ func (a *Agent) RefreshToken(ctx context.Context) error {
 	return nil
 }
 
-// runParallel executes a function on each item in parallel with a bounded worker pool.
-// If maxWorkers <= 1 or len(items) <= 1, runs sequentially instead.
-func runParallel[T any](ctx context.Context, maxWorkers int, items []T, fn func(context.Context, T)) {
-	if maxWorkers <= 1 || len(items) <= 1 {
-		for _, item := range items {
-			fn(ctx, item)
-		}
-		return
-	}
-
-	workers := min(len(items), maxWorkers)
-
-	sem := make(chan struct{}, workers)
-	var wg sync.WaitGroup
-
+// runSequential executes a function on each item sequentially.
+// Each role entry runs within its own goroutine, so no worker pool is needed.
+func runSequential[T any](ctx context.Context, items []T, fn func(context.Context, T)) {
 	for _, item := range items {
-		wg.Add(1)
-		sem <- struct{}{}
-
-		// Capture item for goroutine
-		item := item
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
-			fn(ctx, item)
-		}()
+		fn(ctx, item)
 	}
-
-	wg.Wait()
 }
 
 // NewAgent creates a new Agent with all dependencies wired.
@@ -187,7 +163,8 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 	var tasks []newIssueTask
 
 	for _, issue := range issues {
-		if work, exists := a.state.ActiveIssues[issue.Number]; exists {
+		issueKey := IssueKey(a.cfg.Owner, a.cfg.Repo, issue.Number)
+		if work, exists := a.state.ActiveIssues[issueKey]; exists {
 			// Re-check for PR if we lost track of it
 			if work.PRNumber == 0 && work.Status == StatusImplementing {
 				prs, err := a.gh.ListPRsByHead(ctx, a.cfg.Owner, a.cfg.Repo, a.cfg.GitHubHeadOwner, work.BranchName)
@@ -220,7 +197,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			openPR, hasMerged := classifyPRs(prs)
 			if openPR != nil {
 				a.logger.Info("PR already exists for issue", "issue", issue.Number, "pr", openPR.Number)
-				a.state.ActiveIssues[issue.Number] = &IssueWork{
+				a.state.ActiveIssues[issueKey] = &IssueWork{
 					IssueNumber: issue.Number,
 					IssueTitle:  issue.Title,
 					BranchName:  branchName,
@@ -279,7 +256,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		}
 
 		// Insert into state map before parallel phase
-		a.state.ActiveIssues[issue.Number] = work
+		a.state.ActiveIssues[issueKey] = work
 
 		tasks = append(tasks, newIssueTask{
 			issue:        issue,
@@ -290,7 +267,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 	}
 
 	// Parallel phase: run Claude, push, create PR
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task newIssueTask) {
+	runSequential(ctx, tasks, func(ctx context.Context, task newIssueTask) {
 		prompt := buildImplementationPrompt(task.issue, a.cfg.SignedOffBy)
 		_, err := a.codeAgent.Run(ctx, a.runner, task.worktreePath, prompt, a.logger, false)
 		if err != nil {
@@ -440,7 +417,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	}
 
 	// Parallel phase: run agent to address review feedback, then push changes
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task reviewTask) {
+	runSequential(ctx, tasks, func(ctx context.Context, task reviewTask) {
 		// Capture local HEAD before agent runs so we can detect if it committed directly
 		headBefore, _, err := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
 		if err != nil {
@@ -636,7 +613,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 	}
 
 	// Parallel phase: Claude invocations and post-processing
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task ciTask) {
+	runSequential(ctx, tasks, func(ctx context.Context, task ciTask) {
 		prompt := buildCIFixPrompt(*task.work, task.failures, task.diff, task.commits, a.cfg.SignedOffBy, a.cfg.SkipFix)
 		result, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
 		if err != nil {
@@ -1210,7 +1187,7 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 	}
 
 	// Investigate collected failed runs in parallel
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task triageRunTask) {
+	runSequential(ctx, tasks, func(ctx context.Context, task triageRunTask) {
 		a.investigateTriageRun(ctx, task.ciSource, task.run)
 	})
 }
@@ -1311,7 +1288,7 @@ func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, 
 
 // CleanupDone removes worktrees for merged or closed PRs.
 func (a *Agent) CleanupDone(ctx context.Context) {
-	for issueNum, work := range a.state.ActiveIssues {
+	for key, work := range a.state.ActiveIssues {
 		if work.PRNumber == 0 {
 			continue
 		}
@@ -1332,7 +1309,7 @@ func (a *Agent) CleanupDone(ctx context.Context) {
 			a.logger.Error("failed to remove worktree", "path", work.WorktreePath, "error", err)
 		}
 
-		delete(a.state.ActiveIssues, issueNum)
+		delete(a.state.ActiveIssues, key)
 	}
 }
 
@@ -1398,7 +1375,7 @@ func (a *Agent) BootstrapWatchedPRs(ctx context.Context) {
 			CreatedAt:    time.Now(),
 		}
 
-		a.state.ActiveIssues[prNumber] = work
+		a.state.ActiveIssues[IssueKey(a.cfg.Owner, a.cfg.Repo, prNumber)] = work
 		a.logger.Info("bootstrapped watched PR", "pr", prNumber, "branch", branchName, "title", pr.Title)
 	}
 }
@@ -1736,7 +1713,7 @@ func isConflictError(stderr string) bool {
 
 // resolveConflictsParallel invokes the coding agent to resolve conflicts for a list of tasks in parallel.
 func (a *Agent) resolveConflictsParallel(ctx context.Context, tasks []conflictTask) {
-	runParallel(ctx, a.cfg.MaxWorkers, tasks, func(ctx context.Context, task conflictTask) {
+	runSequential(ctx, tasks, func(ctx context.Context, task conflictTask) {
 		// Get commit count before invoking agent and validate capture
 		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
 		if commitsBefore == nil {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -253,7 +253,7 @@ func TestProcessNewIssues_SkipsAlreadyTracked(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{IssueNumber: 42, Status: "pr-open"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{IssueNumber: 42, Status: "pr-open"}
 
 	agent.ProcessNewIssues(context.Background())
 
@@ -274,7 +274,7 @@ func TestProcessNewIssues_RechecksForPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber: 42,
 		BranchName:  "ai/issue-42",
 		Status:      "implementing",
@@ -289,7 +289,7 @@ func TestProcessNewIssues_RechecksForPR(t *testing.T) {
 	}
 
 	// Should have found the PR
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.PRNumber != 100 {
 		t.Errorf("expected PRNumber 100, got %d", work.PRNumber)
 	}
@@ -313,7 +313,7 @@ func TestProcessNewIssues_HappyPath(t *testing.T) {
 		t.Errorf("expected branch 'ai/issue-42', got %v", wt.createdBranches)
 	}
 
-	work, ok := agent.state.ActiveIssues[42]
+	work, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if !ok {
 		t.Fatal("issue 42 not in state")
 	}
@@ -370,7 +370,7 @@ func TestProcessNewIssues_SkipsWhenPRExists(t *testing.T) {
 		t.Error("should not create worktree when PR already exists")
 	}
 
-	work, ok := agent.state.ActiveIssues[42]
+	work, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if !ok {
 		t.Fatal("issue 42 should be tracked")
 	}
@@ -399,7 +399,7 @@ func TestProcessNewIssues_ClaudeFailure(t *testing.T) {
 		t.Errorf("expected 1 comment (in-progress only, no error comment), got %d", len(gh.addedComments))
 	}
 
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work == nil || work.Status != "failed" {
 		t.Error("expected issue status to be 'failed'")
 	}
@@ -411,7 +411,7 @@ func TestProcessReviewComments_NoNewComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
 		PRNumber:      100,
 		Status:        "pr-open",
@@ -437,7 +437,7 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
 		IssueTitle:    "Fix bug",
 		PRNumber:      100,
@@ -458,8 +458,8 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
 
-	if agent.state.ActiveIssues[42].LastCommentID != 60 {
-		t.Errorf("expected lastCommentID 60, got %d", agent.state.ActiveIssues[42].LastCommentID)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID != 60 {
+		t.Errorf("expected lastCommentID 60, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID)
 	}
 }
 
@@ -474,7 +474,7 @@ func TestProcessReviewComments_SkipsNonWhitelistedUsers(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.Reviewers = []string{"trusted-reviewer"}
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
 		PRNumber:      100,
 		Status:        "pr-open",
@@ -501,7 +501,7 @@ func TestProcessReviewComments_AllowsAllWhenWhitelistEmpty(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	// No reviewers set — empty whitelist means allow all
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
 		IssueTitle:    "Fix bug",
 		PRNumber:      100,
@@ -553,7 +553,7 @@ func TestCleanupDone_MergedPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		Status:       "pr-open",
@@ -565,7 +565,7 @@ func TestCleanupDone_MergedPR(t *testing.T) {
 	if len(wt.removedPaths) != 1 || wt.removedPaths[0] != "/tmp/worktree" {
 		t.Errorf("expected worktree removal, got %v", wt.removedPaths)
 	}
-	if _, exists := agent.state.ActiveIssues[42]; exists {
+	if _, exists := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; exists {
 		t.Error("expected issue 42 to be removed from state")
 	}
 }
@@ -576,7 +576,7 @@ func TestCleanupDone_ClosedPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		Status:       "pr-open",
@@ -588,7 +588,7 @@ func TestCleanupDone_ClosedPR(t *testing.T) {
 	if len(wt.removedPaths) != 1 {
 		t.Error("expected worktree removal for closed PR")
 	}
-	if _, exists := agent.state.ActiveIssues[42]; exists {
+	if _, exists := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; exists {
 		t.Error("expected issue 42 to be removed from state")
 	}
 }
@@ -599,7 +599,7 @@ func TestCleanupDone_OpenPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		Status:       "pr-open",
@@ -611,7 +611,7 @@ func TestCleanupDone_OpenPR(t *testing.T) {
 	if len(wt.removedPaths) != 0 {
 		t.Error("should not remove worktree for open PR")
 	}
-	if _, exists := agent.state.ActiveIssues[42]; !exists {
+	if _, exists := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; !exists {
 		t.Error("should not remove open PR from state")
 	}
 }
@@ -628,7 +628,7 @@ func TestProcessCIFailures_FixesFailingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -648,8 +648,8 @@ func TestProcessCIFailures_FixesFailingCI(t *testing.T) {
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
-	if agent.state.ActiveIssues[42].CIFixAttempts != 1 {
-		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[42].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].CIFixAttempts)
 	}
 }
 
@@ -663,7 +663,7 @@ func TestProcessCIFailures_SkipsPassingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber: 42,
 		PRNumber:    100,
 		BranchName:  "ai/issue-42",
@@ -687,7 +687,7 @@ func TestProcessCIFailures_StopsAfterMaxRetries(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
 		IssueTitle:    "Fix bug",
 		PRNumber:      100,
@@ -716,7 +716,7 @@ func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber: 42,
 		PRNumber:    100,
 		BranchName:  "ai/issue-42",
@@ -745,7 +745,7 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true // Enable flaky issue creation
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -813,7 +813,7 @@ func TestProcessCIFailures_InfrastructureSkipsFlakyIssue(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true // Even with flaky issues enabled, INFRASTRUCTURE should skip
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -843,7 +843,7 @@ func TestProcessCIFailures_InfrastructureSkipsFlakyIssue(t *testing.T) {
 	}
 
 	// Verify state was updated correctly
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCIStatus != "infrastructure-failure" {
 		t.Errorf("expected LastCIStatus 'infrastructure-failure', got %q", work.LastCIStatus)
 	}
@@ -867,7 +867,7 @@ func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false // Disabled by default
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -904,7 +904,7 @@ func TestProcessCIFailures_SkipCommentCIUnrelated(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-unrelated"}
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -921,7 +921,7 @@ func TestProcessCIFailures_SkipCommentCIUnrelated(t *testing.T) {
 	}
 
 	// State should still be updated
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCIStatus != "unrelated-failure" {
 		t.Errorf("expected LastCIStatus 'unrelated-failure', got %q", work.LastCIStatus)
 	}
@@ -947,7 +947,7 @@ func TestProcessCIFailures_SkipCommentCIUnrelated_StillCreatesFlakyIssue(t *test
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-unrelated"}
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -987,7 +987,7 @@ func TestProcessCIFailures_SkipCommentCIInfrastructure(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-infrastructure"}
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1004,7 +1004,7 @@ func TestProcessCIFailures_SkipCommentCIInfrastructure(t *testing.T) {
 	}
 
 	// State should still be updated
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCIStatus != "infrastructure-failure" {
 		t.Errorf("expected LastCIStatus 'infrastructure-failure', got %q", work.LastCIStatus)
 	}
@@ -1030,7 +1030,7 @@ func TestProcessCIFailures_SkipCommentFlaky(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"flaky"}
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1075,7 +1075,7 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1124,7 +1124,7 @@ func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1173,7 +1173,7 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1222,7 +1222,7 @@ func TestProcessCIFailures_CreatesIssueWhenClaudeSaysNone(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1305,7 +1305,7 @@ func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:      42,
 		IssueTitle:       "Fix bug",
 		PRNumber:         100,
@@ -1344,7 +1344,7 @@ func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1357,8 +1357,8 @@ func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
 	if countClaudeCalls(runner.calls) != 0 {
 		t.Errorf("expected 0 claude calls (already reported via comment), got %d", countClaudeCalls(runner.calls))
 	}
-	if agent.state.ActiveIssues[42].LastCheckedCISHA != "abc1234567890" {
-		t.Errorf("expected LastCheckedCISHA to be recovered to abc1234567890, got %q", agent.state.ActiveIssues[42].LastCheckedCISHA)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCheckedCISHA != "abc1234567890" {
+		t.Errorf("expected LastCheckedCISHA to be recovered to abc1234567890, got %q", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCheckedCISHA)
 	}
 }
 
@@ -1374,7 +1374,7 @@ func TestProcessCIFailures_NoDuplicateCommentsOnRepeatedPolls(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1429,7 +1429,7 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -1448,7 +1448,7 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 	}
 
 	// Verify state was updated
-	work := agent.state.ActiveIssues[42]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCheckedCISHA != "abc123" {
 		t.Errorf("expected LastCheckedCISHA to be abc123, got %q", work.LastCheckedCISHA)
 	}
@@ -1537,7 +1537,7 @@ func TestBootstrapWatchedPRs_HappyPath(t *testing.T) {
 		t.Fatalf("expected 2 tracked PRs, got %d", len(agent.state.ActiveIssues))
 	}
 
-	work := agent.state.ActiveIssues[123]
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 123)]
 	if work == nil {
 		t.Fatal("PR 123 not tracked")
 	}
@@ -1554,7 +1554,7 @@ func TestBootstrapWatchedPRs_HappyPath(t *testing.T) {
 		t.Errorf("expected title 'Fix login', got %q", work.IssueTitle)
 	}
 
-	work2 := agent.state.ActiveIssues[456]
+	work2 := agent.state.ActiveIssues[IssueKey("owner", "repo", 456)]
 	if work2 == nil {
 		t.Fatal("PR 456 not tracked")
 	}
@@ -1589,7 +1589,7 @@ func TestBootstrapWatchedPRs_SkipsAlreadyTracked(t *testing.T) {
 	agent.cfg.WatchPRs = []int{123}
 
 	// Pre-populate state
-	agent.state.ActiveIssues[123] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 123)] = &IssueWork{
 		PRNumber: 123,
 		Status:   "pr-open",
 	}
@@ -1610,7 +1610,7 @@ func TestProcessConflicts_SkipsWhenBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1640,7 +1640,7 @@ func TestProcessRebase_RebasesWhenBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1677,7 +1677,7 @@ func TestProcessRebase_RebasesWhenUnstableButBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1707,7 +1707,7 @@ func TestProcessConflicts_SkipsUnstableNotBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1733,7 +1733,7 @@ func TestProcessRebase_SkipsUnstableNotBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1758,7 +1758,7 @@ func TestProcessRebase_SkipsDirty(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1790,7 +1790,7 @@ func TestProcessRebase_InvokesConflictResolutionWhenRebaseFails(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.codeAgent = codeAgent
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1873,7 +1873,7 @@ func TestProcessConflicts_SkipsCleanPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1900,7 +1900,7 @@ func TestProcessRebase_SkipCommentRebase(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"rebase"}
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -1936,7 +1936,7 @@ func TestProcessConflicts_SkipCommentConflict(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"conflict"}
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		PRNumber:     100,
 		BranchName:   "ai/issue-42",
@@ -2375,7 +2375,7 @@ func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,
@@ -2395,8 +2395,8 @@ func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call for commit status failure, got %d", claudeCalls)
 	}
-	if agent.state.ActiveIssues[42].CIFixAttempts != 1 {
-		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[42].CIFixAttempts)
+	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].CIFixAttempts != 1 {
+		t.Errorf("expected 1 CI fix attempt, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].CIFixAttempts)
 	}
 }
 
@@ -2415,7 +2415,7 @@ func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[42] = &IssueWork{
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:  42,
 		IssueTitle:   "Fix bug",
 		PRNumber:     100,

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -9,16 +9,22 @@ import (
 	"time"
 )
 
+// IssueKey returns the composite state key for an issue or PR number.
+// Format: "owner/repo#number" for cross-repo safety.
+func IssueKey(owner, repo string, number int) string {
+	return fmt.Sprintf("%s/%s#%d", owner, repo, number)
+}
+
 // State holds all active issue work in memory.
 type State struct {
-	ActiveIssues     map[int]*IssueWork
-	InvestigatedRuns map[string]bool // jobName:runID -> true
+	ActiveIssues     map[string]*IssueWork // key: "owner/repo#number"
+	InvestigatedRuns map[string]bool       // jobName:runID -> true
 }
 
 // NewState creates an empty state.
 func NewState() *State {
 	return &State{
-		ActiveIssues:     make(map[int]*IssueWork),
+		ActiveIssues:     make(map[string]*IssueWork),
 		InvestigatedRuns: make(map[string]bool),
 	}
 }
@@ -96,7 +102,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 				}
 			}
 
-			state.ActiveIssues[issue.Number] = work
+			state.ActiveIssues[IssueKey(cfg.Owner, cfg.Repo, issue.Number)] = work
 		}
 	}
 
@@ -133,7 +139,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 			CreatedAt:    time.Now(),
 		}
 
-		state.ActiveIssues[prNumber] = work
+		state.ActiveIssues[IssueKey(cfg.Owner, cfg.Repo, prNumber)] = work
 		logger.Info("recovered watched PR state", "pr", prNumber, "branch", pr.Head)
 	}
 

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -40,7 +40,7 @@ func TestBuildStateFromGitHub_RecoversPRState(t *testing.T) {
 
 	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
 
-	work, ok := state.ActiveIssues[42]
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if !ok {
 		t.Fatal("expected issue 42 in state")
 	}
@@ -63,7 +63,7 @@ func TestBuildStateFromGitHub_RecoversFailedState(t *testing.T) {
 
 	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
 
-	work, ok := state.ActiveIssues[99]
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 99)]
 	if !ok {
 		t.Fatal("expected issue 99 in state")
 	}
@@ -107,7 +107,7 @@ func TestBuildStateFromGitHub_WatchPRsSkipsLabeledIssues(t *testing.T) {
 		t.Errorf("expected 1 issue in state, got %d", len(state.ActiveIssues))
 	}
 
-	work, ok := state.ActiveIssues[313]
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 313)]
 	if !ok {
 		t.Fatal("expected watched PR 313 in state")
 	}
@@ -116,7 +116,7 @@ func TestBuildStateFromGitHub_WatchPRsSkipsLabeledIssues(t *testing.T) {
 	}
 
 	// PR 299 from the labeled issue should NOT be in state
-	if _, exists := state.ActiveIssues[123]; exists {
+	if _, exists := state.ActiveIssues[IssueKey("owner", "repo", 123)]; exists {
 		t.Error("labeled issue 123 should not be in state when watch-prs is configured")
 	}
 	for _, w := range state.ActiveIssues {


### PR DESCRIPTION
Fixes #121

## Summary

Replace the single-repo-per-process model with a YAML config file (`--config <path>`) that defines multiple projects in one oompa process. Each project/role runs as an independent goroutine with its own Agent and structured logger. Existing CLI flags are preserved for single-repo backward compatibility.

## Changes

- Add YAML config types and parser (`FileConfig`, `ProjectConfig`, role configs) with `LoadFileConfig()` validation and two-tier inheritance (project defaults + role overrides) in `pkg/agent/fileconfig.go`
- Change `State.ActiveIssues` key from `int` to `string` (`owner/repo#number`) for cross-repo safety via `IssueKey()` helper
- Remove `MaxWorkers` from Config, CLI flag, and worker pool — each role entry runs sequentially within its own goroutine (`runParallel` replaced with `runSequential`)
- Add per-role structured logging with `NewRoleLogger()` that scopes every log line with `project`, `role`, and per-role context fields (`watch_prs`, `label`, `triage_jobs`, `schedule`)
- Add multi-project orchestrator in `cmd/oompa/main.go` with goroutine-per-role-entry, `sync.WaitGroup`, two-signal graceful shutdown (first SIGINT/SIGTERM cancels context, second force-exits), and per-goroutine panic recovery
- Add internal triage scheduler with `ParseSchedule()` supporting daily (`HH:MM TZ`) and weekly (`HH:MM Weekday TZ`) schedules
- Add `--config` CLI flag and `OOMPA_CONFIG` env var; refactor auth/GCP setup into reusable functions
- Add `config.example.yaml` matching the issue's 5-project setup
- Add `gopkg.in/yaml.v3` dependency
- Add comprehensive tests for config loading, validation, two-tier inheritance, schedule parsing, role logger creation, and `IssueKey`

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #121

<!-- oompa-bot -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-project YAML configuration support with per-project authentication and repository paths
  * Scheduled triage jobs with timezone-aware scheduling
  * Per-role customization for PR watching, issue handling, and triage operations
  * Fork repository mapping configuration

* **Breaking Changes**
  * Removed `--max-workers` CLI flag and `OOMPA_MAX_WORKERS` environment variable support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->