### PR TITLE
bug: oompa no longer replies to PR review threads after addressing feedback

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -437,35 +437,66 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		}
 
 		// Push if agent made changes (uncommitted or committed directly)
+		pushed, changeDetected := false, false
 		hasChanges := a.hasUncommittedChanges(ctx, task.work.WorktreePath)
+		changeDetected = hasChanges
 		if hasChanges {
 			if err := a.gitAmendAll(ctx, task.work.WorktreePath); err != nil {
 				a.logger.Error("failed to amend commit", "pr", task.work.PRNumber, "error", err)
 			} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 				a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
+			} else {
+				pushed = true
 			}
 		} else {
 			headAfter, _, revErr := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
 			headSHAAfter := strings.TrimSpace(string(headAfter))
 			if revErr == nil && headSHABefore != "" && headSHAAfter != headSHABefore {
+				changeDetected = true
 				a.logger.Info("agent committed directly, pushing", "pr", task.work.PRNumber)
 				if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 					a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
+				} else {
+					pushed = true
 				}
 			}
 		}
 
-		// Update last seen comment ID
+		// Reply to each review comment thread.
+		// Skip replies when changes were detected but push failed to avoid misleading messages.
+		// Only advance the comment cursor for comments where the reply was posted successfully,
+		// so that failed replies are retried on the next poll cycle.
+		allRepliesPosted := true
 		for _, c := range task.humanComments {
-			if c.ID > task.work.LastCommentID {
-				task.work.LastCommentID = c.ID
+			var replyBody string
+			switch {
+			case pushed:
+				replyBody = "Addressed in the latest push."
+			case !changeDetected:
+				replyBody = "Reviewed — no code changes needed."
+			default:
+				allRepliesPosted = false
+				continue // Push failed for detected changes; skip reply to avoid misleading message
+			}
+			if err := a.gh.ReplyToPRComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, c.ID, replyBody); err != nil {
+				a.logger.Warn("failed to reply to PR comment", "comment", c.ID, "error", err)
+				allRepliesPosted = false
 			}
 		}
 
-		// Update last seen review ID
-		for _, r := range task.humanReviews {
-			if r.ID > task.work.LastReviewID {
-				task.work.LastReviewID = r.ID
+		// Only advance cursors when all replies were posted successfully.
+		// If any reply was skipped or failed, keep the old cursor so the
+		// comments are retried on the next poll cycle.
+		if allRepliesPosted {
+			for _, c := range task.humanComments {
+				if c.ID > task.work.LastCommentID {
+					task.work.LastCommentID = c.ID
+				}
+			}
+			for _, r := range task.humanReviews {
+				if r.ID > task.work.LastReviewID {
+					task.work.LastReviewID = r.ID
+				}
 			}
 		}
 	})

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -35,6 +35,7 @@ type mockGitHubClient struct {
 	workflowRuns    []WorkflowRun // workflow runs to return from ListWorkflowRuns
 
 	listIssuesErr error
+	replyErr      error // error to return from ReplyToPRComment
 }
 
 func (m *mockGitHubClient) ListLabeledIssues(_ context.Context, _, _, _ string) ([]Issue, error) {
@@ -124,6 +125,9 @@ func (m *mockGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, 
 }
 
 func (m *mockGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, _ int, commentID int64, body string) error {
+	if m.replyErr != nil {
+		return m.replyErr
+	}
 	m.addedComments = append(m.addedComments, fmt.Sprintf("reply:%d:%s", commentID, body))
 	return nil
 }
@@ -461,6 +465,85 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID != 60 {
 		t.Errorf("expected lastCommentID 60, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID)
 	}
+
+	// Verify reply was posted to the review comment with correct content.
+	// In this test the mock runner returns empty stdout for git commands,
+	// so no changes are detected and the reply should say "no code changes needed".
+	expectedReply := "reply:60:Reviewed — no code changes needed."
+	foundReply := slices.Contains(gh.addedComments, expectedReply)
+	if !foundReply {
+		t.Errorf("expected reply %q, got comments: %v", expectedReply, gh.addedComments)
+	}
+}
+
+func TestProcessReviewComments_PushFailureDoesNotAdvanceCursor(t *testing.T) {
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	// Runner returns non-empty stdout (triggers changeDetected) and an error (causes push to fail)
+	runner := &mockCommandRunner{stdout: []byte("dirty"), err: fmt.Errorf("git failed")}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	// Use sequentialMockCodeAgent so the agent call succeeds despite the broken runner
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// No replies should be posted (push failed with detected changes)
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:") {
+			t.Errorf("expected no reply when push failed, got: %s", comment)
+		}
+	}
+
+	// Cursor should NOT advance since replies were skipped
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 50 {
+		t.Errorf("expected LastCommentID to stay at 50, got %d", work.LastCommentID)
+	}
+}
+
+func TestProcessReviewComments_ReplyFailureDoesNotAdvanceCursor(t *testing.T) {
+	implResult := streamResultJSON(AgentResult{Result: "Done"})
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+		replyErr: fmt.Errorf("GitHub API error"),
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{implResult}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Cursor should NOT advance since reply failed
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 50 {
+		t.Errorf("expected LastCommentID to stay at 50, got %d", work.LastCommentID)
+	}
 }
 
 func TestProcessReviewComments_SkipsNonWhitelistedUsers(t *testing.T) {
@@ -545,7 +628,6 @@ func (m *sequentialMockCodeAgent) Run(_ context.Context, _ CommandRunner, _, pro
 	}
 	return AgentResult{}, fmt.Errorf("unexpected call %d", idx)
 }
-
 
 func TestCleanupDone_MergedPR(t *testing.T) {
 	gh := &mockGitHubClient{prState: "merged"}


### PR DESCRIPTION
Fixes #128

## Summary

Re-add reply comments to PR review threads after oompa addresses feedback. Commit `2f4134a` removed the built-in reply logic assuming `/ce-resolve-pr-feedback` would handle it, but it doesn't post replies back to GitHub.

## Changes

- Track whether code changes were pushed in `ProcessReviewComments`
- After the agent finishes, reply to each review comment thread via `ReplyToPRComment`:
  - "Addressed in the latest push." when changes were pushed
  - "Reviewed — no code changes needed." when no changes were pushed
- Add test assertion in `TestProcessReviewComments_AddressesHumanComments` verifying replies are posted

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #128

<!-- oompa-bot v:14b504a -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now posts status replies to review comments, confirming when code updates are pushed, notifying when no changes are detected, and logging errors gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->