### PR TITLE
feat: add skip-checks config to ignore specific CI check names

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -56,6 +56,9 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 	var skipComments string
 	flag.StringVar(&skipComments, "skip-comment", os.Getenv("OOMPA_SKIP_COMMENTS"), "Comma-separated list of comment categories to suppress: ci-unrelated, ci-infrastructure, ci-related, conflict, rebase, flaky, issue-in-progress")
 
+	var skipChecks string
+	flag.StringVar(&skipChecks, "skip-checks", os.Getenv("OOMPA_SKIP_CHECKS"), "Comma-separated list of CI check names to ignore entirely")
+
 	var triageJobs string
 	flag.StringVar(&triageJobs, "triage-jobs", os.Getenv("OOMPA_TRIAGE_JOBS"), "Comma-separated CI job URLs to monitor for periodic job triage")
 	triageLookback := time.Duration(0)
@@ -226,6 +229,15 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 				os.Exit(1)
 			}
 			cfg.SkipComments = append(cfg.SkipComments, c)
+		}
+	}
+
+	if skipChecks != "" {
+		for c := range strings.SplitSeq(skipChecks, ",") {
+			c = strings.TrimSpace(c)
+			if c != "" {
+				cfg.SkipChecks = append(cfg.SkipChecks, c)
+			}
 		}
 	}
 

