### PR TITLE
feat: add triage-lookback field to YAML triage role config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,6 +40,7 @@ projects:
       - jobs:
           - https://prow.example.com/nightly
         schedule: "09:00 Europe/Madrid"
+        lookback: 24h
         create-flaky-issues: true
         flaky-label: ci-flake
 

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -68,6 +68,7 @@ type IssuesRoleConfig struct {
 type TriageRoleConfig struct {
 	Jobs              []string `yaml:"jobs"`
 	Schedule          string   `yaml:"schedule"`
+	Lookback          string   `yaml:"lookback"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
 	SkipComment       []string `yaml:"skip-comment"`
@@ -200,6 +201,15 @@ func validateFileConfig(cfg *FileConfig) error {
 			if triage.Schedule != "" {
 				if _, err := ParseSchedule(triage.Schedule, time.Now()); err != nil {
 					return fmt.Errorf("project %d (%s): triage[%d]: %w", i, p.Repo, j, err)
+				}
+			}
+			if triage.Lookback != "" {
+				d, err := time.ParseDuration(triage.Lookback)
+				if err != nil {
+					return fmt.Errorf("project %d (%s): triage[%d]: invalid lookback %q: %w", i, p.Repo, j, triage.Lookback, err)
+				}
+				if d < 0 {
+					return fmt.Errorf("project %d (%s): triage[%d]: lookback must be >= 0, got %q", i, p.Repo, j, triage.Lookback)
 				}
 			}
 			for _, c := range triage.SkipComment {
@@ -357,6 +367,12 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.FlakyLabel = stringOr(triage.FlakyLabel, projFlakyLabel)
 			cfg.SkipComments = stringsOr(triage.SkipComment, projSkipComment)
 			cfg.SkipFix = boolOr(triage.SkipFix, projSkipFix)
+			cfg.TriageLookback = globalCfg.TriageLookback
+			if triage.Lookback != "" {
+				if d, err := time.ParseDuration(triage.Lookback); err == nil {
+					cfg.TriageLookback = d
+				}
+			}
 			entries = append(entries, RoleEntry{
 				Config:   cfg,
 				Role:     "triage",

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -638,6 +638,104 @@ projects:
 	}
 }
 
+func TestLoadFileConfig_InvalidLookback(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        lookback: "not-a-duration"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid lookback duration")
+	}
+}
+
+func TestLoadFileConfig_NegativeLookback(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        lookback: "-1h"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for negative lookback duration")
+	}
+}
+
+func TestLoadFileConfig_ValidLookback(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        lookback: 24h
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error for valid lookback: %v", err)
+	}
+
+	if fc.Projects[0].Triage[0].Lookback != "24h" {
+		t.Errorf("expected lookback '24h', got %q", fc.Projects[0].Triage[0].Lookback)
+	}
+}
+
+func TestBuildRoleEntries_TriageLookback(t *testing.T) {
+	const (
+		defaultLookback  = 12 * time.Hour
+		overrideLookback = 24 * time.Hour
+	)
+
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo: "owner/repo",
+				Triage: []TriageRoleConfig{
+					{
+						Jobs:     []string{"https://ci.example.com/job1"},
+						Lookback: "24h", // Override global default
+					},
+					{
+						Jobs: []string{"https://ci.example.com/job2"},
+						// No lookback — should inherit global default
+					},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode", TriageLookback: defaultLookback})
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// First triage entry overrides with role-level lookback
+	if entries[0].Config.TriageLookback != overrideLookback {
+		t.Errorf("expected TriageLookback %v, got %v", overrideLookback, entries[0].Config.TriageLookback)
+	}
+
+	// Second triage entry inherits global default lookback
+	if entries[1].Config.TriageLookback != defaultLookback {
+		t.Errorf("expected TriageLookback %v, got %v", defaultLookback, entries[1].Config.TriageLookback)
+	}
+}
+
 func TestLoadFileConfig_UnknownKeysRejected(t *testing.T) {
 	yaml := `
 agent: opencode


### PR DESCRIPTION
Fixes #124

## Summary

Add `lookback` field to `TriageRoleConfig` in the YAML config, allowing per-triage-role configuration of the lookback time window (equivalent to the `--triage-lookback` CLI flag).

## Changes

- Add `Lookback string` field to `TriageRoleConfig` struct with `yaml:"lookback"` tag
- Parse the field as `time.Duration` in `BuildRoleEntries` and set `cfg.TriageLookback`
- Add validation in `validateFileConfig` to reject invalid duration strings
- Add tests: invalid lookback validation, valid lookback parsing, and `BuildRoleEntries` lookback propagation
- Update `config.example.yaml` with `lookback: 24h` example

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #124

<!-- oompa-bot v:0c9ea30 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `lookback` parameter for triage operations, enabling users to specify the time window for analyzing and triaging failures.

* **Configuration**
  * Triage job configurations now support a `lookback` duration setting (accepts duration format like "24h").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->