### PR TITLE
feat: support Prow presubmit job triage via pr-logs/directory/ symlink index

### DIFF
--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -477,9 +477,14 @@ func (g *GCSDirectoryJobSource) ListRecentRuns(ctx context.Context, limit int) (
 			continue
 		}
 
-		// Resolve target build path from metadata
-		link, ok := item.Metadata["x-goog-meta-link"]
-		if !ok {
+		// Resolve target build path from metadata.
+		// GCS JSON API exposes custom metadata with bare keys (e.g. "link"),
+		// while the x-goog-meta- prefix is used in XML API / HTTP headers.
+		link := item.Metadata["link"]
+		if link == "" {
+			link = item.Metadata["x-goog-meta-link"]
+		}
+		if link == "" {
 			continue
 		}
 

--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -29,11 +29,19 @@ type CIJobSource interface {
 func ParseCIJobURL(jobURL string, ghClient GitHubClient) (CIJobSource, error) {
 	// GCS-backed CI: any URL containing /view/gs/{bucket}/{prefix}
 	if strings.Contains(jobURL, "/view/gs/") {
+		bucket, prefix := extractBucketPrefix(jobURL)
+		if strings.HasPrefix(prefix, "pr-logs/directory/") {
+			return newGCSDirectoryJobSource(bucket, prefix)
+		}
 		return parseGCSJobURL(jobURL)
 	}
 
 	// GCS-backed CI: direct GCS URL (https://storage.googleapis.com/...)
 	if strings.Contains(jobURL, "storage.googleapis.com") {
+		bucket, prefix := extractDirectGCSBucketPrefix(jobURL)
+		if strings.HasPrefix(prefix, "pr-logs/directory/") {
+			return newGCSDirectoryJobSource(bucket, prefix)
+		}
 		return parseDirectGCSURL(jobURL)
 	}
 
@@ -43,6 +51,41 @@ func ParseCIJobURL(jobURL string, ghClient GitHubClient) (CIJobSource, error) {
 	}
 
 	return nil, fmt.Errorf("unrecognized CI job URL format: %s", jobURL)
+}
+
+// extractBucketPrefix extracts bucket and prefix from a /view/gs/ URL.
+func extractBucketPrefix(jobURL string) (bucket, prefix string) {
+	_, after, ok := strings.Cut(jobURL, "/view/gs/")
+	if !ok {
+		return "", ""
+	}
+	parts := strings.SplitN(after, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	prefix = parts[1]
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return parts[0], prefix
+}
+
+// extractDirectGCSBucketPrefix extracts bucket and prefix from a storage.googleapis.com URL.
+func extractDirectGCSBucketPrefix(jobURL string) (bucket, prefix string) {
+	parsedURL, err := url.Parse(jobURL)
+	if err != nil {
+		return "", ""
+	}
+	path := strings.TrimPrefix(parsedURL.Path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], ""
+	}
+	prefix = parts[1]
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return parts[0], prefix
 }
 
 // parseGCSJobURL parses a Prow-style GCS URL like:
@@ -292,6 +335,265 @@ func (g *GCSJobSource) fetchFinishedJSON(ctx context.Context, buildID string) (s
 
 func (g *GCSJobSource) FetchLog(ctx context.Context, runID string) (string, error) {
 	logURL := fmt.Sprintf("https://storage.googleapis.com/%s/%s%s/build-log.txt", g.bucket, g.prefix, runID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", logURL, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("creating log request: %w", err)
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching log: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("log fetch failed (status %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading log: %w", err)
+	}
+
+	return string(body), nil
+}
+
+// gcsRef holds a resolved GCS bucket and prefix for a symlink-based build directory.
+type gcsRef struct {
+	bucket string
+	prefix string // e.g. "pr-logs/pull/org_repo/PR/job/buildID/"
+}
+
+// GCSDirectoryJobSource implements CIJobSource for Prow presubmit jobs listed
+// via the pr-logs/directory/ symlink index. Each entry is a .txt object whose
+// x-goog-meta-link metadata points to the actual build directory.
+type GCSDirectoryJobSource struct {
+	bucket       string
+	prefix       string            // e.g. "pr-logs/directory/pull-job-name/"
+	jobName      string
+	client       *http.Client
+	resolvedRuns map[string]gcsRef // buildID → resolved bucket+prefix
+}
+
+// newGCSDirectoryJobSource creates a GCSDirectoryJobSource from bucket and prefix.
+func newGCSDirectoryJobSource(bucket, prefix string) (*GCSDirectoryJobSource, error) {
+	if bucket == "" || prefix == "" {
+		return nil, fmt.Errorf("invalid GCS directory URL: bucket=%q prefix=%q", bucket, prefix)
+	}
+
+	// Extract job name from prefix (last non-empty path component)
+	jobName := strings.TrimSuffix(prefix, "/")
+	if idx := strings.LastIndex(jobName, "/"); idx >= 0 {
+		jobName = jobName[idx+1:]
+	}
+
+	return &GCSDirectoryJobSource{
+		bucket:       bucket,
+		prefix:       prefix,
+		jobName:      jobName,
+		client:       &http.Client{Timeout: 30 * time.Second},
+		resolvedRuns: make(map[string]gcsRef),
+	}, nil
+}
+
+func (g *GCSDirectoryJobSource) JobName() string {
+	return g.jobName
+}
+
+// gcsDirectoryListResponse is the JSON response from the GCS list API
+// when listing objects (not prefixes) in a directory index.
+type gcsDirectoryListResponse struct {
+	Items         []gcsDirectoryItem `json:"items"`
+	NextPageToken string             `json:"nextPageToken"`
+}
+
+// gcsDirectoryItem represents an object in the GCS list response.
+type gcsDirectoryItem struct {
+	Name     string            `json:"name"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+func (g *GCSDirectoryJobSource) ListRecentRuns(ctx context.Context, limit int) ([]JobRun, error) {
+	// Clear resolved runs for fresh listing
+	g.resolvedRuns = make(map[string]gcsRef)
+
+	var allItems []gcsDirectoryItem
+	pageToken := ""
+
+	// Paginate through all items in the directory index
+	for {
+		listURL := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=%s",
+			url.PathEscape(g.bucket), url.PathEscape(g.prefix))
+		if pageToken != "" {
+			listURL += "&pageToken=" + url.QueryEscape(pageToken)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", listURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating list request: %w", err)
+		}
+
+		resp, err := g.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("listing GCS directory: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("GCS directory list failed (status %d): %s", resp.StatusCode, string(body))
+		}
+
+		var listResp gcsDirectoryListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decoding GCS directory list response: %w", err)
+		}
+		resp.Body.Close()
+
+		allItems = append(allItems, listResp.Items...)
+
+		if listResp.NextPageToken == "" {
+			break
+		}
+		pageToken = listResp.NextPageToken
+	}
+
+	// Process items: extract build IDs and resolve target paths
+	var runs []JobRun
+	for _, item := range allItems {
+		// Extract build ID from object name: strip prefix and .txt suffix
+		name := strings.TrimPrefix(item.Name, g.prefix)
+		if !strings.HasSuffix(name, ".txt") {
+			continue
+		}
+		buildID := strings.TrimSuffix(name, ".txt")
+		if buildID == "" {
+			continue
+		}
+
+		// Resolve target build path from metadata
+		link, ok := item.Metadata["x-goog-meta-link"]
+		if !ok {
+			continue
+		}
+
+		ref, err := parseGCSURI(link)
+		if err != nil {
+			continue
+		}
+
+		g.resolvedRuns[buildID] = ref
+
+		// Fetch finished.json from the resolved path
+		status, timestamp, err := g.fetchFinishedJSON(ctx, ref)
+		if err != nil {
+			// Skip builds without finished.json (still running or incomplete)
+			continue
+		}
+
+		runs = append(runs, JobRun{
+			ID:        buildID,
+			JobName:   g.jobName,
+			Status:    status,
+			Timestamp: timestamp,
+			LogURL:    fmt.Sprintf("https://storage.googleapis.com/%s/%sbuild-log.txt", ref.bucket, ref.prefix),
+		})
+	}
+
+	// Sort by timestamp descending
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].Timestamp.After(runs[j].Timestamp)
+	})
+
+	// Return up to limit
+	if len(runs) > limit {
+		runs = runs[:limit]
+	}
+
+	return runs, nil
+}
+
+// parseGCSURI parses a gs:// URI into a gcsRef.
+func parseGCSURI(uri string) (gcsRef, error) {
+	if !strings.HasPrefix(uri, "gs://") {
+		return gcsRef{}, fmt.Errorf("not a gs:// URI: %s", uri)
+	}
+	rest := strings.TrimPrefix(uri, "gs://")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) < 2 {
+		return gcsRef{}, fmt.Errorf("invalid gs:// URI (no path): %s", uri)
+	}
+	prefix := parts[1]
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return gcsRef{
+		bucket: parts[0],
+		prefix: prefix,
+	}, nil
+}
+
+func (g *GCSDirectoryJobSource) fetchFinishedJSON(ctx context.Context, ref gcsRef) (string, time.Time, error) {
+	finishedURL := fmt.Sprintf("https://storage.googleapis.com/%s/%sfinished.json", ref.bucket, ref.prefix)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", finishedURL, http.NoBody)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	var finished gcsFinishedJSON
+	if err := json.NewDecoder(resp.Body).Decode(&finished); err != nil {
+		return "", time.Time{}, err
+	}
+
+	// Determine status from finished.json
+	status := "failure"
+	if finished.Passed != nil && *finished.Passed {
+		status = "success"
+	} else if strings.ToUpper(finished.Result) == "SUCCESS" {
+		status = "success"
+	}
+
+	// Use timestamp from finished.json if available
+	timestamp := time.Time{}
+	if finished.Timestamp > 0 {
+		timestamp = time.Unix(finished.Timestamp, 0)
+	} else {
+		// Fallback: try to fetch started.json
+		startedURL := fmt.Sprintf("https://storage.googleapis.com/%s/%sstarted.json", ref.bucket, ref.prefix)
+		startedReq, _ := http.NewRequestWithContext(ctx, "GET", startedURL, http.NoBody)
+		startedResp, err := g.client.Do(startedReq)
+		if err == nil && startedResp.StatusCode == http.StatusOK {
+			var started gcsStartedJSON
+			if json.NewDecoder(startedResp.Body).Decode(&started) == nil && started.Timestamp > 0 {
+				timestamp = time.Unix(started.Timestamp, 0)
+			}
+			startedResp.Body.Close()
+		}
+	}
+
+	return status, timestamp, nil
+}
+
+func (g *GCSDirectoryJobSource) FetchLog(ctx context.Context, runID string) (string, error) {
+	ref, ok := g.resolvedRuns[runID]
+	if !ok {
+		return "", fmt.Errorf("unknown run ID %q (not resolved during ListRecentRuns)", runID)
+	}
+
+	logURL := fmt.Sprintf("https://storage.googleapis.com/%s/%sbuild-log.txt", ref.bucket, ref.prefix)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", logURL, http.NoBody)
 	if err != nil {

--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -319,14 +319,18 @@ func (g *GCSJobSource) fetchFinishedJSON(ctx context.Context, buildID string) (s
 	} else {
 		// Fallback: try to fetch started.json
 		startedURL := fmt.Sprintf("https://storage.googleapis.com/%s/%s%s/started.json", g.bucket, g.prefix, buildID)
-		startedReq, _ := http.NewRequestWithContext(ctx, "GET", startedURL, http.NoBody)
-		startedResp, err := g.client.Do(startedReq)
-		if err == nil && startedResp.StatusCode == http.StatusOK {
-			var started gcsStartedJSON
-			if json.NewDecoder(startedResp.Body).Decode(&started) == nil && started.Timestamp > 0 {
-				timestamp = time.Unix(started.Timestamp, 0)
+		startedReq, err := http.NewRequestWithContext(ctx, "GET", startedURL, http.NoBody)
+		if err == nil {
+			startedResp, err := g.client.Do(startedReq)
+			if err == nil {
+				defer startedResp.Body.Close()
+				if startedResp.StatusCode == http.StatusOK {
+					var started gcsStartedJSON
+					if json.NewDecoder(startedResp.Body).Decode(&started) == nil && started.Timestamp > 0 {
+						timestamp = time.Unix(started.Timestamp, 0)
+					}
+				}
 			}
-			startedResp.Body.Close()
 		}
 	}
 
@@ -573,14 +577,18 @@ func (g *GCSDirectoryJobSource) fetchFinishedJSON(ctx context.Context, ref gcsRe
 	} else {
 		// Fallback: try to fetch started.json
 		startedURL := fmt.Sprintf("https://storage.googleapis.com/%s/%sstarted.json", ref.bucket, ref.prefix)
-		startedReq, _ := http.NewRequestWithContext(ctx, "GET", startedURL, http.NoBody)
-		startedResp, err := g.client.Do(startedReq)
-		if err == nil && startedResp.StatusCode == http.StatusOK {
-			var started gcsStartedJSON
-			if json.NewDecoder(startedResp.Body).Decode(&started) == nil && started.Timestamp > 0 {
-				timestamp = time.Unix(started.Timestamp, 0)
+		startedReq, err := http.NewRequestWithContext(ctx, "GET", startedURL, http.NoBody)
+		if err == nil {
+			startedResp, err := g.client.Do(startedReq)
+			if err == nil {
+				defer startedResp.Body.Close()
+				if startedResp.StatusCode == http.StatusOK {
+					var started gcsStartedJSON
+					if json.NewDecoder(startedResp.Body).Decode(&started) == nil && started.Timestamp > 0 {
+						timestamp = time.Unix(started.Timestamp, 0)
+					}
+				}
 			}
-			startedResp.Body.Close()
 		}
 	}
 

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -259,13 +259,13 @@ func TestGCSDirectoryJobSource_ListRecentRuns(t *testing.T) {
 					{
 						Name: "pr-logs/directory/pull-job/111.txt",
 						Metadata: map[string]string{
-							"x-goog-meta-link": "gs://test-bucket/pr-logs/pull/org_repo/10/pull-job/111",
+							"link": "gs://test-bucket/pr-logs/pull/org_repo/10/pull-job/111",
 						},
 					},
 					{
 						Name: "pr-logs/directory/pull-job/222.txt",
 						Metadata: map[string]string{
-							"x-goog-meta-link": "gs://test-bucket/pr-logs/pull/org_repo/20/pull-job/222",
+							"link": "gs://test-bucket/pr-logs/pull/org_repo/20/pull-job/222",
 						},
 					},
 					{

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -1,6 +1,11 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -124,5 +129,278 @@ func TestParseGitHubActionsURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseGCSDirectoryURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		url         string
+		wantBucket  string
+		wantPrefix  string
+		wantJobName string
+		wantErr     bool
+	}{
+		{
+			name:        "valid pr-logs/directory URL via /view/gs/",
+			url:         "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-cluster-network-addons-operator-unit-test/",
+			wantBucket:  "kubevirt-prow",
+			wantPrefix:  "pr-logs/directory/pull-cluster-network-addons-operator-unit-test/",
+			wantJobName: "pull-cluster-network-addons-operator-unit-test",
+			wantErr:     false,
+		},
+		{
+			name:        "valid pr-logs/directory URL without trailing slash",
+			url:         "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-job-name",
+			wantBucket:  "kubevirt-prow",
+			wantPrefix:  "pr-logs/directory/pull-job-name/",
+			wantJobName: "pull-job-name",
+			wantErr:     false,
+		},
+		{
+			name:        "valid pr-logs/directory URL via storage.googleapis.com",
+			url:         "https://storage.googleapis.com/kubevirt-prow/pr-logs/directory/pull-job-name/",
+			wantBucket:  "kubevirt-prow",
+			wantPrefix:  "pr-logs/directory/pull-job-name/",
+			wantJobName: "pull-job-name",
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			source, err := ParseCIJobURL(tc.url, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			dirSource, ok := source.(*GCSDirectoryJobSource)
+			if !ok {
+				t.Fatalf("expected *GCSDirectoryJobSource, got %T", source)
+			}
+			if dirSource.bucket != tc.wantBucket {
+				t.Errorf("bucket = %q, want %q", dirSource.bucket, tc.wantBucket)
+			}
+			if dirSource.prefix != tc.wantPrefix {
+				t.Errorf("prefix = %q, want %q", dirSource.prefix, tc.wantPrefix)
+			}
+			if dirSource.jobName != tc.wantJobName {
+				t.Errorf("jobName = %q, want %q", dirSource.jobName, tc.wantJobName)
+			}
+		})
+	}
+}
+
+func TestParseGCSDirectoryURL_DetectedByParseCIJobURL(t *testing.T) {
+	testCases := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "pr-logs/directory via /view/gs/ routes to GCSDirectoryJobSource",
+			url:  "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-job-name/",
+		},
+		{
+			name: "pr-logs/directory via storage.googleapis.com routes to GCSDirectoryJobSource",
+			url:  "https://storage.googleapis.com/kubevirt-prow/pr-logs/directory/pull-job-name/",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			source, err := ParseCIJobURL(tc.url, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, ok := source.(*GCSDirectoryJobSource); !ok {
+				t.Errorf("expected *GCSDirectoryJobSource, got %T", source)
+			}
+		})
+	}
+
+	// Non-directory GCS URLs should still route to GCSJobSource
+	nonDirURL := "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-job/"
+	source, err := ParseCIJobURL(nonDirURL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error for non-directory URL: %v", err)
+	}
+	if _, ok := source.(*GCSJobSource); !ok {
+		t.Errorf("expected *GCSJobSource for non-directory URL, got %T", source)
+	}
+}
+
+func TestGCSDirectoryJobSource_ListRecentRuns(t *testing.T) {
+	passed := true
+	finishedJSON := gcsFinishedJSON{
+		Passed:    &passed,
+		Result:    "SUCCESS",
+		Timestamp: 1700000000,
+	}
+	finishedBytes, _ := json.Marshal(finishedJSON)
+
+	failedFinishedJSON := gcsFinishedJSON{
+		Passed:    func() *bool { b := false; return &b }(),
+		Result:    "FAILURE",
+		Timestamp: 1699999000,
+	}
+	failedFinishedBytes, _ := json.Marshal(failedFinishedJSON)
+
+	// Mock server that serves GCS API responses
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		// GCS list API
+		case "/storage/v1/b/test-bucket/o":
+			resp := gcsDirectoryListResponse{
+				Items: []gcsDirectoryItem{
+					{
+						Name: "pr-logs/directory/pull-job/111.txt",
+						Metadata: map[string]string{
+							"x-goog-meta-link": "gs://test-bucket/pr-logs/pull/org_repo/10/pull-job/111",
+						},
+					},
+					{
+						Name: "pr-logs/directory/pull-job/222.txt",
+						Metadata: map[string]string{
+							"x-goog-meta-link": "gs://test-bucket/pr-logs/pull/org_repo/20/pull-job/222",
+						},
+					},
+					{
+						Name: "pr-logs/directory/pull-job/333.txt",
+						// Missing metadata — should be skipped
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		// finished.json for build 111 (success, newer)
+		case "/test-bucket/pr-logs/pull/org_repo/10/pull-job/111/finished.json":
+			_, _ = w.Write(finishedBytes)
+
+		// finished.json for build 222 (failure, older)
+		case "/test-bucket/pr-logs/pull/org_repo/20/pull-job/222/finished.json":
+			_, _ = w.Write(failedFinishedBytes)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source := &GCSDirectoryJobSource{
+		bucket:       "test-bucket",
+		prefix:       "pr-logs/directory/pull-job/",
+		jobName:      "pull-job",
+		client:       server.Client(),
+		resolvedRuns: make(map[string]gcsRef),
+	}
+
+	// Override the GCS URLs to point to our test server
+	// We do this by replacing the source's client with a transport that rewrites URLs
+	source.client = &http.Client{
+		Transport: &rewriteTransport{base: server.URL},
+	}
+
+	runs, err := source.ListRecentRuns(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have 2 runs (333 skipped due to missing metadata)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+
+	// Sorted by timestamp descending: build 111 (1700000000) before build 222 (1699999000)
+	if runs[0].ID != "111" {
+		t.Errorf("first run ID = %q, want %q", runs[0].ID, "111")
+	}
+	if runs[0].Status != "success" {
+		t.Errorf("first run status = %q, want %q", runs[0].Status, "success")
+	}
+	if runs[1].ID != "222" {
+		t.Errorf("second run ID = %q, want %q", runs[1].ID, "222")
+	}
+	if runs[1].Status != "failure" {
+		t.Errorf("second run status = %q, want %q", runs[1].Status, "failure")
+	}
+
+	// Verify resolved runs are stored
+	if _, ok := source.resolvedRuns["111"]; !ok {
+		t.Error("expected resolved run for build 111")
+	}
+	if _, ok := source.resolvedRuns["222"]; !ok {
+		t.Error("expected resolved run for build 222")
+	}
+
+	// Verify limit
+	runs, err = source.ListRecentRuns(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error with limit: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run with limit=1, got %d", len(runs))
+	}
+	if runs[0].ID != "111" {
+		t.Errorf("limited run ID = %q, want %q (most recent)", runs[0].ID, "111")
+	}
+}
+
+func TestGCSDirectoryJobSource_FetchLog(t *testing.T) {
+	expectedLog := "build log content here"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/test-bucket/pr-logs/pull/org_repo/10/pull-job/111/build-log.txt" {
+			fmt.Fprint(w, expectedLog)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	source := &GCSDirectoryJobSource{
+		bucket:  "test-bucket",
+		prefix:  "pr-logs/directory/pull-job/",
+		jobName: "pull-job",
+		client: &http.Client{
+			Transport: &rewriteTransport{base: server.URL},
+		},
+		resolvedRuns: map[string]gcsRef{
+			"111": {
+				bucket: "test-bucket",
+				prefix: "pr-logs/pull/org_repo/10/pull-job/111/",
+			},
+		},
+	}
+
+	log, err := source.FetchLog(context.Background(), "111")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if log != expectedLog {
+		t.Errorf("log = %q, want %q", log, expectedLog)
+	}
+
+	// Fetching unknown run ID should fail
+	_, err = source.FetchLog(context.Background(), "999")
+	if err == nil {
+		t.Error("expected error for unknown run ID, got nil")
+	}
+}
+
+// rewriteTransport rewrites all request URLs to point to a test server.
+type rewriteTransport struct {
+	base string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to the test server, keeping the path
+	req.URL.Scheme = "http"
+	req.URL.Host = t.base[len("http://"):]
+	return http.DefaultTransport.RoundTrip(req)
 }
 


### PR DESCRIPTION
Fixes #132

## Summary

Add `GCSDirectoryJobSource` to support triaging Prow presubmit jobs via the `pr-logs/directory/` symlink index. This enables oompa to scan flaky presubmit CI failures across all PRs in a repo, the same way it already scans periodic jobs.

## Changes

- Add `GCSDirectoryJobSource` struct implementing `CIJobSource` for presubmit directory indexes
- Add `gcsRef` type to hold resolved bucket/prefix for symlink-based build directories
- Add `parseGCSURI` helper to parse `gs://` URIs from `x-goog-meta-link` metadata
- Add `extractBucketPrefix` and `extractDirectGCSBucketPrefix` helpers for URL parsing
- Update `ParseCIJobURL` to detect `pr-logs/directory/` prefix and route to the new source
- Add `ListRecentRuns` with GCS JSON API pagination, metadata-based symlink resolution, and `finished.json` fetching
- Add `FetchLog` using resolved target paths from `ListRecentRuns`
- Add 4 tests: URL parsing, routing detection, list+sort, and log fetching (with HTTP test server)

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #132

<!-- oompa-bot v:2a63401 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Prow directory index URL format in CI job detection.
  * Introduced new CI backend for handling directory-based job sources with improved build log retrieval and run status detection.

* **Tests**
  * Expanded test coverage for URL parsing and CI source behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->