### PR TITLE
perf: GCSDirectoryJobSource fetches all items instead of only recent ones

### DIFF
--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -374,7 +375,7 @@ type gcsRef struct {
 // x-goog-meta-link metadata points to the actual build directory.
 type GCSDirectoryJobSource struct {
 	bucket       string
-	prefix       string            // e.g. "pr-logs/directory/pull-job-name/"
+	prefix       string // e.g. "pr-logs/directory/pull-job-name/"
 	jobName      string
 	client       *http.Client
 	resolvedRuns map[string]gcsRef // buildID → resolved bucket+prefix
@@ -405,6 +406,22 @@ func (g *GCSDirectoryJobSource) JobName() string {
 	return g.jobName
 }
 
+// extractBuildIDNumeric extracts the numeric build ID from a directory item name.
+// Given "pr-logs/directory/pull-job/12345.txt", it returns 12345.
+// Returns -1 if the name doesn't end with ".txt" or doesn't contain a valid numeric build ID.
+func extractBuildIDNumeric(name, prefix string) int64 {
+	trimmed := strings.TrimPrefix(name, prefix)
+	if !strings.HasSuffix(trimmed, ".txt") {
+		return -1
+	}
+	trimmed = strings.TrimSuffix(trimmed, ".txt")
+	id, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return id
+}
+
 // gcsDirectoryListResponse is the JSON response from the GCS list API
 // when listing objects (not prefixes) in a directory index.
 type gcsDirectoryListResponse struct {
@@ -425,7 +442,7 @@ func (g *GCSDirectoryJobSource) ListRecentRuns(ctx context.Context, limit int) (
 	var allItems []gcsDirectoryItem
 	pageToken := ""
 
-	// Paginate through all items in the directory index
+	// Phase 1: Paginate through all items in the directory index (metadata only, no per-item HTTP calls)
 	for {
 		listURL := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o?prefix=%s",
 			url.PathEscape(g.bucket), url.PathEscape(g.prefix))
@@ -464,18 +481,38 @@ func (g *GCSDirectoryJobSource) ListRecentRuns(ctx context.Context, limit int) (
 		pageToken = listResp.NextPageToken
 	}
 
-	// Process items: extract build IDs and resolve target paths
-	var runs []JobRun
+	// Phase 2: Filter out non-build items to prevent them from consuming
+	// the fetch limit. Items without a valid numeric build ID (e.g. .log
+	// or .bak files) are excluded. Cache parsed IDs alongside items so
+	// the sort avoids redundant string parsing.
+	type itemWithID struct {
+		item gcsDirectoryItem
+		id   int64
+	}
+	var filtered []itemWithID
 	for _, item := range allItems {
+		if id := extractBuildIDNumeric(item.Name, g.prefix); id >= 0 {
+			filtered = append(filtered, itemWithID{item: item, id: id})
+		}
+	}
+
+	// Sort by build ID descending (numeric, monotonically increasing)
+	// so we process the most recent builds first.
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i].id > filtered[j].id })
+
+	// Phase 3: Only fetch finished.json for the most recent items.
+	// Use a safety multiplier to account for items that may be skipped
+	// (missing metadata, still running, etc.)
+	fetchLimit := min(max(limit*3, 50), len(filtered))
+
+	// Phase 4: Process only the most recent items
+	var runs []JobRun
+	for _, fi := range filtered[:fetchLimit] {
+		item := fi.item
+
 		// Extract build ID from object name: strip prefix and .txt suffix
 		name := strings.TrimPrefix(item.Name, g.prefix)
-		if !strings.HasSuffix(name, ".txt") {
-			continue
-		}
 		buildID := strings.TrimSuffix(name, ".txt")
-		if buildID == "" {
-			continue
-		}
 
 		// Resolve target build path from metadata.
 		// GCS JSON API exposes custom metadata with bare keys (e.g. "link"),

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -347,6 +348,155 @@ func TestGCSDirectoryJobSource_ListRecentRuns(t *testing.T) {
 	}
 	if runs[0].ID != "111" {
 		t.Errorf("limited run ID = %q, want %q (most recent)", runs[0].ID, "111")
+	}
+}
+
+func TestGCSDirectoryJobSource_ListRecentRuns_OnlyFetchesRecentItems(t *testing.T) {
+	// Create 200 items but only the most recent ones (by build ID) should have
+	// their finished.json fetched. Old items should never be accessed.
+	const totalItems = 200
+
+	// Track which finished.json URLs were fetched
+	fetchedBuildIDs := make(map[string]bool)
+
+	passed := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/storage/v1/b/test-bucket/o":
+			// Generate items with build IDs from 1 to totalItems
+			var items []gcsDirectoryItem
+			for i := 1; i <= totalItems; i++ {
+				items = append(items, gcsDirectoryItem{
+					Name: fmt.Sprintf("pr-logs/directory/pull-job/%d.txt", i),
+					Metadata: map[string]string{
+						"link": fmt.Sprintf("gs://test-bucket/pr-logs/pull/org_repo/10/pull-job/%d", i),
+					},
+				})
+			}
+			resp := gcsDirectoryListResponse{Items: items}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		default:
+			// Handle finished.json requests
+			// Extract build ID from path like /test-bucket/pr-logs/pull/org_repo/10/pull-job/{id}/finished.json
+			path := r.URL.Path
+			if path != "" && path[0] == '/' {
+				path = path[1:]
+			}
+			parts := strings.Split(path, "/")
+			if len(parts) >= 7 && parts[len(parts)-1] == "finished.json" {
+				buildID := parts[len(parts)-2]
+				fetchedBuildIDs[buildID] = true
+
+				finished := gcsFinishedJSON{
+					Passed:    &passed,
+					Result:    "SUCCESS",
+					Timestamp: 1700000000 + int64(len(buildID)), // slightly different timestamps
+				}
+				finishedBytes, _ := json.Marshal(finished)
+				_, _ = w.Write(finishedBytes)
+				return
+			}
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source := &GCSDirectoryJobSource{
+		bucket:       "test-bucket",
+		prefix:       "pr-logs/directory/pull-job/",
+		jobName:      "pull-job",
+		client:       &http.Client{Transport: &rewriteTransport{base: server.URL}},
+		resolvedRuns: make(map[string]gcsRef),
+	}
+
+	runs, err := source.ListRecentRuns(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(runs) != 10 {
+		t.Fatalf("expected 10 runs, got %d", len(runs))
+	}
+
+	// Verify that we fetched at most 50 finished.json files (not all 200)
+	if len(fetchedBuildIDs) > 50 {
+		t.Errorf("fetched finished.json for %d items, expected at most 50 (out of %d total)",
+			len(fetchedBuildIDs), totalItems)
+	}
+
+	// Verify that old build IDs (low numbers) were NOT fetched
+	for i := 1; i <= totalItems-50; i++ {
+		buildID := fmt.Sprintf("%d", i)
+		if fetchedBuildIDs[buildID] {
+			t.Errorf("fetched finished.json for old build ID %s, expected it to be skipped", buildID)
+			break // one error is enough to demonstrate the issue
+		}
+	}
+
+	// Verify that recent build IDs (high numbers) WERE fetched
+	for i := totalItems - 49; i <= totalItems; i++ {
+		buildID := fmt.Sprintf("%d", i)
+		if !fetchedBuildIDs[buildID] {
+			t.Errorf("expected finished.json to be fetched for recent build ID %s", buildID)
+			break
+		}
+	}
+}
+
+func TestExtractBuildIDNumeric(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		prefix string
+		want   int64
+	}{
+		{
+			name:   "valid numeric build ID",
+			input:  "pr-logs/directory/pull-job/12345.txt",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   12345,
+		},
+		{
+			name:   "zero build ID",
+			input:  "pr-logs/directory/pull-job/0.txt",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   0,
+		},
+		{
+			name:   "non-numeric build ID",
+			input:  "pr-logs/directory/pull-job/abc.txt",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   -1,
+		},
+		{
+			name:   "empty after prefix strip",
+			input:  "pr-logs/directory/pull-job/.txt",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   -1,
+		},
+		{
+			name:   "missing .txt suffix",
+			input:  "pr-logs/directory/pull-job/12345.log",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   -1,
+		},
+		{
+			name:   "large build ID",
+			input:  "pr-logs/directory/pull-job/1700000000.txt",
+			prefix: "pr-logs/directory/pull-job/",
+			want:   1700000000,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractBuildIDNumeric(tc.input, tc.prefix)
+			if got != tc.want {
+				t.Errorf("extractBuildIDNumeric(%q, %q) = %d, want %d", tc.input, tc.prefix, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #138

## Summary

Optimize `GCSDirectoryJobSource.ListRecentRuns` to fetch `finished.json` only for the most recent items instead of all items in the directory index. For jobs with 1000+ entries, this reduces HTTP calls from 1000+ to ~50.

## Changes

- Add `extractBuildIDNumeric` helper to parse numeric build IDs from directory item names
- Sort directory items by build ID descending (numeric) after listing, so most recent builds are processed first
- Cap `finished.json` fetches to `max(limit*3, 50)` items instead of fetching all
- Add `strconv` import for numeric build ID parsing
- Add `TestGCSDirectoryJobSource_ListRecentRuns_OnlyFetchesRecentItems` verifying that only recent items are fetched (200 items, at most 50 fetched)
- Add `TestExtractBuildIDNumeric` with table-driven tests for the helper function

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] New test verifies only ~50 out of 200 items have their `finished.json` fetched

## Related Issues

Fixes #138

<!-- oompa-bot v:66e3a7d -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized retrieval of recent CI runs with improved pagination handling and reduced API overhead. The system now efficiently fetches data only for the most recent items in large directories, rather than processing all items. This significantly improves performance and reduces resource consumption when listing recent CI build results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->