### PR TITLE
bug: rebase fails when worktree has unstaged changes from upstream file deletions

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -1056,8 +1056,8 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		// Fetch all remotes and try automatic rebase against the upstream default branch
 		a.runner.Run(ctx, work.WorktreePath, "git", "fetch", "--all") //nolint:errcheck // best-effort
 
-		// Try automatic rebase
-		_, stderr, rebaseErr := a.runner.Run(ctx, work.WorktreePath, "git", "rebase", a.originDefaultBranch())
+		// Try automatic rebase (with retry on unstaged changes)
+		stderr, rebaseErr := a.gitRebaseWithRetry(ctx, work.WorktreePath, work.PRNumber)
 		if rebaseErr == nil {
 			// Rebase succeeded, force push
 			if pushErr := a.gitPush(ctx, work.WorktreePath, true); pushErr != nil {
@@ -1074,13 +1074,13 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 
 		// Rebase failed — abort and let Claude try
 		a.runner.Run(ctx, work.WorktreePath, "git", "rebase", "--abort") //nolint:errcheck // best-effort
-		a.logger.Info("automatic rebase failed, invoking Claude to resolve conflicts", "pr", work.PRNumber, "stderr", string(stderr))
+		a.logger.Info("automatic rebase failed, invoking Claude to resolve conflicts", "pr", work.PRNumber, "stderr", stderr)
 
 		tasks = append(tasks, conflictTask{
 			work:         work,
 			headSHA:      headSHA,
 			rebaseErr:    rebaseErr,
-			rebaseStderr: string(stderr),
+			rebaseStderr: stderr,
 		})
 	}
 
@@ -1138,22 +1138,22 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 
 		a.runner.Run(ctx, work.WorktreePath, "git", "fetch", "--all") //nolint:errcheck // best-effort
 
-		_, stderr, rebaseErr := a.runner.Run(ctx, work.WorktreePath, "git", "rebase", a.originDefaultBranch())
+		stderr, rebaseErr := a.gitRebaseWithRetry(ctx, work.WorktreePath, work.PRNumber)
 		if rebaseErr != nil {
 			a.runner.Run(ctx, work.WorktreePath, "git", "rebase", "--abort") //nolint:errcheck // best-effort
 
 			// Check if the rebase failed due to conflicts
-			if isConflictError(string(stderr)) {
+			if isConflictError(stderr) {
 				a.logger.Info("rebase failed with conflicts, will invoke conflict resolution", "pr", work.PRNumber)
 				tasks = append(tasks, conflictTask{
 					work:         work,
 					headSHA:      headSHA,
 					rebaseErr:    rebaseErr,
-					rebaseStderr: string(stderr),
+					rebaseStderr: stderr,
 				})
 			} else {
 				// Non-conflict rebase failure (e.g., corrupt repo state, hook failure)
-				a.logger.Error("rebase failed for non-conflict reason", "pr", work.PRNumber, "stderr", string(stderr))
+				a.logger.Error("rebase failed for non-conflict reason", "pr", work.PRNumber, "stderr", stderr)
 			}
 			continue
 		}
@@ -1761,6 +1761,21 @@ func (a *Agent) hasFixupCommits(ctx context.Context, worktreePath string) bool {
 	return strings.Contains(string(logOut), "fixup!")
 }
 
+// gitRebaseWithRetry attempts a rebase and, if it fails due to unstaged changes
+// (e.g. upstream file deletions), cleans the worktree and retries once.
+// Returns the stderr output (as a string) and any error from the final rebase attempt.
+func (a *Agent) gitRebaseWithRetry(ctx context.Context, worktreePath string, prNumber int) (string, error) {
+	_, stderr, rebaseErr := a.runner.Run(ctx, worktreePath, "git", "rebase", a.originDefaultBranch())
+	if rebaseErr != nil && isUnstagedChangesError(string(stderr)) {
+		// Upstream file deletions can leave unstaged changes that block rebase.
+		// Clean the worktree and retry.
+		a.logger.Info("cleaning unstaged changes before rebase retry", "pr", prNumber)
+		a.runner.Run(ctx, worktreePath, "git", "checkout", "--", ".") //nolint:errcheck // best-effort
+		_, stderr, rebaseErr = a.runner.Run(ctx, worktreePath, "git", "rebase", a.originDefaultBranch())
+	}
+	return string(stderr), rebaseErr
+}
+
 // gitAutosquashRebase performs an interactive rebase with autosquash to merge fixup commits.
 func (a *Agent) gitAutosquashRebase(ctx context.Context, worktreePath string) error {
 	// Set GIT_SEQUENCE_EDITOR to cat so rebase doesn't wait for interactive input
@@ -1798,6 +1813,12 @@ func truncateString(s string, maxLen int) string {
 func isConflictError(stderr string) bool {
 	lowerStderr := strings.ToLower(stderr)
 	return strings.Contains(lowerStderr, "conflict") || strings.Contains(lowerStderr, "could not apply")
+}
+
+// isUnstagedChangesError returns true if the stderr from a git rebase indicates
+// unstaged changes are blocking the rebase (e.g. upstream file deletions).
+func isUnstagedChangesError(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "unstaged changes")
 }
 
 // resolveConflictsParallel invokes the coding agent to resolve conflicts for a list of tasks in parallel.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -2740,6 +2740,155 @@ func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 	}
 }
 
+func TestIsUnstagedChangesError(t *testing.T) {
+	tests := []struct {
+		stderr string
+		want   bool
+	}{
+		{"error: cannot rebase: You have unstaged changes.\nerror: Please commit or stash them.\n", true},
+		{"error: unstaged changes would be overwritten by rebase", true},
+		{"error: could not apply 3a35b4e... Migrate remaining features\nCONFLICT (content): Merge conflict in main.go", false},
+		{"fatal: some other error", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isUnstagedChangesError(tt.stderr)
+		if got != tt.want {
+			t.Errorf("isUnstagedChangesError(%q) = %v, want %v", tt.stderr, got, tt.want)
+		}
+	}
+}
+
+func TestProcessRebase_CleansUnstagedChangesAndRetries(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "behind",
+	}
+	runner := &unstagedChangesRebaseRunner{
+		mockCommandRunner: &mockCommandRunner{},
+	}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessRebase(context.Background())
+
+	// Should have called git checkout -- . to clean unstaged changes
+	foundCheckout := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "checkout" && c.Args[1] == "--" && c.Args[2] == "." {
+			foundCheckout = true
+		}
+	}
+	if !foundCheckout {
+		t.Error("expected git checkout -- . to be called to clean unstaged changes")
+	}
+
+	// Should have attempted rebase twice (first fails with unstaged, second succeeds)
+	rebaseCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" && !slices.Contains(c.Args, "--abort") {
+			rebaseCalls++
+		}
+	}
+	if rebaseCalls != 2 {
+		t.Errorf("expected 2 rebase calls (initial + retry), got %d", rebaseCalls)
+	}
+
+	// Should NOT have called git rebase --abort (retry succeeded)
+	abortCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" && slices.Contains(c.Args, "--abort") {
+			abortCalls++
+		}
+	}
+	if abortCalls != 0 {
+		t.Errorf("expected 0 rebase --abort calls (retry succeeded), got %d", abortCalls)
+	}
+}
+
+func TestProcessConflicts_CleansUnstagedChangesAndRetries(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "dirty",
+	}
+	runner := &unstagedChangesRebaseRunner{
+		mockCommandRunner: &mockCommandRunner{},
+	}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessConflicts(context.Background())
+
+	// Should have called git checkout -- . to clean unstaged changes
+	foundCheckout := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "checkout" && c.Args[1] == "--" && c.Args[2] == "." {
+			foundCheckout = true
+		}
+	}
+	if !foundCheckout {
+		t.Error("expected git checkout -- . to be called to clean unstaged changes")
+	}
+
+	// Should have attempted rebase twice (first fails with unstaged, second succeeds)
+	rebaseCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" && !slices.Contains(c.Args, "--abort") {
+			rebaseCalls++
+		}
+	}
+	if rebaseCalls != 2 {
+		t.Errorf("expected 2 rebase calls (initial + retry), got %d", rebaseCalls)
+	}
+
+	// Should NOT have called git rebase --abort (retry succeeded)
+	abortCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" && slices.Contains(c.Args, "--abort") {
+			abortCalls++
+		}
+	}
+	if abortCalls != 0 {
+		t.Errorf("expected 0 rebase --abort calls (retry succeeded), got %d", abortCalls)
+	}
+}
+
+// unstagedChangesRebaseRunner simulates a rebase that fails on the first attempt
+// with "unstaged changes" and succeeds on the second attempt after cleanup.
+type unstagedChangesRebaseRunner struct {
+	*mockCommandRunner
+	rebaseAttempts int
+}
+
+func (r *unstagedChangesRebaseRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	r.mockCommandRunner.Run(ctx, workDir, name, args...) //nolint:errcheck // recording call for test assertions
+
+	// Return "unstaged changes" error on the first rebase attempt, succeed on retry
+	if name == "git" && len(args) > 0 && args[0] == "rebase" && !slices.Contains(args, "--abort") {
+		r.rebaseAttempts++
+		if r.rebaseAttempts == 1 {
+			return nil, []byte("error: cannot rebase: You have unstaged changes.\nerror: Please commit or stash them.\n"), fmt.Errorf("rebase failed")
+		}
+		return nil, nil, nil // retry succeeds
+	}
+
+	return nil, nil, nil
+}
+
 func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed both failures"})
 	gh := &mockGitHubClient{


### PR DESCRIPTION
Fixes #144

## Summary

When upstream deletes files that exist on a PR branch, `git fetch` updates remote refs but doesn't clean the working tree. The deleted files appear as unstaged changes, causing `git rebase` to refuse with "You have unstaged changes". This blocks all rebase attempts every poll cycle until manual intervention.

## Changes

- Add `isUnstagedChangesError()` helper to detect the specific "unstaged changes" rebase error
- Add retry logic to `ProcessRebase`: when rebase fails with "unstaged changes", clean the worktree with `git checkout -- .` and retry
- Add matching retry logic to `ProcessConflicts` for the same scenario
- Add unit tests: `TestIsUnstagedChangesError`, `TestProcessRebase_CleansUnstagedChangesAndRetries`, `TestProcessConflicts_CleansUnstagedChangesAndRetries`

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #144

<!-- oompa-bot v:76086ef -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced git rebase resilience to automatically detect when rebase operations fail due to unstaged changes, clear the staging area, and retry the operation, improving reliability in conflict resolution and behind-branch rebasing scenarios without requiring manual intervention.

* **Tests**
  * Added comprehensive test coverage for unstaged changes detection and recovery in git rebase operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->