### PR TITLE
feat: add per-project reviewers field to YAML config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,6 +45,8 @@ projects:
         flaky-label: ci-flake
 
   - repo: openshift/hypershift
+    # Project-level reviewers — inherited by all roles in this project
+    reviewers: [coderabbitai[bot], nunnatsa, orenc1]
     prs:
       - watch: [8365]
         reactions: [ci, conflicts, rebase]
@@ -52,3 +54,5 @@ projects:
   - repo: qinqon/oompa
     issues:
       - label: good-for-ai
+        # Role-level reviewers override project-level (and global)
+        reviewers: [qinqon, gemini-code-assist[bot], coderabbitai[bot]]

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -36,6 +36,7 @@ type ProjectConfig struct {
 	Reactions         []string `yaml:"reactions"`
 	Label             string   `yaml:"label"`
 	OnlyAssigned      *bool    `yaml:"only-assigned"`
+	Reviewers         []string `yaml:"reviewers"` // whitelist of users/bots whose reviews to address
 
 	// Role arrays
 	PRs    []PRsRoleConfig    `yaml:"prs"`
@@ -51,6 +52,7 @@ type PRsRoleConfig struct {
 	SkipFix           *bool    `yaml:"skip-fix"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
+	Reviewers         []string `yaml:"reviewers"` // overrides project-level reviewers
 }
 
 // IssuesRoleConfig represents a single Issues role entry.
@@ -62,6 +64,7 @@ type IssuesRoleConfig struct {
 	Fork              string   `yaml:"fork"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
+	Reviewers         []string `yaml:"reviewers"` // overrides project-level reviewers
 }
 
 // TriageRoleConfig represents a single Triage role entry.
@@ -73,6 +76,7 @@ type TriageRoleConfig struct {
 	FlakyLabel        string   `yaml:"flaky-label"`
 	SkipComment       []string `yaml:"skip-comment"`
 	SkipFix           *bool    `yaml:"skip-fix"`
+	Reviewers         []string `yaml:"reviewers"` // overrides project-level reviewers
 }
 
 // LoadFileConfig reads and parses a YAML config file, returning the validated FileConfig.
@@ -294,6 +298,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		projReactions := p.Reactions
 		projLabel := stringOr(p.Label, "good-for-ai")
 		projOnlyAssigned := boolOr(p.OnlyAssigned, false)
+		projReviewers := stringsOr(p.Reviewers, globalCfg.Reviewers)
 
 		// Base config for this project (shared fields)
 		baseCfg := Config{
@@ -315,7 +320,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			GitAuthorName:   globalCfg.GitAuthorName,
 			GitAuthorEmail:  globalCfg.GitAuthorEmail,
 			SignedOffBy:     globalCfg.SignedOffBy,
-			Reviewers:       globalCfg.Reviewers,
+			Reviewers:       projReviewers,
 			Version:         globalCfg.Version,
 			// GitHub App auth (shared)
 			GitHubAppID:             globalCfg.GitHubAppID,
@@ -337,6 +342,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.SkipFix = boolOr(pr.SkipFix, projSkipFix)
 			cfg.CreateFlakyIssues = boolOr(pr.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(pr.FlakyLabel, projFlakyLabel)
+			cfg.Reviewers = stringsOr(pr.Reviewers, projReviewers)
 			entries = append(entries, RoleEntry{Config: cfg, Role: "prs"})
 		}
 
@@ -349,6 +355,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.SkipComments = stringsOr(issue.SkipComment, projSkipComment)
 			cfg.CreateFlakyIssues = boolOr(issue.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(issue.FlakyLabel, projFlakyLabel)
+			cfg.Reviewers = stringsOr(issue.Reviewers, projReviewers)
 			// Issues can override fork
 			if issue.Fork != "" {
 				forkParts := strings.SplitN(issue.Fork, "/", 2)
@@ -373,6 +380,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 					cfg.TriageLookback = d
 				}
 			}
+			cfg.Reviewers = stringsOr(triage.Reviewers, projReviewers)
 			entries = append(entries, RoleEntry{
 				Config:   cfg,
 				Role:     "triage",

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -496,6 +496,138 @@ func TestNewRoleLogger_Triage(t *testing.T) {
 	}
 }
 
+func TestBuildRoleEntries_ReviewersInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo:      "owner/repo",
+				Reviewers: []string{"proj-reviewer1", "proj-reviewer2"},
+				PRs: []PRsRoleConfig{
+					{
+						Watch: []int{1},
+						// Inherits project-level reviewers
+					},
+					{
+						Watch:     []int{2},
+						Reviewers: []string{"role-reviewer"}, // Override
+					},
+				},
+				Issues: []IssuesRoleConfig{
+					{
+						Label: "ai",
+						// Inherits project-level reviewers
+					},
+					{
+						Label:     "special",
+						Reviewers: []string{"issue-reviewer"}, // Override
+					},
+				},
+				Triage: []TriageRoleConfig{
+					{
+						Jobs: []string{"https://ci.example.com/job1"},
+						// Inherits project-level reviewers
+					},
+					{
+						Jobs:      []string{"https://ci.example.com/job2"},
+						Reviewers: []string{"triage-reviewer"}, // Override
+					},
+				},
+			},
+			{
+				Repo: "org/noproj",
+				PRs:  []PRsRoleConfig{{Watch: []int{10}}},
+				// No project-level reviewers — inherits global
+			},
+		},
+	}
+
+	globalCfg := Config{
+		Agent:     "claudecode",
+		Reviewers: []string{"global-reviewer"},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", globalCfg)
+	if len(entries) != 7 {
+		t.Fatalf("expected 7 entries, got %d", len(entries))
+	}
+
+	// PRs[0]: inherits project-level reviewers
+	if len(entries[0].Config.Reviewers) != 2 || entries[0].Config.Reviewers[0] != "proj-reviewer1" {
+		t.Errorf("PRs[0]: expected project reviewers, got %v", entries[0].Config.Reviewers)
+	}
+
+	// PRs[1]: overrides with role-level reviewers
+	if len(entries[1].Config.Reviewers) != 1 || entries[1].Config.Reviewers[0] != "role-reviewer" {
+		t.Errorf("PRs[1]: expected role reviewers, got %v", entries[1].Config.Reviewers)
+	}
+
+	// Issues[0]: inherits project-level reviewers
+	if len(entries[2].Config.Reviewers) != 2 || entries[2].Config.Reviewers[0] != "proj-reviewer1" {
+		t.Errorf("Issues[0]: expected project reviewers, got %v", entries[2].Config.Reviewers)
+	}
+
+	// Issues[1]: overrides with role-level reviewers
+	if len(entries[3].Config.Reviewers) != 1 || entries[3].Config.Reviewers[0] != "issue-reviewer" {
+		t.Errorf("Issues[1]: expected role reviewers, got %v", entries[3].Config.Reviewers)
+	}
+
+	// Triage[0]: inherits project-level reviewers
+	if len(entries[4].Config.Reviewers) != 2 || entries[4].Config.Reviewers[0] != "proj-reviewer1" {
+		t.Errorf("Triage[0]: expected project reviewers, got %v", entries[4].Config.Reviewers)
+	}
+
+	// Triage[1]: overrides with role-level reviewers
+	if len(entries[5].Config.Reviewers) != 1 || entries[5].Config.Reviewers[0] != "triage-reviewer" {
+		t.Errorf("Triage[1]: expected role reviewers, got %v", entries[5].Config.Reviewers)
+	}
+
+	// Second project PRs[0]: no project reviewers, inherits global
+	if len(entries[6].Config.Reviewers) != 1 || entries[6].Config.Reviewers[0] != "global-reviewer" {
+		t.Errorf("Project2 PRs[0]: expected global reviewers, got %v", entries[6].Config.Reviewers)
+	}
+}
+
+func TestLoadFileConfig_WithReviewers(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    reviewers: [alice, bob]
+    prs:
+      - watch: [1]
+        reviewers: [charlie]
+    issues:
+      - label: ai
+        reviewers: [dave]
+    triage:
+      - jobs: [https://ci.example.com/job]
+        reviewers: [eve]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p := fc.Projects[0]
+	if len(p.Reviewers) != 2 || p.Reviewers[0] != "alice" || p.Reviewers[1] != "bob" {
+		t.Errorf("expected project reviewers [alice bob], got %v", p.Reviewers)
+	}
+	if len(p.PRs[0].Reviewers) != 1 || p.PRs[0].Reviewers[0] != "charlie" {
+		t.Errorf("expected prs reviewers [charlie], got %v", p.PRs[0].Reviewers)
+	}
+	if len(p.Issues[0].Reviewers) != 1 || p.Issues[0].Reviewers[0] != "dave" {
+		t.Errorf("expected issues reviewers [dave], got %v", p.Issues[0].Reviewers)
+	}
+	if len(p.Triage[0].Reviewers) != 1 || p.Triage[0].Reviewers[0] != "eve" {
+		t.Errorf("expected triage reviewers [eve], got %v", p.Triage[0].Reviewers)
+	}
+}
+
 func TestIssueKey(t *testing.T) {
 	key := IssueKey("owner", "repo", 42)
 	if key != "owner/repo#42" {


### PR DESCRIPTION
Fixes #123

## Summary

Add per-project and per-role `reviewers` field to YAML config, enabling different projects to have different reviewer whitelists instead of relying solely on the global `--reviewers` CLI flag.

## Changes

- Add `Reviewers []string` field to `ProjectConfig`, `PRsRoleConfig`, and `IssuesRoleConfig` in `fileconfig.go`
- Wire three-tier inheritance in `BuildRoleEntries`: global CLI flag -> project-level -> role-level override (follows the existing pattern used by `reactions`, `skip-comment`, etc.)
- Add `TestBuildRoleEntries_ReviewersInheritance` test covering all inheritance levels (global, project, role override)
- Add `TestLoadFileConfig_WithReviewers` test for YAML parsing of the new field
- Update `config.example.yaml` with `reviewers` usage examples

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes

## Related Issues

Fixes #123

<!-- oompa-bot v:0c9ea30 -->