### PR TITLE
bug: review feedback creates new commits instead of amending into existing PR commits

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -442,9 +442,22 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 
 		// Push if agent made changes (uncommitted or committed directly)
 		pushed, changeDetected := false, false
-		hasChanges := a.hasUncommittedChanges(ctx, task.work.WorktreePath)
-		changeDetected = hasChanges
-		if hasChanges {
+		hasFixups := a.hasFixupCommits(ctx, task.work.WorktreePath)
+		hasUncommitted := a.hasUncommittedChanges(ctx, task.work.WorktreePath)
+
+		switch {
+		case hasFixups:
+			// Agent created fixup commits — autosquash them into their targets
+			changeDetected = true
+			if err := a.gitAutosquashRebase(ctx, task.work.WorktreePath); err != nil {
+				a.logger.Error("failed to autosquash fixup commits", "pr", task.work.PRNumber, "error", err)
+			} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+				a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
+			} else {
+				pushed = true
+			}
+		case hasUncommitted:
+			changeDetected = true
 			if err := a.gitAmendAll(ctx, task.work.WorktreePath); err != nil {
 				a.logger.Error("failed to amend commit", "pr", task.work.PRNumber, "error", err)
 			} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
@@ -452,13 +465,21 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			} else {
 				pushed = true
 			}
-		} else {
+		default:
 			headAfter, _, revErr := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
 			headSHAAfter := strings.TrimSpace(string(headAfter))
 			if revErr == nil && headSHABefore != "" && headSHAAfter != headSHABefore {
 				changeDetected = true
-				a.logger.Info("agent committed directly, pushing", "pr", task.work.PRNumber)
-				if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
+				// Agent committed directly — squash new commits into the original HEAD
+				// to avoid polluting commit history with "Address PR review feedback" commits.
+				a.logger.Info("agent committed directly, squashing into original HEAD", "pr", task.work.PRNumber)
+				if err := a.gitSquashInto(ctx, task.work.WorktreePath, headSHABefore); err != nil {
+					a.logger.Error("failed to squash agent commits, skipping push to avoid unsquashed commits", "pr", task.work.PRNumber, "error", err)
+					// Restore HEAD so the worktree is usable on the next attempt
+					if _, _, resetErr := a.runner.Run(ctx, task.work.WorktreePath, "git", "reset", "--hard", headSHAAfter); resetErr != nil {
+						a.logger.Error("failed to restore HEAD after squash failure", "pr", task.work.PRNumber, "error", resetErr)
+					}
+				} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 					a.logger.Error("failed to push", "pr", task.work.PRNumber, "error", err)
 				} else {
 					pushed = true
@@ -1603,6 +1624,28 @@ func (a *Agent) gitAmendAll(ctx context.Context, worktreePath string) error {
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "add", "-A"); err != nil {
 		return fmt.Errorf("git add: %w (stderr: %s)", err, string(stderr))
 	}
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
+		return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
+	}
+	return nil
+}
+
+// gitSquashInto squashes all commits after the given SHA into that commit.
+// Used to fold agent-created review feedback commits back into the original HEAD.
+func (a *Agent) gitSquashInto(ctx context.Context, worktreePath, targetSHA string) error {
+	if a.cfg.DryRun {
+		a.logger.Info("[dry-run] would squash into", "worktree", worktreePath, "target", shortSHA(targetSHA))
+		return nil
+	}
+	// Stage all changes first to capture any unstaged modifications the agent left behind
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "add", "-A"); err != nil {
+		return fmt.Errorf("git add: %w (stderr: %s)", err, string(stderr))
+	}
+	// Reset to the target SHA while keeping all changes staged
+	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "reset", "--soft", targetSHA); err != nil {
+		return fmt.Errorf("git reset --soft %s: %w (stderr: %s)", shortSHA(targetSHA), err, string(stderr))
+	}
+	// Amend the target commit with the staged changes
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
 		return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -34,7 +34,7 @@ type mockGitHubClient struct {
 	searchResults   []Issue       // results to return from SearchIssues
 	workflowRuns    []WorkflowRun // workflow runs to return from ListWorkflowRuns
 
-	listIssuesCalled bool  // tracks whether ListLabeledIssues was called
+	listIssuesCalled bool // tracks whether ListLabeledIssues was called
 	listIssuesErr    error
 	replyErr         error // error to return from ReplyToPRComment
 }
@@ -649,6 +649,170 @@ func (m *sequentialMockCodeAgent) Run(_ context.Context, _ CommandRunner, _, pro
 		return m.results[idx].result, m.results[idx].err
 	}
 	return AgentResult{}, fmt.Errorf("unexpected call %d", idx)
