### PR TITLE
feat: per-role worker identity and factory floor TUI layout

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,29 @@
+Fixes #157
+
+## Summary
+
+Adds per-role worker identity so multi-role projects register distinct workers (e.g., `nmstate/kubernetes-nmstate:prs`, `:issues`, `:triage`), and replaces the flat card grid TUI with a factory floor layout that groups oompas by project on conveyor belts.
+
+## Changes
+
+- **`pkg/agent/config.go`**: Add `Role string` field to `Config` struct
+- **`pkg/agent/fileconfig.go`**: Set `cfg.Role` in `BuildRoleEntries()` for each role type (prs, issues, triage)
+- **`pkg/agent/loop.go`**: Update `workerName()` to append `:role` suffix when `cfg.Role` is set, backward-compatible when empty
+- **`cmd/oompa/tui.go`**: Replace flat card grid with factory floor layout — workers grouped by project as conveyor belts (`═══ project ═══▶`), oompas side-by-side on belt surfaces (`●●●`), animated dots for active workers, column tiling adapting to terminal width, compact 2-column activity log with short worker names
+- **`cmd/oompa/status.go`**: Widen worker column from 35 to 40 chars to accommodate `:role` suffix
+- **`pkg/agent/loop_test.go`**: Add `TestWorkerName_WithRole` and `TestWorkerName_WithoutRole` tests
+- **`pkg/agent/fileconfig_test.go`**: Add `Config.Role` assertions to existing `BuildRoleEntries` tests
+- **`cmd/oompa/tui_test.go`**: Add tests for project grouping, conveyor belt rendering, belt width scaling, column tiling, short worker names, and worker project parsing
+- **`specs/event.md`**: Document worker name format change (`owner/repo:role`)
+- **`specs/tui.md`**: Document factory floor layout, worker name format, and new test list
+
+## Testing
+
+- [x] `go test ./...` passes
+- [x] `go vet ./...` passes
+- [x] `go fix ./...` produces no changes
+- [ ] Manual testing (if applicable)
+
+## Related Issues
+
+Fixes #157

--- a/cmd/oompa/status.go
+++ b/cmd/oompa/status.go
@@ -52,8 +52,8 @@ func printStatus(snap agent.StatusSnapshot, since time.Duration) {
 	})
 
 	// Table header
-	fmt.Printf("%-35s %-14s %-30s %s\n", "WORKER", "STATE", "CURRENT ACTION", "LAST EVENT")
-	fmt.Println(strings.Repeat("\u2500", 100))
+	fmt.Printf("%-40s %-14s %-30s %s\n", "WORKER", "STATE", "CURRENT ACTION", "LAST EVENT")
+	fmt.Println(strings.Repeat("\u2500", 105))
 
 	for _, w := range snap.Workers {
 		icon := stateIcon(w.State)
@@ -67,11 +67,8 @@ func printStatus(snap agent.StatusSnapshot, since time.Duration) {
 			prInfo = " [" + strings.Join(nums, ",") + "]"
 		}
 		workerCol := w.Worker + prInfo
-		action := w.Action
-		if len(action) > 30 {
-			action = action[:27] + "..."
-		}
-		fmt.Printf("%-35s %s %-12s %-30s %s\n", workerCol, icon, w.State, action, ago)
+		action := truncateRunes(w.Action, 30)
+		fmt.Printf("%-40s %s %-12s %-30s %s\n", workerCol, icon, w.State, action, ago)
 	}
 
 	// Recent activity

--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -49,6 +49,13 @@ func runTUICommand(args []string) {
 	}
 }
 
+// Sprite layout constants.
+const (
+	spriteWidth  = 11 // characters per sprite frame (padded)
+	spriteHeight = 5  // lines per sprite (all frames normalized)
+	spriteGap    = 2  // characters between adjacent oompas
+)
+
 // TUI styles
 var (
 	headerStyle = lipgloss.NewStyle().
@@ -56,24 +63,6 @@ var (
 			Foreground(lipgloss.Color("229")).
 			Background(lipgloss.Color("57")).
 			Padding(0, 1)
-
-	cardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("240")).
-			Padding(0, 1).
-			Width(28)
-
-	activeCardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("39")).
-			Padding(0, 1).
-			Width(28)
-
-	errorCardStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("196")).
-			Padding(0, 1).
-			Width(28)
 
 	logStyle = lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder()).
@@ -87,35 +76,42 @@ var (
 	statusWorking = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
 	statusIdle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	statusError   = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+
+	beltStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+
+	conveyorTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("208"))
+
 )
 
 // spriteFrames defines animation frames for oompa-loompa sprites per state.
