### PR TITLE
bug: CI failures missed when oompa polls before check runs are registered

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -572,6 +572,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			// No check runs registered yet — don't mark as checked.
 			// This avoids the vacuous-truth bug where allCompleted is true
 			// (its initial value) because the loop over runs never executed.
+			a.logger.Debug("no check runs registered yet, waiting", "pr", work.PRNumber, "sha", shortSHA(headSHA))
 			continue
 		}
 		if len(failures) == 0 {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -568,7 +568,13 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			}
 		}
 
-		if len(runs) == 0 || len(failures) == 0 {
+		if len(runs) == 0 {
+			// No check runs registered yet — don't mark as checked.
+			// This avoids the vacuous-truth bug where allCompleted is true
+			// (its initial value) because the loop over runs never executed.
+			continue
+		}
+		if len(failures) == 0 {
 			// If all checks completed with no failures and this SHA was already
 			// checked, skip. Only set LastCheckedCISHA when all checks are done
 			// to avoid skipping late-finishing failures.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -865,6 +865,47 @@ func TestProcessCIFailures_NoRunsDoesNotMarkChecked(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_NoRunsThenFailuresAreInvestigated(t *testing.T) {
+	// Issue #139 end-to-end regression: when no check runs exist on poll 1,
+	// LastCheckedCISHA must stay empty so that poll 2 (when runs appear with
+	// a failure) actually invokes Claude instead of silently skipping.
+	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed CI"})
+	gh := &mockGitHubClient{
+		checkRuns:  []CheckRun{}, // empty on first poll
+		prHeadSHAs: []string{"sha1", "sha1", "sha1"},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	// Poll 1: no runs yet — must not mark SHA as checked
+	agent.ProcessCIFailures(context.Background())
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCheckedCISHA != "" {
+		t.Fatalf("poll 1: expected LastCheckedCISHA empty, got %q", work.LastCheckedCISHA)
+	}
+	if countClaudeCalls(runner.calls) != 0 {
+		t.Fatalf("poll 1: expected 0 claude calls, got %d", countClaudeCalls(runner.calls))
+	}
+
+	// Poll 2: CI runs now registered with a failure
+	gh.checkRuns = []CheckRun{
+		{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+	}
+	agent.ProcessCIFailures(context.Background())
+	if countClaudeCalls(runner.calls) != 1 {
+		t.Errorf("poll 2: expected 1 claude call, got %d", countClaudeCalls(runner.calls))
+	}
+}
+
 func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED\nFAILING_TEST: TestDB/connection_timeout\nThe test database connection times out intermittently"})
 	gh := &mockGitHubClient{

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -834,6 +834,37 @@ func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
 	}
 }
 
+func TestProcessCIFailures_NoRunsDoesNotMarkChecked(t *testing.T) {
+	// Issue #139: When no check runs are registered yet (e.g., oompa polls
+	// before GitHub registers CI), allCompleted is vacuously true. The agent
+	// must NOT set LastCheckedCISHA in this case, otherwise real CI failures
+	// that appear later will be skipped by the fast path.
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{}, // No check runs registered yet
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber: 42,
+		PRNumber:    100,
+		BranchName:  "ai/issue-42",
+		Status:      "pr-open",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	if len(runner.calls) != 0 {
+		t.Error("should not invoke claude when no check runs exist")
+	}
+
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCheckedCISHA != "" {
+		t.Errorf("expected LastCheckedCISHA to remain empty when no check runs registered, got %q", work.LastCheckedCISHA)
+	}
+}
+
 func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED\nFAILING_TEST: TestDB/connection_timeout\nThe test database connection times out intermittently"})
 	gh := &mockGitHubClient{


### PR DESCRIPTION
Fixes #139

## Summary

Fix a bug where oompa prematurely marks a commit SHA as "fully checked" when polling before GitHub has registered any CI check runs, causing real CI failures to be silently skipped.

## Changes

- Separate the `len(runs) == 0` case from the `len(failures) == 0` case in `ProcessCIFailures` (`loop.go`). When no check runs are registered yet, continue polling without setting `LastCheckedCISHA`.
- Add `TestProcessCIFailures_NoRunsDoesNotMarkChecked` to verify that `LastCheckedCISHA` remains empty when no check runs exist.

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #139

<!-- oompa-bot v:4bf2dc8 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a logic error where the system incorrectly treated an absence of GitHub check runs as successful completion of all checks. The system now properly distinguishes between "no runs present" and "all runs completed successfully."

* **Tests**
  * Added test coverage to verify correct behavior in cases where GitHub provides no check runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->