+}
+
+func TestProcessReviewComments_SquashesAgentCommits(t *testing.T) {
+	// When the agent commits directly (HEAD changes), ProcessReviewComments should
+	// squash the new commits into the original HEAD via git reset --soft + amend.
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	// Use a custom runner that simulates the agent committing directly
+	// by returning different SHAs for sequential git rev-parse HEAD calls.
+	runner := &reviewSquashRunner{
+		mockCommandRunner: &mockCommandRunner{},
+		headSHAs:          []string{"original-sha", "agent-committed-sha"},
+	}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Verify git add -A, git reset --soft, and git commit --amend were called
+	foundAdd := false
+	foundReset := false
+	foundAmend := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 1 && c.Args[0] == "add" {
+			foundAdd = true
+		}
+		if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "reset" && c.Args[1] == "--soft" && c.Args[2] == "original-sha" {
+			foundReset = true
+		}
+		if c.Name == "git" && len(c.Args) >= 2 && c.Args[0] == "commit" && c.Args[1] == "--amend" {
+			foundAmend = true
+		}
+	}
+
+	if !foundAdd {
+		t.Error("expected git add -A to stage all changes before squashing")
+	}
+	if !foundReset {
+		t.Error("expected git reset --soft <original-sha> to squash agent commits")
+	}
+	if !foundAmend {
+		t.Error("expected git commit --amend to fold changes into original commit")
+	}
+
+	// Cursor should advance (push succeeded)
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 60 {
+		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
+	}
+}
+
+// reviewSquashRunner is a test helper that returns different SHAs for sequential
+// git rev-parse HEAD calls, simulating an agent that commits directly.
+type reviewSquashRunner struct {
+	*mockCommandRunner
+	headSHAs  []string
+	headIndex int
+}
+
+func (r *reviewSquashRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	// Record the call in the base mock
+	r.mockCommandRunner.Run(ctx, workDir, name, args...) //nolint:errcheck // recording call for test assertions
+
+	// Return different SHAs for git rev-parse HEAD
+	if name == "git" && len(args) >= 2 && args[0] == "rev-parse" && args[1] == "HEAD" {
+		if r.headIndex < len(r.headSHAs) {
+			sha := r.headSHAs[r.headIndex]
+			r.headIndex++
+			return []byte(sha + "\n"), nil, nil
+		}
+		return []byte("unknown-sha\n"), nil, nil
+	}
+
+	// For git status --porcelain, return empty (no uncommitted changes)
+	if name == "git" && len(args) >= 1 && args[0] == "status" {
+		return []byte(""), nil, nil
+	}
+
+	// For git log (fixup commit check), return empty (no fixup commits)
+	if name == "git" && len(args) >= 1 && args[0] == "log" {
+		return []byte(""), nil, nil
+	}
+
+	return nil, nil, nil
+}
+
+func TestProcessReviewComments_AutosquashesFixupCommits(t *testing.T) {
+	// When the agent creates fixup commits, ProcessReviewComments should
+	// autosquash them rather than pushing separate commits.
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	runner := &reviewFixupRunner{
+		mockCommandRunner: &mockCommandRunner{},
+	}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Verify autosquash rebase was called
+	foundAutosquash := false
+	for _, c := range runner.calls {
+		if c.Name == "sh" && len(c.Args) >= 2 && strings.Contains(c.Args[1], "autosquash") {
+			foundAutosquash = true
+		}
+	}
+
+	if !foundAutosquash {
+		t.Error("expected autosquash rebase to be called for fixup commits")
+	}
+}
+
+// reviewFixupRunner is a test helper that simulates an agent creating fixup commits.
+type reviewFixupRunner struct {
+	*mockCommandRunner
+}
+
+func (r *reviewFixupRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	r.mockCommandRunner.Run(ctx, workDir, name, args...) //nolint:errcheck // recording call for test assertions
+
+	// For git log --format=%s (fixup commit check), return a fixup commit
+	if name == "git" && len(args) >= 1 && args[0] == "log" {
+		if slices.Contains(args, "--format=%s") {
+			return []byte("fixup! original commit\n"), nil, nil
+		}
+		return []byte(""), nil, nil
+	}
+
+	// For git status --porcelain, return empty (no uncommitted changes)
+	if name == "git" && len(args) >= 1 && args[0] == "status" {
+		return []byte(""), nil, nil
+	}
+
+	return nil, nil, nil
 }
 
 func TestCleanupDone_MergedPR(t *testing.T) {

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -77,7 +77,8 @@ Instructions:
 1. Use /ce-resolve-pr-feedback to evaluate and address all review feedback.
 2. Run "make lint" and "make test" to verify your changes.
 
-Do NOT commit, push, or amend — the agent handles that automatically.`)
+CRITICAL: Do NOT commit, push, or amend — the agent handles git operations automatically.
+If you make code changes, leave them UNCOMMITTED. Do NOT run "git add", "git commit", or "git push".`)
 
 	return prompt.String()
 }

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -92,6 +92,7 @@ func TestBuildReviewResponsePrompt(t *testing.T) {
 		"</user-provided-content>",
 		"untrusted user input",
 		"Do NOT commit",
+		"leave them UNCOMMITTED",
 	}
 
 	for _, want := range checks {


### PR DESCRIPTION
Fixes #136

## Summary

Fix review feedback creating new commits instead of amending into existing PR commits. When the agent addresses review feedback, new commits are now squashed into the original HEAD instead of being pushed as separate "Address PR review feedback" commits.

## Changes

- Add `gitSquashInto` helper that uses `git reset --soft` + `git commit --amend` to fold new commits into a target SHA
- Refactor `ProcessReviewComments` post-agent logic to use a three-way switch matching the CI fix path:
  1. Fixup commits detected: autosquash rebase (new)
  2. Uncommitted changes: amend into HEAD (existing)
  3. Agent committed directly: squash into original HEAD (new, was previously pushed as-is)
- Strengthen the review response prompt to explicitly tell the agent to leave changes uncommitted
- Add tests for squash and autosquash behavior

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #136

<!-- oompa-bot v:4bf2dc8 -->