--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -73,6 +74,10 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		var failures []CheckRun
 		allCompleted := true
 		for _, r := range runs {
+			if slices.Contains(a.cfg.SkipChecks, r.Name) {
+				a.logger.Debug("skipping excluded CI check", "pr", work.PRNumber, "check", r.Name)
+				continue
+			}
 			if r.Status == "completed" && r.Conclusion == "failure" {
 				failures = append(failures, r)
 			}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Version           string   // build version (commit SHA) for comment watermarks
 	SkipFix           bool     // when true, investigate and comment but never fix or push code changes
 	SkipComments      []string // comment categories to suppress: ci-unrelated, ci-infrastructure, ci-related, conflict, rebase, flaky, issue-in-progress
+	SkipChecks        []string // CI check names to ignore entirely (filtered before investigation)
 
 	// GitHub App authentication (alternative to GITHUB_TOKEN)
 	GitHubAppID             int64

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -32,6 +32,7 @@ type ProjectConfig struct {
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
 	SkipComment       []string `yaml:"skip-comment"`
+	SkipChecks        []string `yaml:"skip-checks"`
 	SkipFix           *bool    `yaml:"skip-fix"`
 	Reactions         []string `yaml:"reactions"`
 	Label             string   `yaml:"label"`
@@ -49,6 +50,7 @@ type PRsRoleConfig struct {
 	Watch             []int    `yaml:"watch"`
 	Reactions         []string `yaml:"reactions"`
 	SkipComment       []string `yaml:"skip-comment"`
+	SkipChecks        []string `yaml:"skip-checks"`
 	SkipFix           *bool    `yaml:"skip-fix"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
@@ -61,6 +63,7 @@ type IssuesRoleConfig struct {
 	OnlyAssigned      *bool    `yaml:"only-assigned"`
 	SkipFix           *bool    `yaml:"skip-fix"`
 	SkipComment       []string `yaml:"skip-comment"`
+	SkipChecks        []string `yaml:"skip-checks"`
 	Fork              string   `yaml:"fork"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
@@ -75,6 +78,7 @@ type TriageRoleConfig struct {
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
 	SkipComment       []string `yaml:"skip-comment"`
+	SkipChecks        []string `yaml:"skip-checks"`
 	SkipFix           *bool    `yaml:"skip-fix"`
 	Reviewers         []string `yaml:"reviewers"` // overrides project-level reviewers
 }
@@ -294,6 +298,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		projCreateFlaky := boolOr(p.CreateFlakyIssues, false)
 		projFlakyLabel := stringOr(p.FlakyLabel, "flaky-test")
 		projSkipComment := p.SkipComment
+		projSkipChecks := p.SkipChecks
 		projSkipFix := boolOr(p.SkipFix, false)
 		projReactions := p.Reactions
 		projLabel := stringOr(p.Label, "good-for-ai")
@@ -339,6 +344,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.WatchPRs = pr.Watch
 			cfg.Reactions = stringsOr(pr.Reactions, projReactions)
 			cfg.SkipComments = stringsOr(pr.SkipComment, projSkipComment)
+			cfg.SkipChecks = stringsOr(pr.SkipChecks, projSkipChecks)
 			cfg.SkipFix = boolOr(pr.SkipFix, projSkipFix)
 			cfg.CreateFlakyIssues = boolOr(pr.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(pr.FlakyLabel, projFlakyLabel)
@@ -353,6 +359,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.OnlyAssigned = boolOr(issue.OnlyAssigned, projOnlyAssigned)
 			cfg.SkipFix = boolOr(issue.SkipFix, projSkipFix)
 			cfg.SkipComments = stringsOr(issue.SkipComment, projSkipComment)
+			cfg.SkipChecks = stringsOr(issue.SkipChecks, projSkipChecks)
 			cfg.CreateFlakyIssues = boolOr(issue.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(issue.FlakyLabel, projFlakyLabel)
 			cfg.Reviewers = stringsOr(issue.Reviewers, projReviewers)
@@ -373,6 +380,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.CreateFlakyIssues = boolOr(triage.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(triage.FlakyLabel, projFlakyLabel)
 			cfg.SkipComments = stringsOr(triage.SkipComment, projSkipComment)
+			cfg.SkipChecks = stringsOr(triage.SkipChecks, projSkipChecks)
 			cfg.SkipFix = boolOr(triage.SkipFix, projSkipFix)
 			cfg.TriageLookback = globalCfg.TriageLookback
 			if triage.Lookback != "" {

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -868,6 +868,142 @@ func TestBuildRoleEntries_TriageLookback(t *testing.T) {
 	}
 }
 
+func TestBuildRoleEntries_SkipChecksTwoTierInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo:       "owner/repo",
+				SkipChecks: []string{"can-be-merged"},
+				PRs: []PRsRoleConfig{
+					{
+						Watch: []int{100},
+						// Inherits project-level skip-checks
+					},
+					{
+						Watch:      []int{200},
+						SkipChecks: []string{"can-be-merged", "verified"}, // Override
+					},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// First entry inherits project-level skip-checks
+	e1 := entries[0]
+	if len(e1.Config.SkipChecks) != 1 || e1.Config.SkipChecks[0] != "can-be-merged" {
+		t.Errorf("expected inherited skip-checks [can-be-merged], got %v", e1.Config.SkipChecks)
+	}
+
+	// Second entry overrides with role-level skip-checks
+	e2 := entries[1]
+	if len(e2.Config.SkipChecks) != 2 || e2.Config.SkipChecks[0] != "can-be-merged" || e2.Config.SkipChecks[1] != "verified" {
+		t.Errorf("expected overridden skip-checks [can-be-merged verified], got %v", e2.Config.SkipChecks)
+	}
+}
+
+func TestBuildRoleEntries_SkipChecksIssuesAndTriageInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo:       "owner/repo",
+				SkipChecks: []string{"can-be-merged"},
+				Issues: []IssuesRoleConfig{
+					{
+						Label: "ai",
+						// Inherits project-level skip-checks
+					},
+					{
+						Label:      "special",
+						SkipChecks: []string{"can-be-merged", "verified"}, // Override
+					},
+				},
+				Triage: []TriageRoleConfig{
+					{
+						Jobs: []string{"https://ci.example.com/job1"},
+						// Inherits project-level skip-checks
+					},
+					{
+						Jobs:       []string{"https://ci.example.com/job2"},
+						SkipChecks: []string{"e2e-check"}, // Override
+					},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	// Issues[0]: inherits project-level skip-checks
+	if len(entries[0].Config.SkipChecks) != 1 || entries[0].Config.SkipChecks[0] != "can-be-merged" {
+		t.Errorf("Issues[0]: expected inherited skip-checks [can-be-merged], got %v", entries[0].Config.SkipChecks)
+	}
+
+	// Issues[1]: overrides with role-level skip-checks
+	if len(entries[1].Config.SkipChecks) != 2 || entries[1].Config.SkipChecks[0] != "can-be-merged" || entries[1].Config.SkipChecks[1] != "verified" {
+		t.Errorf("Issues[1]: expected overridden skip-checks [can-be-merged verified], got %v", entries[1].Config.SkipChecks)
+	}
+
+	// Triage[0]: inherits project-level skip-checks
+	if len(entries[2].Config.SkipChecks) != 1 || entries[2].Config.SkipChecks[0] != "can-be-merged" {
+		t.Errorf("Triage[0]: expected inherited skip-checks [can-be-merged], got %v", entries[2].Config.SkipChecks)
+	}
+
+	// Triage[1]: overrides with role-level skip-checks
+	if len(entries[3].Config.SkipChecks) != 1 || entries[3].Config.SkipChecks[0] != "e2e-check" {
+		t.Errorf("Triage[1]: expected overridden skip-checks [e2e-check], got %v", entries[3].Config.SkipChecks)
+	}
+}
+
+func TestLoadFileConfig_SkipChecksAccepted(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    skip-checks:
+      - can-be-merged
+    prs:
+      - watch: [1]
+        skip-checks:
+          - verified
+    issues:
+      - label: ai
+        skip-checks:
+          - e2e-check
+    triage:
+      - jobs: [https://ci.example.com/job]
+        skip-checks:
+          - lint-check
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Projects[0].SkipChecks) != 1 || cfg.Projects[0].SkipChecks[0] != "can-be-merged" {
+		t.Errorf("expected project skip-checks [can-be-merged], got %v", cfg.Projects[0].SkipChecks)
+	}
+	if len(cfg.Projects[0].PRs[0].SkipChecks) != 1 || cfg.Projects[0].PRs[0].SkipChecks[0] != "verified" {
+		t.Errorf("expected PR skip-checks [verified], got %v", cfg.Projects[0].PRs[0].SkipChecks)
+	}
+	if len(cfg.Projects[0].Issues[0].SkipChecks) != 1 || cfg.Projects[0].Issues[0].SkipChecks[0] != "e2e-check" {
+		t.Errorf("expected Issues skip-checks [e2e-check], got %v", cfg.Projects[0].Issues[0].SkipChecks)
+	}
+	if len(cfg.Projects[0].Triage[0].SkipChecks) != 1 || cfg.Projects[0].Triage[0].SkipChecks[0] != "lint-check" {
+		t.Errorf("expected Triage skip-checks [lint-check], got %v", cfg.Projects[0].Triage[0].SkipChecks)
+	}
+}
+
 func TestLoadFileConfig_UnknownKeysRejected(t *testing.T) {
 	yaml := `
 agent: opencode

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -2936,3 +2936,102 @@ func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
 		t.Errorf("expected one prompt to contain commit status failure 'pull-unit-test'")
 	}
 }
+
+func TestProcessCIFailures_SkipChecksExcludesFromFailures(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "can-be-merged", Status: "completed", Conclusion: "failure", Output: "merge gate failed"},
+			{ID: 2, Name: "unit-tests", Status: "completed", Conclusion: "failure", Output: "test failed"},
+		},
+	}
+	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED this is flaky"})
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SkipChecks = []string{"can-be-merged"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Only the non-skipped check should be investigated
+	claudeCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			claudeCalls++
+			// Verify the prompt does NOT mention the skipped check
+			if strings.Contains(c.Args[len(c.Args)-1], "can-be-merged") {
+				t.Error("skipped check 'can-be-merged' should not appear in claude prompt")
+			}
+		}
+	}
+	if claudeCalls != 1 {
+		t.Fatalf("expected 1 claude call for non-skipped check, got %d", claudeCalls)
+	}
+}
+
+func TestProcessCIFailures_SkipChecksAllFailuresSkipped(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "can-be-merged", Status: "completed", Conclusion: "failure", Output: "merge gate failed"},
+			{ID: 2, Name: "verified", Status: "completed", Conclusion: "failure", Output: "not verified"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SkipChecks = []string{"can-be-merged", "verified"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// No claude calls since all failures are skipped
+	if len(runner.calls) != 0 {
+		t.Errorf("expected no claude calls when all failures are skipped, got %d", len(runner.calls))
+	}
+}
+
+func TestProcessCIFailures_SkipChecksDoesNotAffectAllCompleted(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "can-be-merged", Status: "in_progress", Conclusion: ""},
+			{ID: 2, Name: "unit-tests", Status: "completed", Conclusion: "success"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SkipChecks = []string{"can-be-merged"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber: 42,
+		PRNumber:    100,
+		BranchName:  "ai/issue-42",
+		Status:      "pr-open",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// The skipped in_progress check should not prevent allCompleted from being true.
+	// With can-be-merged skipped, only unit-tests (completed+success) remains,
+	// so allCompleted=true and LastCheckedCISHA should be set.
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCheckedCISHA != "abc123" {
+		t.Errorf("expected LastCheckedCISHA to be set when skipped check is the only non-completed, got %q", work.LastCheckedCISHA)
+	}
+}

--- a/specs/config.md
+++ b/specs/config.md
@@ -20,6 +20,7 @@ type Config struct {
     Reactions         []string // which reactions to run: "reviews", "ci", "conflicts" (empty = all)
     CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
     SkipComments      []string // comment categories to suppress (empty = none suppressed)
+    SkipChecks        []string // CI check names to ignore entirely (filtered before investigation)
 }
 ```
 
@@ -41,6 +42,7 @@ type Config struct {
 | `OOMPA_WATCH_PRS` | `--watch-prs` | (empty) | Comma-separated PR numbers to monitor directly (bypasses issue discovery) |
 | `OOMPA_REACTIONS` | `--reactions` | (empty = all) | Comma-separated list of reactions to run: `reviews`, `ci`, `conflicts` |
 | `OOMPA_SKIP_COMMENTS` | `--skip-comment` | (empty) | Comma-separated list of comment categories to suppress: `ci-unrelated`, `ci-infrastructure`, `ci-related`, `conflict`, `rebase`, `flaky`, `issue-in-progress` |
+| `OOMPA_SKIP_CHECKS` | `--skip-checks` | (empty) | Comma-separated list of CI check names to ignore entirely |
 | `OOMPA_CREATE_FLAKY_ISSUES` | `--create-flaky-issues` | `false` | When true, create issues for unrelated CI failures (opt-in) |
 
 Config from env vars (`OOMPA_*`) with flag overrides, read in `main()`.


### PR DESCRIPTION
Fixes #155

## Summary

Add a `skip-checks` config option that tells oompa to completely ignore specific CI check names before any investigation occurs. This eliminates wasted agent tokens, false positive comments, and incorrect CI fix attempt counting for checks that are always failing by design (e.g. `can-be-merged` merge gates).

## Changes

- Add `SkipChecks []string` field to `ProjectConfig` and `PRsRoleConfig` in `pkg/agent/fileconfig.go`
- Wire two-tier inheritance (project-level default with per-role override) through `BuildRoleEntries`
- Add `SkipChecks []string` field to `Config` struct in `pkg/agent/config.go`
- Filter skipped checks early in `ProcessCIFailures` (before failures list and `allCompleted` logic) in `pkg/agent/ci.go`
- Update `specs/config.md` to document the new field
- Add tests for CI filtering, two-tier inheritance, and YAML config parsing

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #155

<!-- oompa-bot v:d526db6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-checks` CLI option and `OOMPA_SKIP_CHECKS` environment variable to exclude specific CI checks from investigation (accepts comma-separated list with automatic whitespace trimming)
  * Added `skip-checks` YAML configuration option at project and per-role levels, supporting role-level overrides of project defaults

* **Documentation**
  * Updated configuration documentation to describe the new skip-checks option and its environment variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->