### PR TITLE
bug: triage role scans all repo issues due to empty label in BuildStateFromGitHub

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -157,6 +157,10 @@ func NewAgent(gh GitHubClient, runner CommandRunner, worktrees WorktreeManager, 
 
 // ProcessNewIssues finds labeled issues and spawns Claude to implement fixes.
 func (a *Agent) ProcessNewIssues(ctx context.Context) {
+	if a.cfg.Label == "" {
+		return
+	}
+
 	issues, err := a.gh.ListLabeledIssues(ctx, a.cfg.Owner, a.cfg.Repo, a.cfg.Label)
 	if err != nil {
 		a.logger.Error("failed to list issues", "error", err)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -34,11 +34,13 @@ type mockGitHubClient struct {
 	searchResults   []Issue       // results to return from SearchIssues
 	workflowRuns    []WorkflowRun // workflow runs to return from ListWorkflowRuns
 
-	listIssuesErr error
-	replyErr      error // error to return from ReplyToPRComment
+	listIssuesCalled bool  // tracks whether ListLabeledIssues was called
+	listIssuesErr    error
+	replyErr         error // error to return from ReplyToPRComment
 }
 
 func (m *mockGitHubClient) ListLabeledIssues(_ context.Context, _, _, _ string) ([]Issue, error) {
+	m.listIssuesCalled = true
 	return m.issues, m.listIssuesErr
 }
 
@@ -406,6 +408,26 @@ func TestProcessNewIssues_ClaudeFailure(t *testing.T) {
 	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work == nil || work.Status != "failed" {
 		t.Error("expected issue status to be 'failed'")
+	}
+}
+
+func TestProcessNewIssues_EmptyLabelSkips(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Should not be processed"}},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.Label = "" // Triage role: no label set
+
+	agent.ProcessNewIssues(context.Background())
+
+	if gh.listIssuesCalled {
+		t.Error("ListLabeledIssues should not be called when label is empty")
+	}
+	if len(agent.state.ActiveIssues) != 0 {
+		t.Error("no issues should be processed when label is empty")
 	}
 }
 

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -47,7 +47,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 
 	// Skip labeled issue scanning when --watch-prs is configured
 	// (watch mode bypasses issue discovery)
-	if len(cfg.WatchPRs) == 0 {
+	if len(cfg.WatchPRs) == 0 && cfg.Label != "" {
 		issues, err := gh.ListLabeledIssues(ctx, cfg.Owner, cfg.Repo, cfg.Label)
 		if err != nil {
 			logger.Error("failed to list issues for state rebuild", "error", err)

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -46,7 +46,8 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 	state := NewState()
 
 	// Skip labeled issue scanning when --watch-prs is configured
-	// (watch mode bypasses issue discovery)
+	// (watch mode bypasses issue discovery) or when no label is set
+	// (triage roles have no label and should not scan for issues)
 	if len(cfg.WatchPRs) == 0 && cfg.Label != "" {
 		issues, err := gh.ListLabeledIssues(ctx, cfg.Owner, cfg.Repo, cfg.Label)
 		if err != nil {

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -126,6 +126,23 @@ func TestBuildStateFromGitHub_WatchPRsSkipsLabeledIssues(t *testing.T) {
 	}
 }
 
+func TestBuildStateFromGitHub_EmptyLabelSkipsScan(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues: []Issue{
+			{Number: 42, Title: "Unrelated issue", Labels: []string{"ai-failed"}},
+			{Number: 99, Title: "Another issue", Labels: []string{"ai-failed"}},
+		},
+	}
+	// Triage role: no label set, no watch PRs
+	cfg := Config{Owner: "owner", Repo: "repo", Label: ""}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	if len(state.ActiveIssues) != 0 {
+		t.Errorf("expected empty state when label is empty, got %d issues", len(state.ActiveIssues))
+	}
+}
+
 func TestState_MarkRunInvestigated(t *testing.T) {
 	s := NewState()
 


### PR DESCRIPTION
Fixes #133

## Summary

Fix triage role accidentally scanning all repo issues due to empty label in `BuildStateFromGitHub`. When `cfg.Label` is empty, `ListLabeledIssues` passes `Labels: []string{""}` to the GitHub API, which returns all open issues -- causing unrelated `ai-failed` issues to be recovered into state.

## Changes

- Add `cfg.Label != ""` guard to the labeled-issue scan condition in `BuildStateFromGitHub` (`pkg/agent/state.go:50`)
- Add `TestBuildStateFromGitHub_EmptyLabelSkipsScan` test verifying that an empty label config produces empty state

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #133

<!-- oompa-bot v:2a63401 -->