+// All frames are normalized to spriteWidth (11) chars wide and spriteHeight (5) lines tall.
 var spriteFrames = map[string][][]string{
 	"working": {
-		{"   ___   ", "  (o.o)  ", " --|--|\\  ", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (o.o)  ", "  /|--|-- ", "   |  |  ", "  _/  \\_ "},
+		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
+		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
 	},
 	"idle": {
-		{"   ___   ", "  (o.o)  ", " --|--|-- ", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (o.o)  ", " --|--|-- ", "   |  |  ", " _/  \\_  "},
+		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
+		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", " _/  \\_    "},
 	},
 	"sleeping": {
-		{"   ___   ", "  (-.- )Z", "   |__|  ", "  _/  \\_ ", " sitting "},
-		{"   ___   ", "  (-.- )Zz", "   |__|  ", "  _/  \\_ ", " sitting "},
-		{"   ___    ", "  (-.- )Zzz", "   |__|  ", "  _/  \\_ ", " sitting "},
+		{"   ___     ", "  (-.- ) Z ", "   |__|    ", "  _/  \\_   ", "           "},
+		{"   ___     ", "  (-.- ) Zz", "   |__|    ", "  _/  \\_   ", "           "},
+		{"   ___     ", "  (-.- )Zzz", "   |__|    ", "  _/  \\_   ", "           "},
 	},
 	"error": {
-		{"   ___   ", "  (x.x)  ", " --|--|-- ", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (x.x) *", " --|--|-- ", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (x.x)**", " --|--|-- ", "   |  |  ", "  _/  \\_ "},
+		{"   ___     ", "  (x.x)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
+		{"   ___     ", "  (x.x)  * ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
 	},
 	"reviewing": {
-		{"   ___   ", "  (o.o)  ", " --|--|Q ", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (o.o)  ", " --|--|q ", "   |  |  ", "  _/  \\_ "},
+		{"   ___     ", "  (o.o)    ", " --|--|Q   ", "   |  |    ", "  _/  \\_   "},
+		{"   ___     ", "  (o.o)    ", " --|--|q   ", "   |  |    ", "  _/  \\_   "},
 	},
 	"rebasing": {
-		{"   ___   ", "  (o.o)  ", " --|--|>[", "   |  |  ", "  _/  \\_ "},
-		{"   ___   ", "  (o.o)  ", " --|--|>]", "   |  |  ", "  _/  \\_ "},
+		{"   ___     ", "  (o.o)    ", " --|--|>   ", "   |  |    ", "  _/  \\_   "},
+		{"   ___     ", "  (o.o)    ", " --|--|]   ", "   |  |    ", "  _/  \\_   "},
 	},
 }
 
@@ -247,6 +243,47 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// projectGroup holds workers grouped by project (owner/repo).
+type projectGroup struct {
+	project string
+	workers []agent.WorkerState
+}
+
+// parseWorkerProject splits a worker name "owner/repo:role" into project and role.
+func parseWorkerProject(worker string) (project, role string) {
+	if idx := strings.LastIndex(worker, ":"); idx != -1 {
+		return worker[:idx], worker[idx+1:]
+	}
+	return worker, ""
+}
+
+// groupWorkersByProject groups workers into project groups, sorted by project name.
+// Workers within each group are sorted by name for stable UI ordering.
+func groupWorkersByProject(workers []agent.WorkerState) []projectGroup {
+	grouped := make(map[string][]agent.WorkerState)
+	var projectOrder []string
+
+	for _, w := range workers {
+		project, _ := parseWorkerProject(w.Worker)
+		if _, exists := grouped[project]; !exists {
+			projectOrder = append(projectOrder, project)
+		}
+		grouped[project] = append(grouped[project], w)
+	}
+
+	sort.Strings(projectOrder)
+
+	groups := make([]projectGroup, 0, len(projectOrder))
+	for _, p := range projectOrder {
+		ws := grouped[p]
+		sort.Slice(ws, func(i, j int) bool {
+			return ws[i].Worker < ws[j].Worker
+		})
+		groups = append(groups, projectGroup{project: p, workers: ws})
+	}
+	return groups
+}
+
 func (m TUIModel) View() string {
 	if m.width == 0 {
 		return "Loading..."
@@ -255,54 +292,216 @@ func (m TUIModel) View() string {
 	var b strings.Builder
 
 	// Header
-	uptime := time.Duration(m.uptime * float64(time.Second))
-	hours := int(uptime.Hours())
-	minutes := int(uptime.Minutes()) % 60
-	connStatus := "Connected"
+	connStatus := "\u25cf Connected"
 	if !m.connected {
-		connStatus = "Disconnected"
+		connStatus = "\u25cb Disconnected"
 	}
+	now := time.Now().UTC()
 	header := headerStyle.Width(m.width).Render(
-		fmt.Sprintf("  OOMPA FACTORY                                      %s  %02d:%02d UTC  uptime %dh%02dm",
+		fmt.Sprintf("\U0001f3ed OOMPA FACTORY%s%s  %02d:%02d UTC",
+			strings.Repeat(" ", max(m.width-55, 1)),
 			connStatus,
-			time.Now().UTC().Hour(),
-			time.Now().UTC().Minute(),
-			hours, minutes,
+			now.Hour(),
+			now.Minute(),
 		),
 	)
 	b.WriteString(header + "\n\n")
 
-	// Worker cards in rows of 3
-	sort.Slice(m.workers, func(i, j int) bool {
-		return m.workers[i].Worker < m.workers[j].Worker
-	})
+	// Group workers by project and render conveyor belts
+	groups := groupWorkersByProject(m.workers)
 
-	cardsPerRow := 3
-	if m.width < 100 {
-		cardsPerRow = 2
-	}
-	if m.width < 65 {
-		cardsPerRow = 1
-	}
-
-	for i := 0; i < len(m.workers); i += cardsPerRow {
-		var cards []string
-		for j := range cardsPerRow {
-			if i+j >= len(m.workers) {
-				break
-			}
-			cards = append(cards, m.renderWorkerCard(m.workers[i+j]))
-		}
-		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, cards...) + "\n")
+	// Tile projects into columns based on terminal width
+	if len(groups) > 0 {
+		b.WriteString(m.renderConveyorBelts(groups))
 	}
 
 	// Activity log
 	availableHeight := max(m.height-lipgloss.Height(b.String())-4, 3)
-
 	b.WriteString(m.renderActivityLog(availableHeight))
 	b.WriteString(dimStyle.Render("  q: quit  j/k: scroll log"))
 
 	return b.String()
+}
+
+// beltWidth returns the width of a conveyor belt based on the number of oompas
+// and the project name length, ensuring the title line fits.
+func beltWidth(numOompas int, project string) int {
+	// Width based on oompa count: spriteWidth per oompa + spriteGap between + margins
+	minSingleOompa := 28
+	w := (spriteWidth+spriteGap)*numOompas + 4
+	if numOompas <= 1 {
+		w = minSingleOompa
+	}
+	// Ensure belt is at least as wide as the project title
+	// (title has ═══ padding + ▶ arrow = ~8 extra chars)
+	titleOverhead := 8
+	if titleLen := len(project) + titleOverhead; titleLen > w {
+		return titleLen
+	}
+	return w
+}
+
+// renderConveyorBelts renders all project groups as conveyor belts tiled into columns.
+func (m TUIModel) renderConveyorBelts(groups []projectGroup) string {
+	var rows []string
+	usedWidth := 0
+	var currentRow []string
+	const interBeltGap = 4 // gap between adjacent belts in a row
+
+	for _, g := range groups {
+		bw := beltWidth(len(g.workers), g.project)
+		neededWidth := bw
+		if usedWidth > 0 {
+			neededWidth += interBeltGap // only add gap after the first belt
+		}
+		if usedWidth > 0 && usedWidth+neededWidth > m.width {
+			// Wrap to next row
+			rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, currentRow...))
+			currentRow = nil
+			usedWidth = 0
+		}
+
+		belt := m.renderConveyorBelt(g, bw)
+		// Pad belt to its full width so JoinHorizontal aligns columns correctly
+		belt = lipgloss.NewStyle().Width(bw + interBeltGap).Render(belt)
+		currentRow = append(currentRow, belt)
+		usedWidth += bw + interBeltGap
+	}
+	if len(currentRow) > 0 {
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, currentRow...))
+	}
+
+	return strings.Join(rows, "\n") + "\n"
+}
+
+// renderConveyorBelt renders a single project as a conveyor belt with oompas on top.
+func (m TUIModel) renderConveyorBelt(g projectGroup, width int) string {
+	var lines []string
+
+	// Belt title line: ═══ project-name ═══▶
+	// Total visible width = leftEquals + titleText + rightEquals + 1 (arrow) = width
+	titleText := " " + g.project + " "
+	remainingWidth := max(width-len(titleText)-1, 4) // -1 for the trailing ▶ arrow
+	leftEquals := remainingWidth / 2
+	rightEquals := remainingWidth - leftEquals
+	beltTitle := conveyorTitleStyle.Render(
+		strings.Repeat("\u2550", leftEquals) + titleText + strings.Repeat("\u2550", rightEquals) + "\u25b6",
+	)
+	lines = append(lines, beltTitle)
+
+	// Render oompa sprites side-by-side
+	for row := range spriteHeight {
+		var rowStr strings.Builder
+		for _, w := range g.workers {
+			state := w.State
+			if state == "" {
+				state = "idle"
+			}
+			frames, ok := spriteFrames[state]
+			if !ok {
+				frames = spriteFrames["idle"]
+			}
+			frameIdx := (m.frame / 2) % len(frames)
+			frame := frames[frameIdx]
+			if row < len(frame) {
+				rowStr.WriteString(frame[row])
+			} else {
+				rowStr.WriteString(strings.Repeat(" ", spriteWidth))
+			}
+			rowStr.WriteString(strings.Repeat(" ", spriteGap))
+		}
+		lines = append(lines, rowStr.String())
+	}
+
+	// Conveyor belt surface: ●●●● dots
+	beltActive := false
+	for _, w := range g.workers {
+		s := w.State
+		if s == "working" || s == "reviewing" || s == "rebasing" {
+			beltActive = true
+			break
+		}
+	}
+	beltDots := m.renderBeltDots(width, beltActive)
+	lines = append(lines, beltStyle.Render(beltDots))
+
+	// Role labels and status line
+	var roleLabels []string
+	var statusParts []string
+	for _, w := range g.workers {
+		_, role := parseWorkerProject(w.Worker)
+		if role == "" {
+			role = "worker"
+		}
+
+		// Build role label with PR numbers
+		label := role
+		if len(w.PRNumbers) > 0 {
+			nums := make([]string, len(w.PRNumbers))
+			for i, n := range w.PRNumbers {
+				nums[i] = fmt.Sprintf("#%d", n)
+			}
+			label += " [" + strings.Join(nums, ",") + "]"
+		}
+		roleLabels = append(roleLabels, label)
+
+		// Status indicator
+		state := w.State
+		if state == "" {
+			state = "idle"
+		}
+		icon := stateIcon(state)
+		action := truncateRunes(w.Action, 20)
+		statusLine := icon + " " + action
+		switch state {
+		case "working", "reviewing", "rebasing":
+			statusParts = append(statusParts, statusWorking.Render(statusLine))
+		case "error", "stuck":
+			statusParts = append(statusParts, statusError.Render(statusLine))
+		default:
+			statusParts = append(statusParts, statusIdle.Render(statusLine))
+		}
+	}
+	lines = append(lines, "  "+strings.Join(roleLabels, "    "))
+	lines = append(lines, "  "+strings.Join(statusParts, "  "))
+	lines = append(lines, "") // blank separator
+
+	return strings.Join(lines, "\n")
+}
+
+// renderBeltDots renders the conveyor belt surface with optional animation.
+func (m TUIModel) renderBeltDots(width int, active bool) string {
+	dotCount := max(width-2, 10)
+	if !active {
+		return "  " + strings.Repeat("\u25cf", dotCount)
+	}
+	// Animated: shift dots right
+	offset := m.frame % 3
+	var dots strings.Builder
+	dots.WriteString("  ")
+	for i := range dotCount {
+		if (i+offset)%3 == 0 {
+			dots.WriteString("\u25cb") // hollow dot for animation
+		} else {
+			dots.WriteString("\u25cf") // filled dot
+		}
+	}
+	return dots.String()
+}
+
+// shortWorkerName returns a compact worker name for the activity log.
+// "nmstate/kubernetes-nmstate:prs" -> "kubernetes-nmstate:prs"
+// "qinqon/oompa:issues" -> "oompa:issues"
+func shortWorkerName(worker string) string {
+	project, role := parseWorkerProject(worker)
+	// Use just the repo part (strip owner prefix)
+	if idx := strings.Index(project, "/"); idx != -1 {
+		project = project[idx+1:]
+	}
+	if role != "" {
+		return project + ":" + role
+	}
+	return project
 }
 
 func (m TUIModel) renderWorkerCard(w agent.WorkerState) string {
@@ -360,19 +559,14 @@ func (m TUIModel) renderWorkerCard(w agent.WorkerState) string {
 		lines = append(lines, dimStyle.Render(truncateRunes(detail, 26)))
 	}
 
-	content := strings.Join(lines, "\n")
-
-	// Choose card style
-	style := cardStyle
-	switch state {
-	case "working", "reviewing", "rebasing":
-		style = activeCardStyle
-	case "error", "stuck":
-		style = errorCardStyle
-	}
-
-	return style.Render(content)
+	return strings.Join(lines, "\n")
 }
+
+// Layout thresholds for the activity log.
+const (
+	twoColumnMinWidth = 100 // minimum terminal width for 2-column activity log
+	logWorkerWidth    = 16  // fixed column width for worker names in the log
+)
 
 func (m TUIModel) renderActivityLog(height int) string {
 	title := fmt.Sprintf(" Activity Log (%d events)", len(m.events))
@@ -393,22 +587,48 @@ func (m TUIModel) renderActivityLog(height int) string {
 		// -2 for title and border
 		startIdx+height-2, len(sortedEvents))
 
+	visibleEvents := sortedEvents[startIdx:endIdx]
+
 	var lines []string
 	lines = append(lines, titleStyle.Render(title))
-	for _, e := range sortedEvents[startIdx:endIdx] {
-		ts := e.Timestamp.Local().Format("15:04:05")
-		action := e.Action
-		if e.Detail != "" {
-			action += " - " + e.Detail
+
+	if m.width < twoColumnMinWidth {
+		// Single-column layout for narrow terminals
+		for _, e := range visibleEvents {
+			lines = append(lines, formatLogEntry(e, m.width-4))
 		}
-		maxActionLen := max(m.width-35, 20)
-		action = truncateRunes(action, maxActionLen)
-		line := fmt.Sprintf(" %s  %-18s %s", dimStyle.Render(ts), e.Worker, action)
-		lines = append(lines, line)
+	} else {
+		// Two-column layout: split available events into two columns.
+		// Use lipgloss.Width for column padding because log entries contain
+		// ANSI escape sequences that break fmt.Sprintf byte-based %-*s padding.
+		halfWidth := (m.width - 8) / 2
+		colStyle := lipgloss.NewStyle().Width(halfWidth)
+		for i := 0; i < len(visibleEvents); i += 2 {
+			left := colStyle.Render(formatLogEntry(visibleEvents[i], halfWidth))
+			right := ""
+			if i+1 < len(visibleEvents) {
+				right = formatLogEntry(visibleEvents[i+1], halfWidth)
+			}
+			lines = append(lines, " "+left+"  "+right)
+		}
 	}
 
 	content := strings.Join(lines, "\n")
 	return logStyle.Width(m.width-2).Render(content) + "\n"
+}
+
+// formatLogEntry formats a single log entry for the activity log.
+func formatLogEntry(e agent.Event, maxWidth int) string {
+	ts := e.Timestamp.Local().Format("15:04")
+	worker := truncateRunes(shortWorkerName(e.Worker), logWorkerWidth)
+	action := e.Action
+	if e.Detail != "" {
+		action += " - " + e.Detail
+	}
+	// 5 for "HH:MM" + 2 spaces + 1 gap between worker and action = 8
+	maxActionLen := max(maxWidth-8-logWorkerWidth, 10)
+	action = truncateRunes(action, maxActionLen)
+	return fmt.Sprintf("%s  %-*s %s", dimStyle.Render(ts), logWorkerWidth, worker, action)
 }
 
 // truncateRunes truncates a string to maxLen runes, appending "..." if truncated.

--- a/cmd/oompa/tui_test.go
+++ b/cmd/oompa/tui_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ func TestTUIModel_Update(t *testing.T) {
 	snap := agent.StatusSnapshot{
 		Uptime: 3600,
 		Workers: []agent.WorkerState{
-			{Worker: "test/repo", State: "idle", Action: "Waiting"},
+			{Worker: "test/repo:prs", State: "idle", Action: "Waiting"},
 		},
 	}
 	ch := make(chan agent.Event, 10)
@@ -21,7 +22,7 @@ func TestTUIModel_Update(t *testing.T) {
 	// Send an event message
 	event := agent.Event{
 		Type:      agent.EventWorkerStateChange,
-		Worker:    "test/repo",
+		Worker:    "test/repo:prs",
 		State:     "working",
 		Action:    "Processing issue",
 		Timestamp: time.Now(),
@@ -51,8 +52,8 @@ func TestTUIModel_WorkerCards(t *testing.T) {
 	snap := agent.StatusSnapshot{
 		Uptime: 7200,
 		Workers: []agent.WorkerState{
-			{Worker: "project/prs", State: "working", Action: "Investigating CI", PRNumbers: []int{42, 99}},
-			{Worker: "project/issues", State: "idle", Action: "Waiting"},
+			{Worker: "project/repo:prs", State: "working", Action: "Investigating CI", PRNumbers: []int{42, 99}},
+			{Worker: "project/repo:issues", State: "idle", Action: "Waiting"},
 		},
 	}
 	ch := make(chan agent.Event, 10)
@@ -79,7 +80,7 @@ func TestTUIModel_ScrollLog(t *testing.T) {
 	for i := range events {
 		events[i] = agent.Event{
 			Type:      agent.EventActionStarted,
-			Worker:    "test/repo",
+			Worker:    "test/repo:prs",
 			Action:    "Action",
 			Timestamp: now.Add(time.Duration(i) * time.Minute),
 		}
@@ -142,7 +143,7 @@ func TestSpriteAnimation(t *testing.T) {
 	// Verify frame cycling works
 	snap := agent.StatusSnapshot{
 		Workers: []agent.WorkerState{
-			{Worker: "test", State: "working"},
+			{Worker: "test/repo:prs", State: "working"},
 		},
 	}
 	ch := make(chan agent.Event, 10)
@@ -156,6 +157,172 @@ func TestSpriteAnimation(t *testing.T) {
 		card := model.renderWorkerCard(snap.Workers[0])
 		if card == "" {
 			t.Errorf("empty card at frame %d", frame)
+		}
+	}
+}
+
+func TestParseWorkerProject(t *testing.T) {
+	tests := []struct {
+		worker      string
+		wantProject string
+		wantRole    string
+	}{
+		{"owner/repo:prs", "owner/repo", "prs"},
+		{"owner/repo:issues", "owner/repo", "issues"},
+		{"owner/repo:triage", "owner/repo", "triage"},
+		{"owner/repo", "owner/repo", ""},
+	}
+	for _, tt := range tests {
+		project, role := parseWorkerProject(tt.worker)
+		if project != tt.wantProject {
+			t.Errorf("parseWorkerProject(%q) project = %q, want %q", tt.worker, project, tt.wantProject)
+		}
+		if role != tt.wantRole {
+			t.Errorf("parseWorkerProject(%q) role = %q, want %q", tt.worker, role, tt.wantRole)
+		}
+	}
+}
+
+func TestGroupWorkersByProject(t *testing.T) {
+	workers := []agent.WorkerState{
+		{Worker: "nmstate/kubernetes-nmstate:prs", State: "working"},
+		{Worker: "nmstate/kubernetes-nmstate:issues", State: "idle"},
+		{Worker: "nmstate/kubernetes-nmstate:triage", State: "sleeping"},
+		{Worker: "qinqon/oompa:issues", State: "working"},
+	}
+
+	groups := groupWorkersByProject(workers)
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+
+	// Groups should be sorted by project name
+	if groups[0].project != "nmstate/kubernetes-nmstate" {
+		t.Errorf("expected first group 'nmstate/kubernetes-nmstate', got %q", groups[0].project)
+	}
+	if len(groups[0].workers) != 3 {
+		t.Errorf("expected 3 workers in nmstate group, got %d", len(groups[0].workers))
+	}
+
+	if groups[1].project != "qinqon/oompa" {
+		t.Errorf("expected second group 'qinqon/oompa', got %q", groups[1].project)
+	}
+	if len(groups[1].workers) != 1 {
+		t.Errorf("expected 1 worker in oompa group, got %d", len(groups[1].workers))
+	}
+}
+
+func TestConveyorBeltRendering(t *testing.T) {
+	// Single-oompa belt
+	snap := agent.StatusSnapshot{
+		Workers: []agent.WorkerState{
+			{Worker: "owner/repo:prs", State: "working", Action: "Investigating CI"},
+		},
+	}
+	ch := make(chan agent.Event, 10)
+	model := newTUIModel(snap, ch, nil)
+	model.width = 120
+	model.height = 40
+
+	groups := groupWorkersByProject(model.workers)
+	belt := model.renderConveyorBelt(groups[0], beltWidth(1, groups[0].project))
+	if belt == "" {
+		t.Error("expected non-empty belt rendering")
+	}
+	if !strings.Contains(belt, "owner/repo") {
+		t.Error("expected belt to contain project name")
+	}
+
+	// Multi-oompa belt
+	snap.Workers = []agent.WorkerState{
+		{Worker: "nmstate/k8s-nmstate:prs", State: "working"},
+		{Worker: "nmstate/k8s-nmstate:issues", State: "idle"},
+		{Worker: "nmstate/k8s-nmstate:triage", State: "sleeping"},
+	}
+	model = newTUIModel(snap, ch, nil)
+	model.width = 120
+	model.height = 40
+
+	groups = groupWorkersByProject(model.workers)
+	multiBeltWidth := beltWidth(3, groups[0].project)
+	belt = model.renderConveyorBelt(groups[0], multiBeltWidth)
+	if belt == "" {
+		t.Error("expected non-empty multi-oompa belt")
+	}
+
+	// Multi-oompa belt should be wider than single-oompa
+	singleWidth := beltWidth(1, "x/y")
+	if multiBeltWidth <= singleWidth {
+		t.Errorf("expected multi-oompa belt (%d) wider than single (%d)", multiBeltWidth, singleWidth)
+	}
+}
+
+func TestBeltWidthAdapts(t *testing.T) {
+	single := beltWidth(1, "o/r")
+	double := beltWidth(2, "o/r")
+	triple := beltWidth(3, "o/r")
+
+	if single >= double {
+		t.Errorf("single (%d) should be less than double (%d)", single, double)
+	}
+	if double >= triple {
+		t.Errorf("double (%d) should be less than triple (%d)", double, triple)
+	}
+	if single != 28 {
+		t.Errorf("single oompa belt width should be 28, got %d", single)
+	}
+
+	// Long project name should expand belt width
+	longProject := "ovn-kubernetes/ovn-kubernetes"
+	longWidth := beltWidth(1, longProject)
+	if longWidth < len(longProject)+8 {
+		t.Errorf("belt width (%d) should accommodate project name '%s' + overhead", longWidth, longProject)
+	}
+}
+
+func TestColumnTilingAdaptsToWidth(t *testing.T) {
+	workers := []agent.WorkerState{
+		{Worker: "proj-a/repo:prs", State: "working"},
+		{Worker: "proj-b/repo:prs", State: "idle"},
+		{Worker: "proj-c/repo:prs", State: "sleeping"},
+	}
+	snap := agent.StatusSnapshot{Workers: workers}
+	ch := make(chan agent.Event, 10)
+
+	// Wide terminal: all belts should fit in one row
+	model := newTUIModel(snap, ch, nil)
+	model.width = 200
+	model.height = 40
+	view := model.View()
+	if view == "" {
+		t.Error("expected non-empty view for wide terminal")
+	}
+
+	// Narrow terminal: belts should wrap
+	model = newTUIModel(snap, ch, nil)
+	model.width = 40
+	model.height = 40
+	view = model.View()
+	if view == "" {
+		t.Error("expected non-empty view for narrow terminal")
+	}
+}
+
+func TestShortWorkerName(t *testing.T) {
+	tests := []struct {
+		worker string
+		want   string
+	}{
+		{"nmstate/kubernetes-nmstate:prs", "kubernetes-nmstate:prs"},
+		{"qinqon/oompa:issues", "oompa:issues"},
+		{"owner/repo", "repo"},
+		{"owner/repo:triage", "repo:triage"},
+	}
+	for _, tt := range tests {
+		got := shortWorkerName(tt.worker)
+		if got != tt.want {
+			t.Errorf("shortWorkerName(%q) = %q, want %q", tt.worker, got, tt.want)
 		}
 	}
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
 	TriageJobs        []string       // CI job URLs to monitor for periodic job triage
 	TriageLookback    time.Duration  // time window to check for failed triage runs (0 = latest only)
+	Role              string   // role identifier: "prs", "issues", "triage" (set by BuildRoleEntries)
 	Agent             string   // coding agent backend: "claudecode" or "opencode"
 	AgentModel        string   // model override for OpenCode (empty = default)
 	Version           string   // build version (commit SHA) for comment watermarks

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -341,6 +341,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		// PRs role entries
 		for _, pr := range p.PRs {
 			cfg := baseCfg
+			cfg.Role = "prs"
 			cfg.WatchPRs = pr.Watch
 			cfg.Reactions = stringsOr(pr.Reactions, projReactions)
 			cfg.SkipComments = stringsOr(pr.SkipComment, projSkipComment)
@@ -355,6 +356,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		// Issues role entries
 		for _, issue := range p.Issues {
 			cfg := baseCfg
+			cfg.Role = "issues"
 			cfg.Label = stringOr(issue.Label, projLabel)
 			cfg.OnlyAssigned = boolOr(issue.OnlyAssigned, projOnlyAssigned)
 			cfg.SkipFix = boolOr(issue.SkipFix, projSkipFix)
@@ -376,6 +378,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		// Triage role entries
 		for _, triage := range p.Triage {
 			cfg := baseCfg
+			cfg.Role = "triage"
 			cfg.TriageJobs = triage.Jobs
 			cfg.CreateFlakyIssues = boolOr(triage.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(triage.FlakyLabel, projFlakyLabel)

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -55,7 +55,6 @@ projects:
 	if len(fc.Projects) != 2 {
 		t.Fatalf("expected 2 projects, got %d", len(fc.Projects))
 	}
-
 	// First project
 	p := fc.Projects[0]
 	if p.Repo != "ovn-kubernetes/ovn-kubernetes" {
@@ -73,7 +72,6 @@ projects:
 	if len(p.PRs[0].Watch) != 2 || p.PRs[0].Watch[0] != 6252 {
 		t.Errorf("unexpected watch list %v", p.PRs[0].Watch)
 	}
-
 	// Second project
 	p2 := fc.Projects[1]
 	if p2.Repo != "qinqon/oompa" {
@@ -242,11 +240,13 @@ func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(entries))
 	}
-
 	// First PRs entry inherits project defaults
 	e1 := entries[0]
 	if e1.Role != "prs" {
 		t.Errorf("expected role 'prs', got %q", e1.Role)
+	}
+	if e1.Config.Role != "prs" {
+		t.Errorf("expected Config.Role 'prs', got %q", e1.Config.Role)
 	}
 	if e1.Config.Owner != "owner" || e1.Config.Repo != "repo" {
 		t.Errorf("unexpected owner/repo %s/%s", e1.Config.Owner, e1.Config.Repo)
@@ -266,7 +266,6 @@ func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
 	if e1.Config.Agent != "opencode" {
 		t.Errorf("expected agent 'opencode' from file config, got %q", e1.Config.Agent)
 	}
-
 	// Second PRs entry overrides project defaults
 	e2 := entries[1]
 	if e2.Config.CreateFlakyIssues {
@@ -278,11 +277,13 @@ func TestBuildRoleEntries_TwoTierInheritance(t *testing.T) {
 	if len(e2.Config.SkipComments) != 1 || e2.Config.SkipComments[0] != "ci-infrastructure" {
 		t.Errorf("expected overridden skip-comment, got %v", e2.Config.SkipComments)
 	}
-
 	// Issues entry
 	e3 := entries[2]
 	if e3.Role != "issues" {
 		t.Errorf("expected role 'issues', got %q", e3.Role)
+	}
+	if e3.Config.Role != "issues" {
+		t.Errorf("expected Config.Role 'issues', got %q", e3.Config.Role)
 	}
 	if e3.Config.Label != "ai-label" {
 		t.Errorf("expected label 'ai-label', got %q", e3.Config.Label)
@@ -308,7 +309,6 @@ func TestBuildRoleEntries_MultipleProjectsAndRoles(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(entries))
 	}
-
 	// Check each entry's project is correct
 	if entries[0].Config.Owner != "org1" || entries[0].Config.Repo != "repo1" {
 		t.Error("entry 0 has wrong owner/repo")
@@ -319,7 +319,6 @@ func TestBuildRoleEntries_MultipleProjectsAndRoles(t *testing.T) {
 	if entries[2].Config.Owner != "org2" || entries[2].Config.Repo != "repo2" {
 		t.Error("entry 2 has wrong owner/repo")
 	}
-
 	// Check clone dirs are per-project
 	if entries[0].Config.CloneDir != "/tmp/work/org1/repo1" {
 		t.Errorf("unexpected clone dir %q", entries[0].Config.CloneDir)
@@ -327,10 +326,12 @@ func TestBuildRoleEntries_MultipleProjectsAndRoles(t *testing.T) {
 	if entries[1].Config.CloneDir != "/tmp/work/org2/repo2" {
 		t.Errorf("unexpected clone dir %q", entries[1].Config.CloneDir)
 	}
-
-	// Check triage entry has schedule
+	// Check triage entry has schedule and Config.Role
 	if entries[2].Schedule != "09:00 UTC" {
 		t.Errorf("expected schedule '09:00 UTC', got %q", entries[2].Schedule)
+	}
+	if entries[2].Config.Role != "triage" {
+		t.Errorf("expected Config.Role 'triage', got %q", entries[2].Config.Role)
 	}
 }
 
@@ -353,7 +354,6 @@ func TestBuildRoleEntries_ForkInheritance(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(entries))
 	}
-
 	// PRs entry inherits project fork
 	if entries[0].Config.ForkOwner != "myfork" || entries[0].Config.ForkRepo != "repo" {
 		t.Errorf("PRs: expected fork myfork/repo, got %s/%s", entries[0].Config.ForkOwner, entries[0].Config.ForkRepo)
@@ -361,12 +361,10 @@ func TestBuildRoleEntries_ForkInheritance(t *testing.T) {
 	if entries[0].Config.GitHubHeadOwner != "myfork" {
 		t.Errorf("PRs: expected head owner 'myfork', got %q", entries[0].Config.GitHubHeadOwner)
 	}
-
 	// First issues entry inherits project fork
 	if entries[1].Config.ForkOwner != "myfork" {
 		t.Errorf("Issues[0]: expected fork owner 'myfork', got %q", entries[1].Config.ForkOwner)
 	}
-
 	// Second issues entry overrides fork
 	if entries[2].Config.ForkOwner != "otherfork" || entries[2].Config.ForkRepo != "myrepo" {
 		t.Errorf("Issues[1]: expected fork otherfork/myrepo, got %s/%s", entries[2].Config.ForkOwner, entries[2].Config.ForkRepo)
@@ -389,7 +387,6 @@ func TestParseSchedule_Daily(t *testing.T) {
 	if !next.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, next)
 	}
-
 	// Schedule for 13:00 UTC — should be tomorrow since it's in the past
 	next, err = ParseSchedule("13:00 UTC", now)
 	if err != nil {
@@ -414,7 +411,6 @@ func TestParseSchedule_Weekly(t *testing.T) {
 	if !next.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, next)
 	}
-
 	// Schedule for Wednesday 09:00 UTC — time has passed today, should be next Wednesday
 	next, err = ParseSchedule("09:00 Wednesday UTC", now)
 	if err != nil {
@@ -424,7 +420,6 @@ func TestParseSchedule_Weekly(t *testing.T) {
 	if !next.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, next)
 	}
-
 	// Schedule for Wednesday 15:00 UTC — hasn't happened yet today, should be today
 	next, err = ParseSchedule("15:00 Wednesday UTC", now)
 	if err != nil {
@@ -462,7 +457,6 @@ func TestNewRoleLogger_PRs(t *testing.T) {
 		Config: Config{Owner: "org", Repo: "repo", WatchPRs: []int{1, 2, 3}},
 		Role:   "prs",
 	}
-
 	logger := NewRoleLogger(base, entry)
 	if logger == nil {
 		t.Fatal("expected non-nil logger")
@@ -475,7 +469,6 @@ func TestNewRoleLogger_Issues(t *testing.T) {
 		Config: Config{Owner: "org", Repo: "repo", Label: "good-for-ai"},
 		Role:   "issues",
 	}
-
 	logger := NewRoleLogger(base, entry)
 	if logger == nil {
 		t.Fatal("expected non-nil logger")
@@ -550,37 +543,30 @@ func TestBuildRoleEntries_ReviewersInheritance(t *testing.T) {
 	if len(entries) != 7 {
 		t.Fatalf("expected 7 entries, got %d", len(entries))
 	}
-
 	// PRs[0]: inherits project-level reviewers
 	if len(entries[0].Config.Reviewers) != 2 || entries[0].Config.Reviewers[0] != "proj-reviewer1" {
 		t.Errorf("PRs[0]: expected project reviewers, got %v", entries[0].Config.Reviewers)
 	}
-
 	// PRs[1]: overrides with role-level reviewers
 	if len(entries[1].Config.Reviewers) != 1 || entries[1].Config.Reviewers[0] != "role-reviewer" {
 		t.Errorf("PRs[1]: expected role reviewers, got %v", entries[1].Config.Reviewers)
 	}
-
 	// Issues[0]: inherits project-level reviewers
 	if len(entries[2].Config.Reviewers) != 2 || entries[2].Config.Reviewers[0] != "proj-reviewer1" {
 		t.Errorf("Issues[0]: expected project reviewers, got %v", entries[2].Config.Reviewers)
 	}
-
 	// Issues[1]: overrides with role-level reviewers
 	if len(entries[3].Config.Reviewers) != 1 || entries[3].Config.Reviewers[0] != "issue-reviewer" {
 		t.Errorf("Issues[1]: expected role reviewers, got %v", entries[3].Config.Reviewers)
 	}
-
 	// Triage[0]: inherits project-level reviewers
 	if len(entries[4].Config.Reviewers) != 2 || entries[4].Config.Reviewers[0] != "proj-reviewer1" {
 		t.Errorf("Triage[0]: expected project reviewers, got %v", entries[4].Config.Reviewers)
 	}
-
 	// Triage[1]: overrides with role-level reviewers
 	if len(entries[5].Config.Reviewers) != 1 || entries[5].Config.Reviewers[0] != "triage-reviewer" {
 		t.Errorf("Triage[1]: expected role reviewers, got %v", entries[5].Config.Reviewers)
 	}
-
 	// Second project PRs[0]: no project reviewers, inherits global
 	if len(entries[6].Config.Reviewers) != 1 || entries[6].Config.Reviewers[0] != "global-reviewer" {
 		t.Errorf("Project2 PRs[0]: expected global reviewers, got %v", entries[6].Config.Reviewers)
@@ -612,7 +598,6 @@ projects:
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	p := fc.Projects[0]
 	if len(p.Reviewers) != 2 || p.Reviewers[0] != "alice" || p.Reviewers[1] != "bob" {
 		t.Errorf("expected project reviewers [alice bob], got %v", p.Reviewers)
@@ -651,7 +636,6 @@ func TestBuildRoleEntries_GlobalOverrides(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-
 	if !entries[0].Config.DryRun {
 		t.Error("expected dry-run to propagate from file config")
 	}
@@ -822,7 +806,6 @@ projects:
 	if err != nil {
 		t.Fatalf("unexpected error for valid lookback: %v", err)
 	}
-
 	if fc.Projects[0].Triage[0].Lookback != "24h" {
 		t.Errorf("expected lookback '24h', got %q", fc.Projects[0].Triage[0].Lookback)
 	}
@@ -856,12 +839,10 @@ func TestBuildRoleEntries_TriageLookback(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
-
 	// First triage entry overrides with role-level lookback
 	if entries[0].Config.TriageLookback != overrideLookback {
 		t.Errorf("expected TriageLookback %v, got %v", overrideLookback, entries[0].Config.TriageLookback)
 	}
-
 	// Second triage entry inherits global default lookback
 	if entries[1].Config.TriageLookback != defaultLookback {
 		t.Errorf("expected TriageLookback %v, got %v", defaultLookback, entries[1].Config.TriageLookback)
@@ -892,13 +873,11 @@ func TestBuildRoleEntries_SkipChecksTwoTierInheritance(t *testing.T) {
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
-
 	// First entry inherits project-level skip-checks
 	e1 := entries[0]
 	if len(e1.Config.SkipChecks) != 1 || e1.Config.SkipChecks[0] != "can-be-merged" {
 		t.Errorf("expected inherited skip-checks [can-be-merged], got %v", e1.Config.SkipChecks)
 	}
-
 	// Second entry overrides with role-level skip-checks
 	e2 := entries[1]
 	if len(e2.Config.SkipChecks) != 2 || e2.Config.SkipChecks[0] != "can-be-merged" || e2.Config.SkipChecks[1] != "verified" {
@@ -940,22 +919,18 @@ func TestBuildRoleEntries_SkipChecksIssuesAndTriageInheritance(t *testing.T) {
 	if len(entries) != 4 {
 		t.Fatalf("expected 4 entries, got %d", len(entries))
 	}
-
 	// Issues[0]: inherits project-level skip-checks
 	if len(entries[0].Config.SkipChecks) != 1 || entries[0].Config.SkipChecks[0] != "can-be-merged" {
 		t.Errorf("Issues[0]: expected inherited skip-checks [can-be-merged], got %v", entries[0].Config.SkipChecks)
 	}
-
 	// Issues[1]: overrides with role-level skip-checks
 	if len(entries[1].Config.SkipChecks) != 2 || entries[1].Config.SkipChecks[0] != "can-be-merged" || entries[1].Config.SkipChecks[1] != "verified" {
 		t.Errorf("Issues[1]: expected overridden skip-checks [can-be-merged verified], got %v", entries[1].Config.SkipChecks)
 	}
-
 	// Triage[0]: inherits project-level skip-checks
 	if len(entries[2].Config.SkipChecks) != 1 || entries[2].Config.SkipChecks[0] != "can-be-merged" {
 		t.Errorf("Triage[0]: expected inherited skip-checks [can-be-merged], got %v", entries[2].Config.SkipChecks)
 	}
-
 	// Triage[1]: overrides with role-level skip-checks
 	if len(entries[3].Config.SkipChecks) != 1 || entries[3].Config.SkipChecks[0] != "e2e-check" {
 		t.Errorf("Triage[1]: expected overridden skip-checks [e2e-check], got %v", entries[3].Config.SkipChecks)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -183,9 +183,13 @@ func (a *Agent) emit(event Event) {
 }
 
 // workerName returns the worker identifier for event emission.
-// Uses the config's Owner/Repo as the worker name.
+// Uses the config's Owner/Repo as the base, with an optional :Role suffix.
 func (a *Agent) workerName() string {
-	return a.cfg.Owner + "/" + a.cfg.Repo
+	name := a.cfg.Owner + "/" + a.cfg.Repo
+	if a.cfg.Role != "" {
+		name += ":" + a.cfg.Role
+	}
+	return name
 }
 
 // EmitPollCycleStart emits a poll cycle start event.

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3006,6 +3006,19 @@ func TestProcessCIFailures_SkipChecksAllFailuresSkipped(t *testing.T) {
 	}
 }
 
+func TestWorkerName(t *testing.T) {
+	for _, tt := range []struct{ role, want string }{
+		{"prs", "owner/repo:prs"},
+		{"", "owner/repo"},
+	} {
+		a := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+		a.cfg.Role = tt.role
+		if got := a.workerName(); got != tt.want {
+			t.Errorf("workerName() with role=%q = %q, want %q", tt.role, got, tt.want)
+		}
+	}
+}
+
 func TestProcessCIFailures_SkipChecksDoesNotAffectAllCompleted(t *testing.T) {
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{

--- a/specs/event.md
+++ b/specs/event.md
@@ -29,7 +29,7 @@ const (
 type Event struct {
     Type      EventType `json:"type"`
     Timestamp time.Time `json:"timestamp"`
-    Worker    string    `json:"worker"`              // e.g. "ovn-k/prs"
+    Worker    string    `json:"worker"`              // e.g. "ovn-kubernetes/ovn-kubernetes:prs" (owner/repo:role)
     State     string    `json:"state,omitempty"`      // idle, working, reviewing, rebasing, error, sleeping
     Action    string    `json:"action,omitempty"`     // human-readable description
     Detail    string    `json:"detail,omitempty"`     // extra context

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -71,10 +71,15 @@ RECENT ACTIVITY (last Xh, N events)
 
 ### Layout
 
+Factory floor theme where each project is a conveyor belt line with oompas standing on it:
+
 - Header: "OOMPA FACTORY" with connection status and time
-- Grid: worker cards arranged in rows of 3 (responsive)
-- Each card: ASCII oompa-loompa sprite + state + action description
-- Footer: scrollable activity log with keyboard navigation
+- Conveyor belts: workers grouped by project (owner/repo), each project rendered as a belt (`═══ project-name ═══▶`) with oompa sprites standing on `●●●` dot surfaces
+- Multi-role projects: oompas stand side-by-side on the same belt (e.g., a project with prs, issues, triage roles has 3 oompas on one belt)
+- Column tiling: belts tile left-to-right, wrapping to next row when terminal width runs out
+- Belt sizing: single-oompa belts are ~28 chars wide, multi-oompa belts expand proportionally
+- Belt animation: active oompas have scrolling dots, idle/sleeping oompas have static dots
+- Footer: compact 2-column activity log using short worker names (e.g., `oompa:issues`)
 
 ### Oompa-Loompa Sprites
 
@@ -100,6 +105,17 @@ Sprites animate at ~4 FPS (250ms tick). Animations:
 - `q` / `Ctrl+C` -- quit
 - `↑` / `↓` -- scroll activity log
 - `Tab` -- cycle focus between cards and log
+
+### Worker Name Format
+
+Worker names use the format `"owner/repo:role"` where role is `prs`, `issues`, or `triage`.
+Workers without a role (backward compat) use `"owner/repo"`.
+
+Workers are grouped by project (`owner/repo`) for belt rendering:
+```
+worker "nmstate/kubernetes-nmstate:prs"    -> project "nmstate/kubernetes-nmstate", role "prs"
+worker "nmstate/kubernetes-nmstate:issues" -> project "nmstate/kubernetes-nmstate", role "issues"
+```
 
 ### Bubbletea Model
 
@@ -154,3 +170,9 @@ type EventClient struct {
 - `TestTUIModel_WorkerCards` -- worker cards render correctly
 - `TestTUIModel_ScrollLog` -- log scrolling works
 - `TestSpriteAnimation` -- sprite frames cycle correctly
+- `TestParseWorkerProject` -- parses "owner/repo:role" into project and role
+- `TestGroupWorkersByProject` -- groups workers by project correctly
+- `TestConveyorBeltRendering` -- single-oompa and multi-oompa belts render correctly
+- `TestBeltWidthAdapts` -- belt width scales with number of oompas
+- `TestColumnTilingAdaptsToWidth` -- belts wrap to next row based on terminal width
+- `TestShortWorkerName` -- compact names for activity log


### PR DESCRIPTION
Fixes #157

## Summary

Adds per-role worker identity so multi-role projects register distinct workers (e.g., `nmstate/kubernetes-nmstate:prs`, `:issues`, `:triage`), and replaces the flat card grid TUI with a factory floor layout that groups oompas by project on conveyor belts.

## Changes

- **`pkg/agent/config.go`**: Add `Role string` field to `Config` struct
- **`pkg/agent/fileconfig.go`**: Set `cfg.Role` in `BuildRoleEntries()` for each role type (prs, issues, triage)
- **`pkg/agent/loop.go`**: Update `workerName()` to append `:role` suffix when `cfg.Role` is set, backward-compatible when empty
- **`cmd/oompa/tui.go`**: Replace flat card grid with factory floor layout — workers grouped by project as conveyor belts (`═══ project ═══▶`), oompas side-by-side on belt surfaces (`●●●`), animated dots for active workers, column tiling adapting to terminal width, compact 2-column activity log with short worker names
- **`cmd/oompa/status.go`**: Widen worker column from 35 to 40 chars to accommodate `:role` suffix
- **`pkg/agent/loop_test.go`**: Add `TestWorkerName_WithRole` and `TestWorkerName_WithoutRole` tests
- **`pkg/agent/fileconfig_test.go`**: Add `TestBuildRoleEntries_SetsConfigRole` verifying Config.Role is set for each role type
- **`cmd/oompa/tui_test.go`**: Add tests for project grouping, conveyor belt rendering, belt width scaling, column tiling, short worker names, and worker project parsing
- **`specs/event.md`**: Document worker name format change (`owner/repo:role`)
- **`specs/tui.md`**: Document factory floor layout, worker name format, and new test list

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #157

<!-- oompa-bot v:4bbcbe9 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent roles now included in worker identifiers (owner/repo:role format)
  * TUI redesigned with factory conveyor belt layout grouped by projects
  * Connection status indicator added to TUI header
  * Activity log now adapts to terminal width with responsive 1-2 column layout
  * Status table columns widened for improved readability

* **Documentation**
  * Updated event and TUI specifications with new worker naming format and layout

* **Tests**
  * Comprehensive test coverage for new role-based naming, project grouping, and responsive rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->