### PR TITLE
feat(tui): factory floor layout with project super boxes and animated sprites

### DIFF
--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -49,71 +49,150 @@ func runTUICommand(args []string) {
 	}
 }
 
-// Sprite layout constants.
-const (
-	spriteWidth  = 11 // characters per sprite frame (padded)
-	spriteHeight = 5  // lines per sprite (all frames normalized)
-	spriteGap    = 2  // characters between adjacent oompas
-)
+// ── Styles ──────────────────────────────────────────────────────────
 
-// TUI styles
+const cardInnerWidth = 22
+
 var (
-	headerStyle = lipgloss.NewStyle().
+	tuiHeaderStyle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(lipgloss.Color("229")).
 			Background(lipgloss.Color("57")).
 			Padding(0, 1)
 
-	logStyle = lipgloss.NewStyle().
+	// Inner oompa card styles
+	oompaCardIdle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("238")).
+			Padding(0, 1).
+			Width(cardInnerWidth + 4)
+
+	oompaCardActive = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("39")).
+			Padding(0, 1).
+			Width(cardInnerWidth + 4)
+
+	oompaCardError = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("196")).
+			Padding(0, 1).
+			Width(cardInnerWidth + 4)
+
+	oompaCardScheduled = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("141")).
+				Padding(0, 1).
+				Width(cardInnerWidth + 4)
+
+	// Super box styles (thick border to distinguish from inner cards)
+	superBoxIdle = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(lipgloss.Color("238")).
+			Padding(0, 1)
+
+	superBoxActive = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(lipgloss.Color("39")).
+			Padding(0, 1)
+
+	superBoxError = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(lipgloss.Color("196")).
+			Padding(0, 1)
+
+	superBoxMixed = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(lipgloss.Color("214")).
+			Padding(0, 1)
+
+	projectNameStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("214")).
+				Bold(true)
+
+	roleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("250"))
+
+	prStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("117"))
+
+	stateWorkingStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
+	stateIdleStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("242"))
+	stateErrorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	stateScheduleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
+
+	tuiDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+	beltActiveStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	beltIdleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	beltErrorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+
+	tuiLogStyle = lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder()).
 			BorderForeground(lipgloss.Color("240")).
 			Padding(0, 1)
 
-	titleStyle = lipgloss.NewStyle().Bold(true)
-
-	dimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-
-	statusWorking = lipgloss.NewStyle().Foreground(lipgloss.Color("39")).Bold(true)
-	statusIdle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	statusError   = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-
-	beltStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
-
-	conveyorTitleStyle = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(lipgloss.Color("208"))
-
+	tuiTitleStyle = lipgloss.NewStyle().Bold(true)
 )
 
+// ── Sprite frames ───────────────────────────────────────────────────
+
 // spriteFrames defines animation frames for oompa-loompa sprites per state.
-// All frames are normalized to spriteWidth (11) chars wide and spriteHeight (5) lines tall.
-var spriteFrames = map[string][][]string{
-	"working": {
-		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
-		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
-	},
+var tuiSpriteFrames = map[string][][4]string{
 	"idle": {
-		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
-		{"   ___     ", "  (o.o)    ", " --|--|--  ", "   |  |    ", " _/  \\_    "},
+		{"   ___   ", "  (o.o)  ", " --|--|-- ", "  _/ \\_ "},
+		{"   ___   ", "  (o.o)  ", " --|--|-- ", "  _/ \\_ "},
+	},
+	"working": {
+		{"   ___   ", "  (o.o)  ", " --|--|\\  ", "  _/ \\_🔨"},
+		{"   ___  🔨", "  (o.o)/  ", " --|--|  ", "  _/ \\_  "},
 	},
 	"sleeping": {
-		{"   ___     ", "  (-.- ) Z ", "   |__|    ", "  _/  \\_   ", "           "},
-		{"   ___     ", "  (-.- ) Zz", "   |__|    ", "  _/  \\_   ", "           "},
-		{"   ___     ", "  (-.- )Zzz", "   |__|    ", "  _/  \\_   ", "           "},
-	},
-	"error": {
-		{"   ___     ", "  (x.x)    ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
-		{"   ___     ", "  (x.x)  * ", " --|--|--  ", "   |  |    ", "  _/  \\_   "},
-	},
-	"reviewing": {
-		{"   ___     ", "  (o.o)    ", " --|--|Q   ", "   |  |    ", "  _/  \\_   "},
-		{"   ___     ", "  (o.o)    ", " --|--|q   ", "   |  |    ", "  _/  \\_   "},
+		{"   ___  Z", "  (-.-) z", "   |__|  ", "  _/ \\_  "},
+		{"   ___ Zz", "  (-.-)  ", "   |__|  ", "  _/ \\_  "},
+		{"   ___Zzz", "  (-.-)  ", "   |__|  ", "  _/ \\_  "},
 	},
 	"rebasing": {
-		{"   ___     ", "  (o.o)    ", " --|--|>   ", "   |  |    ", "  _/  \\_   "},
-		{"   ___     ", "  (o.o)    ", " --|--|]   ", "   |  |    ", "  _/  \\_   "},
+		{"  ╠═╬═╣  ", "  ╠═╬═╣  ", "  ╠═╬═╣  ", "  ╠(o.o) "},
+		{"  ╠═╬═╣  ", "  ╠═╬═╣  ", "  ╠(o.o) ", "  ╠--|-- "},
+		{"  ╠═╬═╣  ", "  ╠(o.o) ", "  ╠--|-- ", "  ╠═╬═╣  "},
+		{"  ╠(o.o) ", "  ╠--|-- ", "  ╠═╬═╣  ", "  ╠═╬═╣  "},
+		{"  ╠═╬═╣  ", "  ╠═╬═╣  ", "  ╠═╬═╣  ", "  ╠═╬═╣  "},
+	},
+	"reviewing": {
+		{"   ___   ", "  (o.o)  ", " --|--|🔍 ", "  _/ \\_  "},
+		{"   ___   ", "  (o.o)  ", " --|--|🔎 ", "  _/ \\_  "},
+	},
+	"error": {
+		{"   ___   ", "  (x.x)  ", " --|--|-- ", "  _/ \\_  "},
+		{"   ___ ★ ", "  (x.x)  ", " --|--|-- ", "  _/ \\_  "},
+		{" ★ ___ ★ ", "  (x.x)  ", " --|--|-- ", "  _/ \\_  "},
+	},
+	"scheduled": {
+		{"   ___   ", "  (-.-) ☽", "   |__|  ", "  _/ \\_  "},
+		{"   ___ ☽ ", "  (-.-)  ", "   |__|  ", "  _/ \\_  "},
 	},
 }
+
+// stateLabels maps states to plain descriptive words.
+var stateLabels = map[string]string{
+	"idle":      "idle",
+	"working":   "working",
+	"sleeping":  "sleeping",
+	"rebasing":  "rebasing",
+	"reviewing": "reviewing",
+	"error":     "error",
+	"scheduled": "scheduled",
+}
+
+// ── ProjectGroup ────────────────────────────────────────────────────
+
+type projectGroup struct {
+	name    string
+	workers []agent.WorkerState
+}
+
+// ── TUI Model ───────────────────────────────────────────────────────
 
 // TUIModel is the bubbletea model for the live TUI dashboard.
 type TUIModel struct {
@@ -121,8 +200,8 @@ type TUIModel struct {
 	events       []agent.Event
 	width        int
 	height       int
-	frame        int // animation frame counter
-	logOffset    int // scroll position in activity log
+	frame        int
+	logOffset    int
 	connected    bool
 	eventCh      <-chan agent.Event
 	streamClient *agent.EventClient
@@ -149,7 +228,7 @@ func (m TUIModel) Init() tea.Cmd {
 }
 
 func tickAnimation() tea.Cmd {
-	return tea.Tick(250*time.Millisecond, func(_ time.Time) tea.Msg {
+	return tea.Tick(150*time.Millisecond, func(_ time.Time) tea.Msg {
 		return tickMsg{}
 	})
 }
@@ -190,7 +269,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		m.frame++
-		m.uptime += 0.25
+		m.uptime += 0.15
 		return m, tickAnimation()
 
 	case disconnectedMsg:
@@ -234,54 +313,229 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 
-		// Auto-scroll to top (newest event first in the sorted view)
 		m.logOffset = 0
-
 		return m, listenForEvents(m.eventCh)
 	}
 
 	return m, nil
 }
 
-// projectGroup holds workers grouped by project (owner/repo).
-type projectGroup struct {
-	project string
-	workers []agent.WorkerState
-}
+// ── Rendering ───────────────────────────────────────────────────────
 
-// parseWorkerProject splits a worker name "owner/repo:role" into project and role.
-func parseWorkerProject(worker string) (project, role string) {
-	if idx := strings.LastIndex(worker, ":"); idx != -1 {
-		return worker[:idx], worker[idx+1:]
+func tuiStateIcon(state string) string {
+	switch state {
+	case "working", "reviewing", "rebasing":
+		return "●"
+	case "error":
+		return "✖"
+	case "scheduled":
+		return "◐"
+	default:
+		return "○"
 	}
-	return worker, ""
 }
 
-// groupWorkersByProject groups workers into project groups, sorted by project name.
-// Workers within each group are sorted by name for stable UI ordering.
-func groupWorkersByProject(workers []agent.WorkerState) []projectGroup {
-	grouped := make(map[string][]agent.WorkerState)
-	var projectOrder []string
+func (m TUIModel) renderBelt(state string, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	dotsLen := width - 2
 
+	var buf strings.Builder
+	for i := 0; i < dotsLen; i++ {
+		switch state {
+		case "working", "reviewing", "rebasing":
+			pos := (i + m.frame) % 5
+			if pos < 3 {
+				buf.WriteRune('●')
+			} else {
+				buf.WriteRune('○')
+			}
+		case "error":
+			if m.frame%6 < 3 {
+				buf.WriteRune('○')
+			} else {
+				buf.WriteRune('●')
+			}
+		default:
+			buf.WriteRune('○')
+		}
+	}
+
+	dots := buf.String() + "━▶"
+	switch state {
+	case "working", "reviewing", "rebasing":
+		return beltActiveStyle.Render(dots)
+	case "error":
+		return beltErrorStyle.Render(dots)
+	default:
+		return beltIdleStyle.Render(dots)
+	}
+}
+
+func (m TUIModel) renderOompaCard(w agent.WorkerState) string {
+	cw := cardInnerWidth
+
+	state := w.State
+	if state == "" {
+		state = "idle"
+	}
+
+	// Sprite
+	frames, ok := tuiSpriteFrames[state]
+	if !ok {
+		frames = tuiSpriteFrames["idle"]
+	}
+	frameIdx := (m.frame / 3) % len(frames)
+	sprite := frames[frameIdx]
+
+	// State label
+	label := stateLabels[state]
+	if label == "" {
+		label = state
+	}
+	var labelLine string
+	switch state {
+	case "working", "reviewing", "rebasing":
+		labelLine = stateWorkingStyle.Render("  ~ " + label + " ~")
+	case "error":
+		labelLine = stateErrorStyle.Render("  ~ " + label + " ~")
+	case "scheduled":
+		labelLine = stateScheduleStyle.Render("  ~ " + label + " ~")
+	default:
+		labelLine = stateIdleStyle.Render("  ~ " + label + " ~")
+	}
+
+	// Belt
+	belt := m.renderBelt(state, cw)
+
+	// Role + PRs
+	// Extract role from worker name (format: "owner/repo:role")
+	role := w.Worker
+	if idx := strings.LastIndex(role, ":"); idx >= 0 {
+		role = role[idx+1:]
+	}
+	roleLine := roleStyle.Render(role)
+	if len(w.PRNumbers) > 0 {
+		nums := make([]string, len(w.PRNumbers))
+		for i, n := range w.PRNumbers {
+			nums[i] = fmt.Sprintf("#%d", n)
+		}
+		roleLine += " " + prStyle.Render(strings.Join(nums, ","))
+	}
+
+	// State + action
+	icon := tuiStateIcon(state)
+	stateText := icon + " " + truncateRunes(w.Action, cw-4)
+	var stateLine string
+	switch state {
+	case "working", "reviewing", "rebasing":
+		stateLine = stateWorkingStyle.Render(stateText)
+	case "error":
+		stateLine = stateErrorStyle.Render(stateText)
+	case "scheduled":
+		stateLine = stateScheduleStyle.Render(stateText)
+	default:
+		stateLine = stateIdleStyle.Render(stateText)
+	}
+
+	content := strings.Join([]string{
+		sprite[0],
+		sprite[1],
+		sprite[2],
+		sprite[3],
+		labelLine,
+		belt,
+		roleLine,
+		stateLine,
+	}, "\n")
+
+	// Pick card border style
+	cardStyle := oompaCardIdle
+	switch state {
+	case "working", "reviewing", "rebasing":
+		cardStyle = oompaCardActive
+	case "error":
+		cardStyle = oompaCardError
+	case "scheduled":
+		cardStyle = oompaCardScheduled
+	}
+
+	return cardStyle.Render(content)
+}
+
+// groupWorkersByProject groups workers by project name, preserving order.
+func groupWorkersByProject(workers []agent.WorkerState) []projectGroup {
+	projectMap := make(map[string][]agent.WorkerState)
+	var projectOrder []string
 	for _, w := range workers {
-		project, _ := parseWorkerProject(w.Worker)
-		if _, exists := grouped[project]; !exists {
+		// Extract project from worker name (format: "owner/repo:role" or "owner/repo")
+		project := w.Worker
+		if idx := strings.LastIndex(project, ":"); idx >= 0 {
+			project = project[:idx]
+		}
+		if _, exists := projectMap[project]; !exists {
 			projectOrder = append(projectOrder, project)
 		}
-		grouped[project] = append(grouped[project], w)
+		projectMap[project] = append(projectMap[project], w)
 	}
-
-	sort.Strings(projectOrder)
-
-	groups := make([]projectGroup, 0, len(projectOrder))
-	for _, p := range projectOrder {
-		ws := grouped[p]
-		sort.Slice(ws, func(i, j int) bool {
-			return ws[i].Worker < ws[j].Worker
-		})
-		groups = append(groups, projectGroup{project: p, workers: ws})
+	var groups []projectGroup
+	for _, name := range projectOrder {
+		groups = append(groups, projectGroup{name: name, workers: projectMap[name]})
 	}
 	return groups
+}
+
+// bestGroupState returns the most important state for super box border coloring.
+func bestGroupState(workers []agent.WorkerState) string {
+	hasActive := false
+	hasError := false
+	for _, w := range workers {
+		switch w.State {
+		case "working", "reviewing", "rebasing":
+			hasActive = true
+		case "error":
+			hasError = true
+		}
+	}
+	if hasError {
+		return "error"
+	}
+	if hasActive {
+		return "active"
+	}
+	return "idle"
+}
+
+func (m TUIModel) renderSuperBox(group projectGroup) string {
+	// Render each oompa card
+	var cards []string
+	for _, w := range group.workers {
+		cards = append(cards, m.renderOompaCard(w))
+	}
+
+	// Join cards horizontally
+	innerContent := lipgloss.JoinHorizontal(lipgloss.Top, cards...)
+
+	// Project name header
+	header := " " + projectNameStyle.Render(group.name)
+
+	// Full content
+	fullContent := header + "\n" + innerContent
+
+	// Pick super box style
+	boxStyle := superBoxIdle
+	switch bestGroupState(group.workers) {
+	case "active":
+		boxStyle = superBoxActive
+	case "error":
+		boxStyle = superBoxError
+	}
+	if len(group.workers) > 1 {
+		boxStyle = superBoxMixed
+	}
+
+	return boxStyle.Render(fullContent)
 }
 
 func (m TUIModel) View() string {
@@ -292,343 +546,109 @@ func (m TUIModel) View() string {
 	var b strings.Builder
 
 	// Header
-	connStatus := "\u25cf Connected"
+	uptime := time.Duration(m.uptime * float64(time.Second))
+	hours := int(uptime.Hours())
+	minutes := int(uptime.Minutes()) % 60
+	connStatus := "● Connected"
 	if !m.connected {
-		connStatus = "\u25cb Disconnected"
+		connStatus = "● Disconnected"
 	}
-	now := time.Now().UTC()
-	header := headerStyle.Width(m.width).Render(
-		fmt.Sprintf("\U0001f3ed OOMPA FACTORY%s%s  %02d:%02d UTC",
-			strings.Repeat(" ", max(m.width-55, 1)),
+	header := tuiHeaderStyle.Width(m.width).Render(
+		fmt.Sprintf("  🏭 OOMPA FACTORY                                       %s  %02d:%02d UTC  uptime %dh%02dm",
 			connStatus,
-			now.Hour(),
-			now.Minute(),
+			time.Now().UTC().Hour(),
+			time.Now().UTC().Minute(),
+			hours, minutes,
 		),
 	)
 	b.WriteString(header + "\n\n")
 
-	// Group workers by project and render conveyor belts
+	// Sort workers alphabetically
+	sort.Slice(m.workers, func(i, j int) bool {
+		return m.workers[i].Worker < m.workers[j].Worker
+	})
+
+	// Group workers by project
 	groups := groupWorkersByProject(m.workers)
 
-	// Tile projects into columns based on terminal width
-	if len(groups) > 0 {
-		b.WriteString(m.renderConveyorBelts(groups))
+	// Render all super boxes
+	type renderedBox struct {
+		content string
+		width   int
+	}
+	var boxes []renderedBox
+	for _, g := range groups {
+		rendered := m.renderSuperBox(g)
+		w := lipgloss.Width(rendered)
+		boxes = append(boxes, renderedBox{content: rendered, width: w})
+	}
+
+	// Adaptive layout: pack super boxes into rows
+	gap := 1
+	var currentRow []string
+	currentWidth := 0
+
+	for _, box := range boxes {
+		needed := box.width
+		if currentWidth > 0 {
+			needed += gap
+		}
+		if currentWidth > 0 && currentWidth+needed > m.width {
+			b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, currentRow...) + "\n")
+			currentRow = nil
+			currentWidth = 0
+		}
+		if currentWidth > 0 {
+			currentRow = append(currentRow, strings.Repeat(" ", gap))
+			currentWidth += gap
+		}
+		currentRow = append(currentRow, box.content)
+		currentWidth += box.width
+	}
+	if len(currentRow) > 0 {
+		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, currentRow...) + "\n")
 	}
 
 	// Activity log
-	availableHeight := max(m.height-lipgloss.Height(b.String())-4, 3)
-	b.WriteString(m.renderActivityLog(availableHeight))
-	b.WriteString(dimStyle.Render("  q: quit  j/k: scroll log"))
+	linesUsed := strings.Count(b.String(), "\n")
+	logHeight := max(m.height-linesUsed-2, 3)
+	b.WriteString(m.renderTUIActivityLog(logHeight))
+	b.WriteString(tuiDimStyle.Render("  q: quit  j/k: scroll log"))
 
 	return b.String()
 }
 
-// beltWidth returns the width of a conveyor belt based on the number of oompas
-// and the project name length, ensuring the title line fits.
-func beltWidth(numOompas int, project string) int {
-	// Width based on oompa count: spriteWidth per oompa + spriteGap between + margins
-	minSingleOompa := 28
-	w := (spriteWidth+spriteGap)*numOompas + 4
-	if numOompas <= 1 {
-		w = minSingleOompa
-	}
-	// Ensure belt is at least as wide as the project title
-	// (title has ═══ padding + ▶ arrow = ~8 extra chars)
-	titleOverhead := 8
-	if titleLen := len(project) + titleOverhead; titleLen > w {
-		return titleLen
-	}
-	return w
-}
-
-// renderConveyorBelts renders all project groups as conveyor belts tiled into columns.
-func (m TUIModel) renderConveyorBelts(groups []projectGroup) string {
-	var rows []string
-	usedWidth := 0
-	var currentRow []string
-	const interBeltGap = 4 // gap between adjacent belts in a row
-
-	for _, g := range groups {
-		bw := beltWidth(len(g.workers), g.project)
-		neededWidth := bw
-		if usedWidth > 0 {
-			neededWidth += interBeltGap // only add gap after the first belt
-		}
-		if usedWidth > 0 && usedWidth+neededWidth > m.width {
-			// Wrap to next row
-			rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, currentRow...))
-			currentRow = nil
-			usedWidth = 0
-		}
-
-		belt := m.renderConveyorBelt(g, bw)
-		// Pad belt to its full width so JoinHorizontal aligns columns correctly
-		belt = lipgloss.NewStyle().Width(bw + interBeltGap).Render(belt)
-		currentRow = append(currentRow, belt)
-		usedWidth += bw + interBeltGap
-	}
-	if len(currentRow) > 0 {
-		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, currentRow...))
-	}
-
-	return strings.Join(rows, "\n") + "\n"
-}
-
-// renderConveyorBelt renders a single project as a conveyor belt with oompas on top.
-func (m TUIModel) renderConveyorBelt(g projectGroup, width int) string {
-	var lines []string
-
-	// Belt title line: ═══ project-name ═══▶
-	// Total visible width = leftEquals + titleText + rightEquals + 1 (arrow) = width
-	titleText := " " + g.project + " "
-	remainingWidth := max(width-len(titleText)-1, 4) // -1 for the trailing ▶ arrow
-	leftEquals := remainingWidth / 2
-	rightEquals := remainingWidth - leftEquals
-	beltTitle := conveyorTitleStyle.Render(
-		strings.Repeat("\u2550", leftEquals) + titleText + strings.Repeat("\u2550", rightEquals) + "\u25b6",
-	)
-	lines = append(lines, beltTitle)
-
-	// Render oompa sprites side-by-side
-	for row := range spriteHeight {
-		var rowStr strings.Builder
-		for _, w := range g.workers {
-			state := w.State
-			if state == "" {
-				state = "idle"
-			}
-			frames, ok := spriteFrames[state]
-			if !ok {
-				frames = spriteFrames["idle"]
-			}
-			frameIdx := (m.frame / 2) % len(frames)
-			frame := frames[frameIdx]
-			if row < len(frame) {
-				rowStr.WriteString(frame[row])
-			} else {
-				rowStr.WriteString(strings.Repeat(" ", spriteWidth))
-			}
-			rowStr.WriteString(strings.Repeat(" ", spriteGap))
-		}
-		lines = append(lines, rowStr.String())
-	}
-
-	// Conveyor belt surface: ●●●● dots
-	beltActive := false
-	for _, w := range g.workers {
-		s := w.State
-		if s == "working" || s == "reviewing" || s == "rebasing" {
-			beltActive = true
-			break
-		}
-	}
-	beltDots := m.renderBeltDots(width, beltActive)
-	lines = append(lines, beltStyle.Render(beltDots))
-
-	// Role labels and status line
-	var roleLabels []string
-	var statusParts []string
-	for _, w := range g.workers {
-		_, role := parseWorkerProject(w.Worker)
-		if role == "" {
-			role = "worker"
-		}
-
-		// Build role label with PR numbers
-		label := role
-		if len(w.PRNumbers) > 0 {
-			nums := make([]string, len(w.PRNumbers))
-			for i, n := range w.PRNumbers {
-				nums[i] = fmt.Sprintf("#%d", n)
-			}
-			label += " [" + strings.Join(nums, ",") + "]"
-		}
-		roleLabels = append(roleLabels, label)
-
-		// Status indicator
-		state := w.State
-		if state == "" {
-			state = "idle"
-		}
-		icon := stateIcon(state)
-		action := truncateRunes(w.Action, 20)
-		statusLine := icon + " " + action
-		switch state {
-		case "working", "reviewing", "rebasing":
-			statusParts = append(statusParts, statusWorking.Render(statusLine))
-		case "error", "stuck":
-			statusParts = append(statusParts, statusError.Render(statusLine))
-		default:
-			statusParts = append(statusParts, statusIdle.Render(statusLine))
-		}
-	}
-	lines = append(lines, "  "+strings.Join(roleLabels, "    "))
-	lines = append(lines, "  "+strings.Join(statusParts, "  "))
-	lines = append(lines, "") // blank separator
-
-	return strings.Join(lines, "\n")
-}
-
-// renderBeltDots renders the conveyor belt surface with optional animation.
-func (m TUIModel) renderBeltDots(width int, active bool) string {
-	dotCount := max(width-2, 10)
-	if !active {
-		return "  " + strings.Repeat("\u25cf", dotCount)
-	}
-	// Animated: shift dots right
-	offset := m.frame % 3
-	var dots strings.Builder
-	dots.WriteString("  ")
-	for i := range dotCount {
-		if (i+offset)%3 == 0 {
-			dots.WriteString("\u25cb") // hollow dot for animation
-		} else {
-			dots.WriteString("\u25cf") // filled dot
-		}
-	}
-	return dots.String()
-}
-
-// shortWorkerName returns a compact worker name for the activity log.
-// "nmstate/kubernetes-nmstate:prs" -> "kubernetes-nmstate:prs"
-// "qinqon/oompa:issues" -> "oompa:issues"
-func shortWorkerName(worker string) string {
-	project, role := parseWorkerProject(worker)
-	// Use just the repo part (strip owner prefix)
-	if idx := strings.Index(project, "/"); idx != -1 {
-		project = project[idx+1:]
-	}
-	if role != "" {
-		return project + ":" + role
-	}
-	return project
-}
-
-func (m TUIModel) renderWorkerCard(w agent.WorkerState) string {
-	state := w.State
-	if state == "" {
-		state = "idle"
-	}
-
-	// Get sprite for this state
-	spriteKey := state
-	frames, ok := spriteFrames[spriteKey]
-	if !ok {
-		frames = spriteFrames["idle"]
-	}
-
-	frameIdx := (m.frame / 2) % len(frames) // change every 500ms
-	sprite := frames[frameIdx]
-
-	// Build card content
-	var lines []string
-
-	// Worker name with PR info
-	name := w.Worker
-	if len(w.PRNumbers) > 0 {
-		nums := make([]string, len(w.PRNumbers))
-		for i, n := range w.PRNumbers {
-			nums[i] = fmt.Sprintf("%d", n)
-		}
-		name += " [" + strings.Join(nums, ",") + "]"
-	}
-	lines = append(lines, titleStyle.Render(truncateRunes(name, 26)))
-
-	// Sprite
-	lines = append(lines, sprite...)
-
-	// State
-	stateStr := stateIcon(state) + " " + state
-	switch state {
-	case "working", "reviewing", "rebasing":
-		lines = append(lines, statusWorking.Render(stateStr))
-	case "error", "stuck":
-		lines = append(lines, statusError.Render(stateStr))
-	default:
-		lines = append(lines, statusIdle.Render(stateStr))
-	}
-
-	// Action
-	action := w.Action
-	if action != "" {
-		lines = append(lines, truncateRunes(action, 26))
-	}
-	// Detail
-	detail := w.Detail
-	if detail != "" {
-		lines = append(lines, dimStyle.Render(truncateRunes(detail, 26)))
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-// Layout thresholds for the activity log.
-const (
-	twoColumnMinWidth = 100 // minimum terminal width for 2-column activity log
-	logWorkerWidth    = 16  // fixed column width for worker names in the log
-)
-
-func (m TUIModel) renderActivityLog(height int) string {
+func (m TUIModel) renderTUIActivityLog(height int) string {
 	title := fmt.Sprintf(" Activity Log (%d events)", len(m.events))
 
-	// Sort events newest first for display
 	sortedEvents := make([]agent.Event, len(m.events))
 	copy(sortedEvents, m.events)
 	sort.Slice(sortedEvents, func(i, j int) bool {
 		return sortedEvents[i].Timestamp.After(sortedEvents[j].Timestamp)
 	})
 
-	// Apply scroll offset
 	startIdx := m.logOffset
 	if startIdx >= len(sortedEvents) {
 		startIdx = 0
 	}
-	endIdx := min(
-		// -2 for title and border
-		startIdx+height-2, len(sortedEvents))
-
-	visibleEvents := sortedEvents[startIdx:endIdx]
+	endIdx := min(startIdx+height-2, len(sortedEvents))
 
 	var lines []string
-	lines = append(lines, titleStyle.Render(title))
-
-	if m.width < twoColumnMinWidth {
-		// Single-column layout for narrow terminals
-		for _, e := range visibleEvents {
-			lines = append(lines, formatLogEntry(e, m.width-4))
+	lines = append(lines, tuiTitleStyle.Render(title))
+	for _, e := range sortedEvents[startIdx:endIdx] {
+		ts := e.Timestamp.Local().Format("15:04:05")
+		action := e.Action
+		if e.Detail != "" {
+			action += " - " + e.Detail
 		}
-	} else {
-		// Two-column layout: split available events into two columns.
-		// Use lipgloss.Width for column padding because log entries contain
-		// ANSI escape sequences that break fmt.Sprintf byte-based %-*s padding.
-		halfWidth := (m.width - 8) / 2
-		colStyle := lipgloss.NewStyle().Width(halfWidth)
-		for i := 0; i < len(visibleEvents); i += 2 {
-			left := colStyle.Render(formatLogEntry(visibleEvents[i], halfWidth))
-			right := ""
-			if i+1 < len(visibleEvents) {
-				right = formatLogEntry(visibleEvents[i+1], halfWidth)
-			}
-			lines = append(lines, " "+left+"  "+right)
-		}
+		maxActionLen := max(m.width-35, 20)
+		action = truncateRunes(action, maxActionLen)
+		line := fmt.Sprintf(" %s  %-18s %s", tuiDimStyle.Render(ts), e.Worker, action)
+		lines = append(lines, line)
 	}
 
 	content := strings.Join(lines, "\n")
-	return logStyle.Width(m.width-2).Render(content) + "\n"
-}
-
-// formatLogEntry formats a single log entry for the activity log.
-func formatLogEntry(e agent.Event, maxWidth int) string {
-	ts := e.Timestamp.Local().Format("15:04")
-	worker := truncateRunes(shortWorkerName(e.Worker), logWorkerWidth)
-	action := e.Action
-	if e.Detail != "" {
-		action += " - " + e.Detail
-	}
-	// 5 for "HH:MM" + 2 spaces + 1 gap between worker and action = 8
-	maxActionLen := max(maxWidth-8-logWorkerWidth, 10)
-	action = truncateRunes(action, maxActionLen)
-	return fmt.Sprintf("%s  %-*s %s", dimStyle.Render(ts), logWorkerWidth, worker, action)
+	return tuiLogStyle.Width(m.width - 2).Render(content) + "\n"
 }
 
 // truncateRunes truncates a string to maxLen runes, appending "..." if truncated.

--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -360,7 +360,7 @@ func (m TUIModel) renderBelt(state string, width int) string {
 
 	switch state {
 	case "working", "reviewing", "rebasing":
-		for i := 0; i < dotsLen; i++ {
+		for i := range dotsLen {
 			pos := (i + m.frame) % beltWaveLen
 			if pos < beltWaveFill {
 				buf.WriteRune('●')
@@ -373,11 +373,11 @@ func (m TUIModel) renderBelt(state string, width int) string {
 		if m.frame%beltBlinkLen < beltBlinkFill {
 			dot = '○'
 		}
-		for i := 0; i < dotsLen; i++ {
+		for range dotsLen {
 			buf.WriteRune(dot)
 		}
 	default:
-		for i := 0; i < dotsLen; i++ {
+		for range dotsLen {
 			buf.WriteRune('○')
 		}
 	}
@@ -683,7 +683,7 @@ func (m TUIModel) renderTUIActivityLog(height int) string {
 	}
 
 	content := strings.Join(lines, "\n")
-	return tuiLogStyle.Width(m.width - 2).Render(content) + "\n"
+	return tuiLogStyle.Width(m.width-2).Render(content) + "\n"
 }
 
 // truncateRunes truncates a string to maxLen runes, appending "..." if truncated.

--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -213,8 +213,8 @@ type tickMsg struct{}
 type disconnectedMsg struct{}
 
 func newTUIModel(snap agent.StatusSnapshot, eventCh <-chan agent.Event, streamClient *agent.EventClient) TUIModel {
-	// Sort workers once at construction
-	workers := snap.Workers
+	// Copy and sort workers to avoid mutating the caller's snapshot slice
+	workers := append([]agent.WorkerState(nil), snap.Workers...)
 	sort.Slice(workers, func(i, j int) bool {
 		return workers[i].Worker < workers[j].Worker
 	})
@@ -431,9 +431,10 @@ func (m TUIModel) renderOompaCard(w agent.WorkerState) string {
 
 	// Role + PRs
 	// Extract role from worker name (format: "owner/repo:role")
-	role := w.Worker
-	if idx := strings.LastIndex(role, ":"); idx >= 0 {
-		role = role[idx+1:]
+	// For legacy names without ":", default to "worker"
+	role := "worker"
+	if idx := strings.LastIndex(w.Worker, ":"); idx >= 0 {
+		role = w.Worker[idx+1:]
 	}
 	roleLine := roleStyle.Render(role)
 	if len(w.PRNumbers) > 0 {
@@ -590,15 +591,20 @@ func (m TUIModel) View() string {
 	minutes := int(uptime.Minutes()) % 60
 	connStatus := "● Connected"
 	if !m.connected {
-		connStatus = "● Disconnected"
+		connStatus = "○ Disconnected"
 	}
+	leftPart := "  🏭 OOMPA FACTORY"
+	rightPart := fmt.Sprintf("%s  %02d:%02d UTC  uptime %dh%02dm",
+		connStatus,
+		time.Now().UTC().Hour(),
+		time.Now().UTC().Minute(),
+		hours, minutes,
+	)
+	gap := max(
+		// 4 for padding
+		m.width-lipgloss.Width(leftPart)-lipgloss.Width(rightPart)-4, 2)
 	header := tuiHeaderStyle.Width(m.width).Render(
-		fmt.Sprintf("  🏭 OOMPA FACTORY                                       %s  %02d:%02d UTC  uptime %dh%02dm",
-			connStatus,
-			time.Now().UTC().Hour(),
-			time.Now().UTC().Minute(),
-			hours, minutes,
-		),
+		leftPart + strings.Repeat(" ", gap) + rightPart,
 	)
 	b.WriteString(header + "\n\n")
 
@@ -657,8 +663,10 @@ func (m TUIModel) renderTUIActivityLog(height int) string {
 
 	// Iterate in reverse (newest first) instead of copying and sorting.
 	// Events are appended chronologically, so reverse iteration gives newest first.
-	maxEntries := height - 2
-	startFromEnd := m.logOffset
+	maxEntries := max(height-2, 0)
+	// Clamp offset so we always show at least some events when available
+	maxOffset := max(len(m.events)-maxEntries, 0)
+	startFromEnd := min(m.logOffset, maxOffset)
 	var lines []string
 	lines = append(lines, tuiTitleStyle.Render(title))
 
@@ -677,7 +685,8 @@ func (m TUIModel) renderTUIActivityLog(height int) string {
 		}
 		maxActionLen := max(m.width-35, 20)
 		action = truncateRunes(action, maxActionLen)
-		line := fmt.Sprintf(" %s  %-18s %s", tuiDimStyle.Render(ts), e.Worker, action)
+		worker := truncateRunes(e.Worker, 18)
+		line := fmt.Sprintf(" %s  %-18s %s", tuiDimStyle.Render(ts), worker, action)
 		lines = append(lines, line)
 		count++
 	}

--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -213,8 +213,13 @@ type tickMsg struct{}
 type disconnectedMsg struct{}
 
 func newTUIModel(snap agent.StatusSnapshot, eventCh <-chan agent.Event, streamClient *agent.EventClient) TUIModel {
+	// Sort workers once at construction
+	workers := snap.Workers
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].Worker < workers[j].Worker
+	})
 	return TUIModel{
-		workers:      snap.Workers,
+		workers:      workers,
 		events:       snap.Events,
 		connected:    true,
 		eventCh:      eventCh,
@@ -311,6 +316,10 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				PRNumbers: event.PRNumbers,
 				LastEvent: event.Timestamp,
 			})
+			// Re-sort after adding a new worker
+			sort.Slice(m.workers, func(i, j int) bool {
+				return m.workers[i].Worker < m.workers[j].Worker
+			})
 		}
 
 		m.logOffset = 0
@@ -342,22 +351,33 @@ func (m TUIModel) renderBelt(state string, width int) string {
 	dotsLen := width - 2
 
 	var buf strings.Builder
-	for i := 0; i < dotsLen; i++ {
-		switch state {
-		case "working", "reviewing", "rebasing":
-			pos := (i + m.frame) % 5
-			if pos < 3 {
+	const (
+		beltWaveLen   = 5 // wave pattern length for active belts
+		beltWaveFill  = 3 // filled dots per wave cycle
+		beltBlinkLen  = 6 // blink cycle length for error belts
+		beltBlinkFill = 3 // frames with empty dots per blink cycle
+	)
+
+	switch state {
+	case "working", "reviewing", "rebasing":
+		for i := 0; i < dotsLen; i++ {
+			pos := (i + m.frame) % beltWaveLen
+			if pos < beltWaveFill {
 				buf.WriteRune('●')
 			} else {
 				buf.WriteRune('○')
 			}
-		case "error":
-			if m.frame%6 < 3 {
-				buf.WriteRune('○')
-			} else {
-				buf.WriteRune('●')
-			}
-		default:
+		}
+	case "error":
+		dot := '●'
+		if m.frame%beltBlinkLen < beltBlinkFill {
+			dot = '○'
+		}
+		for i := 0; i < dotsLen; i++ {
+			buf.WriteRune(dot)
+		}
+	default:
+		for i := 0; i < dotsLen; i++ {
 			buf.WriteRune('○')
 		}
 	}
@@ -487,15 +507,35 @@ func groupWorkersByProject(workers []agent.WorkerState) []projectGroup {
 }
 
 // bestGroupState returns the most important state for super box border coloring.
+// Returns "mixed" only when workers have heterogeneous state categories.
 func bestGroupState(workers []agent.WorkerState) string {
 	hasActive := false
 	hasError := false
+	hasIdle := false
 	for _, w := range workers {
 		switch w.State {
 		case "working", "reviewing", "rebasing":
 			hasActive = true
 		case "error":
 			hasError = true
+		default:
+			hasIdle = true
+		}
+	}
+	// Mixed: multiple different state categories present in multi-worker groups
+	if len(workers) > 1 {
+		categories := 0
+		if hasActive {
+			categories++
+		}
+		if hasError {
+			categories++
+		}
+		if hasIdle {
+			categories++
+		}
+		if categories > 1 {
+			return "mixed"
 		}
 	}
 	if hasError {
@@ -523,15 +563,14 @@ func (m TUIModel) renderSuperBox(group projectGroup) string {
 	// Full content
 	fullContent := header + "\n" + innerContent
 
-	// Pick super box style
+	// Pick super box style based on group state
 	boxStyle := superBoxIdle
 	switch bestGroupState(group.workers) {
 	case "active":
 		boxStyle = superBoxActive
 	case "error":
 		boxStyle = superBoxError
-	}
-	if len(group.workers) > 1 {
+	case "mixed":
 		boxStyle = superBoxMixed
 	}
 
@@ -563,12 +602,7 @@ func (m TUIModel) View() string {
 	)
 	b.WriteString(header + "\n\n")
 
-	// Sort workers alphabetically
-	sort.Slice(m.workers, func(i, j int) bool {
-		return m.workers[i].Worker < m.workers[j].Worker
-	})
-
-	// Group workers by project
+	// Group workers by project (workers are kept sorted in Update)
 	groups := groupWorkersByProject(m.workers)
 
 	// Render all super boxes
@@ -583,15 +617,15 @@ func (m TUIModel) View() string {
 		boxes = append(boxes, renderedBox{content: rendered, width: w})
 	}
 
-	// Adaptive layout: pack super boxes into rows
-	gap := 1
+	// Adaptive layout: pack super boxes into rows using lipgloss spacing
+	const boxGap = 1
 	var currentRow []string
 	currentWidth := 0
 
 	for _, box := range boxes {
 		needed := box.width
 		if currentWidth > 0 {
-			needed += gap
+			needed += boxGap
 		}
 		if currentWidth > 0 && currentWidth+needed > m.width {
 			b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, currentRow...) + "\n")
@@ -599,8 +633,8 @@ func (m TUIModel) View() string {
 			currentWidth = 0
 		}
 		if currentWidth > 0 {
-			currentRow = append(currentRow, strings.Repeat(" ", gap))
-			currentWidth += gap
+			currentRow = append(currentRow, lipgloss.NewStyle().PaddingRight(boxGap).Render(""))
+			currentWidth += boxGap
 		}
 		currentRow = append(currentRow, box.content)
 		currentWidth += box.width
@@ -610,7 +644,7 @@ func (m TUIModel) View() string {
 	}
 
 	// Activity log
-	linesUsed := strings.Count(b.String(), "\n")
+	linesUsed := lipgloss.Height(b.String())
 	logHeight := max(m.height-linesUsed-2, 3)
 	b.WriteString(m.renderTUIActivityLog(logHeight))
 	b.WriteString(tuiDimStyle.Render("  q: quit  j/k: scroll log"))
@@ -621,21 +655,21 @@ func (m TUIModel) View() string {
 func (m TUIModel) renderTUIActivityLog(height int) string {
 	title := fmt.Sprintf(" Activity Log (%d events)", len(m.events))
 
-	sortedEvents := make([]agent.Event, len(m.events))
-	copy(sortedEvents, m.events)
-	sort.Slice(sortedEvents, func(i, j int) bool {
-		return sortedEvents[i].Timestamp.After(sortedEvents[j].Timestamp)
-	})
-
-	startIdx := m.logOffset
-	if startIdx >= len(sortedEvents) {
-		startIdx = 0
-	}
-	endIdx := min(startIdx+height-2, len(sortedEvents))
-
+	// Iterate in reverse (newest first) instead of copying and sorting.
+	// Events are appended chronologically, so reverse iteration gives newest first.
+	maxEntries := height - 2
+	startFromEnd := m.logOffset
 	var lines []string
 	lines = append(lines, tuiTitleStyle.Render(title))
-	for _, e := range sortedEvents[startIdx:endIdx] {
+
+	count := 0
+	skipped := 0
+	for i := len(m.events) - 1; i >= 0 && count < maxEntries; i-- {
+		if skipped < startFromEnd {
+			skipped++
+			continue
+		}
+		e := m.events[i]
 		ts := e.Timestamp.Local().Format("15:04:05")
 		action := e.Action
 		if e.Detail != "" {
@@ -645,6 +679,7 @@ func (m TUIModel) renderTUIActivityLog(height int) string {
 		action = truncateRunes(action, maxActionLen)
 		line := fmt.Sprintf(" %s  %-18s %s", tuiDimStyle.Render(ts), e.Worker, action)
 		lines = append(lines, line)
+		count++
 	}
 
 	content := strings.Join(lines, "\n")

--- a/cmd/oompa/tui_test.go
+++ b/cmd/oompa/tui_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +47,7 @@ func TestTUIModel_Update(t *testing.T) {
 	}
 }
 
-func TestTUIModel_WorkerCards(t *testing.T) {
+func TestTUIModel_OompaCards(t *testing.T) {
 	snap := agent.StatusSnapshot{
 		Uptime: 7200,
 		Workers: []agent.WorkerState{
@@ -61,8 +60,8 @@ func TestTUIModel_WorkerCards(t *testing.T) {
 	model.width = 120
 	model.height = 40
 
-	// Render a worker card
-	card := model.renderWorkerCard(snap.Workers[0])
+	// Render an oompa card
+	card := model.renderOompaCard(snap.Workers[0])
 	if card == "" {
 		t.Error("expected non-empty card rendering")
 	}
@@ -71,6 +70,39 @@ func TestTUIModel_WorkerCards(t *testing.T) {
 	view := model.View()
 	if view == "" {
 		t.Error("expected non-empty view")
+	}
+}
+
+func TestTUIModel_SuperBox(t *testing.T) {
+	snap := agent.StatusSnapshot{
+		Uptime: 3600,
+		Workers: []agent.WorkerState{
+			{Worker: "nmstate/k8s-nmstate:prs", State: "rebasing", Action: "3 behind main", PRNumbers: []int{1467}},
+			{Worker: "nmstate/k8s-nmstate:issues", State: "idle", Action: "Waiting"},
+			{Worker: "nmstate/k8s-nmstate:triage", State: "scheduled", Action: "Next 09:00"},
+		},
+	}
+	ch := make(chan agent.Event, 10)
+	model := newTUIModel(snap, ch, nil)
+	model.width = 120
+	model.height = 40
+
+	// Group workers
+	groups := groupWorkersByProject(snap.Workers)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 project group, got %d", len(groups))
+	}
+	if groups[0].name != "nmstate/k8s-nmstate" {
+		t.Errorf("expected project name 'nmstate/k8s-nmstate', got %s", groups[0].name)
+	}
+	if len(groups[0].workers) != 3 {
+		t.Errorf("expected 3 workers in group, got %d", len(groups[0].workers))
+	}
+
+	// Render super box
+	box := model.renderSuperBox(groups[0])
+	if box == "" {
+		t.Error("expected non-empty super box rendering")
 	}
 }
 
@@ -94,7 +126,6 @@ func TestTUIModel_ScrollLog(t *testing.T) {
 	model.width = 120
 	model.height = 40
 
-	// Initial offset should be 0 (newest first)
 	if model.logOffset != 0 {
 		t.Errorf("expected initial logOffset 0, got %d", model.logOffset)
 	}
@@ -123,20 +154,15 @@ func TestTUIModel_ScrollLog(t *testing.T) {
 
 func TestSpriteAnimation(t *testing.T) {
 	// Verify all sprite states have at least one frame
-	states := []string{"working", "idle", "sleeping", "error", "reviewing", "rebasing"}
+	states := []string{"working", "idle", "sleeping", "error", "reviewing", "rebasing", "scheduled"}
 	for _, state := range states {
-		frames, ok := spriteFrames[state]
+		frames, ok := tuiSpriteFrames[state]
 		if !ok {
 			t.Errorf("missing sprite frames for state %q", state)
 			continue
 		}
 		if len(frames) == 0 {
 			t.Errorf("expected at least 1 frame for state %q", state)
-		}
-		for i, frame := range frames {
-			if len(frame) == 0 {
-				t.Errorf("frame %d for state %q has no lines", i, state)
-			}
 		}
 	}
 
@@ -151,178 +177,51 @@ func TestSpriteAnimation(t *testing.T) {
 	model.width = 120
 	model.height = 40
 
-	// Render at different frames to ensure no panic
 	for frame := range 10 {
 		model.frame = frame
-		card := model.renderWorkerCard(snap.Workers[0])
+		card := model.renderOompaCard(snap.Workers[0])
 		if card == "" {
 			t.Errorf("empty card at frame %d", frame)
 		}
 	}
 }
 
-func TestParseWorkerProject(t *testing.T) {
-	tests := []struct {
-		worker      string
-		wantProject string
-		wantRole    string
-	}{
-		{"owner/repo:prs", "owner/repo", "prs"},
-		{"owner/repo:issues", "owner/repo", "issues"},
-		{"owner/repo:triage", "owner/repo", "triage"},
-		{"owner/repo", "owner/repo", ""},
-	}
-	for _, tt := range tests {
-		project, role := parseWorkerProject(tt.worker)
-		if project != tt.wantProject {
-			t.Errorf("parseWorkerProject(%q) project = %q, want %q", tt.worker, project, tt.wantProject)
-		}
-		if role != tt.wantRole {
-			t.Errorf("parseWorkerProject(%q) role = %q, want %q", tt.worker, role, tt.wantRole)
-		}
-	}
-}
-
 func TestGroupWorkersByProject(t *testing.T) {
 	workers := []agent.WorkerState{
-		{Worker: "nmstate/kubernetes-nmstate:prs", State: "working"},
-		{Worker: "nmstate/kubernetes-nmstate:issues", State: "idle"},
-		{Worker: "nmstate/kubernetes-nmstate:triage", State: "sleeping"},
-		{Worker: "qinqon/oompa:issues", State: "working"},
+		{Worker: "org/repo-a:prs"},
+		{Worker: "org/repo-b:prs"},
+		{Worker: "org/repo-a:issues"},
+		{Worker: "org/repo-c:prs"},
 	}
 
 	groups := groupWorkersByProject(workers)
-
-	if len(groups) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(groups))
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
 	}
-
-	// Groups should be sorted by project name
-	if groups[0].project != "nmstate/kubernetes-nmstate" {
-		t.Errorf("expected first group 'nmstate/kubernetes-nmstate', got %q", groups[0].project)
+	if groups[0].name != "org/repo-a" {
+		t.Errorf("expected first group 'org/repo-a', got %s", groups[0].name)
 	}
-	if len(groups[0].workers) != 3 {
-		t.Errorf("expected 3 workers in nmstate group, got %d", len(groups[0].workers))
-	}
-
-	if groups[1].project != "qinqon/oompa" {
-		t.Errorf("expected second group 'qinqon/oompa', got %q", groups[1].project)
-	}
-	if len(groups[1].workers) != 1 {
-		t.Errorf("expected 1 worker in oompa group, got %d", len(groups[1].workers))
+	if len(groups[0].workers) != 2 {
+		t.Errorf("expected 2 workers in first group, got %d", len(groups[0].workers))
 	}
 }
 
-func TestConveyorBeltRendering(t *testing.T) {
-	// Single-oompa belt
-	snap := agent.StatusSnapshot{
-		Workers: []agent.WorkerState{
-			{Worker: "owner/repo:prs", State: "working", Action: "Investigating CI"},
-		},
-	}
-	ch := make(chan agent.Event, 10)
-	model := newTUIModel(snap, ch, nil)
-	model.width = 120
-	model.height = 40
-
-	groups := groupWorkersByProject(model.workers)
-	belt := model.renderConveyorBelt(groups[0], beltWidth(1, groups[0].project))
-	if belt == "" {
-		t.Error("expected non-empty belt rendering")
-	}
-	if !strings.Contains(belt, "owner/repo") {
-		t.Error("expected belt to contain project name")
-	}
-
-	// Multi-oompa belt
-	snap.Workers = []agent.WorkerState{
-		{Worker: "nmstate/k8s-nmstate:prs", State: "working"},
-		{Worker: "nmstate/k8s-nmstate:issues", State: "idle"},
-		{Worker: "nmstate/k8s-nmstate:triage", State: "sleeping"},
-	}
-	model = newTUIModel(snap, ch, nil)
-	model.width = 120
-	model.height = 40
-
-	groups = groupWorkersByProject(model.workers)
-	multiBeltWidth := beltWidth(3, groups[0].project)
-	belt = model.renderConveyorBelt(groups[0], multiBeltWidth)
-	if belt == "" {
-		t.Error("expected non-empty multi-oompa belt")
-	}
-
-	// Multi-oompa belt should be wider than single-oompa
-	singleWidth := beltWidth(1, "x/y")
-	if multiBeltWidth <= singleWidth {
-		t.Errorf("expected multi-oompa belt (%d) wider than single (%d)", multiBeltWidth, singleWidth)
-	}
-}
-
-func TestBeltWidthAdapts(t *testing.T) {
-	single := beltWidth(1, "o/r")
-	double := beltWidth(2, "o/r")
-	triple := beltWidth(3, "o/r")
-
-	if single >= double {
-		t.Errorf("single (%d) should be less than double (%d)", single, double)
-	}
-	if double >= triple {
-		t.Errorf("double (%d) should be less than triple (%d)", double, triple)
-	}
-	if single != 28 {
-		t.Errorf("single oompa belt width should be 28, got %d", single)
-	}
-
-	// Long project name should expand belt width
-	longProject := "ovn-kubernetes/ovn-kubernetes"
-	longWidth := beltWidth(1, longProject)
-	if longWidth < len(longProject)+8 {
-		t.Errorf("belt width (%d) should accommodate project name '%s' + overhead", longWidth, longProject)
-	}
-}
-
-func TestColumnTilingAdaptsToWidth(t *testing.T) {
-	workers := []agent.WorkerState{
-		{Worker: "proj-a/repo:prs", State: "working"},
-		{Worker: "proj-b/repo:prs", State: "idle"},
-		{Worker: "proj-c/repo:prs", State: "sleeping"},
-	}
-	snap := agent.StatusSnapshot{Workers: workers}
-	ch := make(chan agent.Event, 10)
-
-	// Wide terminal: all belts should fit in one row
-	model := newTUIModel(snap, ch, nil)
-	model.width = 200
-	model.height = 40
-	view := model.View()
-	if view == "" {
-		t.Error("expected non-empty view for wide terminal")
-	}
-
-	// Narrow terminal: belts should wrap
-	model = newTUIModel(snap, ch, nil)
-	model.width = 40
-	model.height = 40
-	view = model.View()
-	if view == "" {
-		t.Error("expected non-empty view for narrow terminal")
-	}
-}
-
-func TestShortWorkerName(t *testing.T) {
+func TestTruncateRunes(t *testing.T) {
 	tests := []struct {
-		worker string
+		input  string
+		maxLen int
 		want   string
 	}{
-		{"nmstate/kubernetes-nmstate:prs", "kubernetes-nmstate:prs"},
-		{"qinqon/oompa:issues", "oompa:issues"},
-		{"owner/repo", "repo"},
-		{"owner/repo:triage", "repo:triage"},
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"ab", 3, "ab"},
+		{"abcd", 3, "..."},
+		{"", 5, ""},
 	}
 	for _, tt := range tests {
-		got := shortWorkerName(tt.worker)
+		got := truncateRunes(tt.input, tt.maxLen)
 		if got != tt.want {
-			t.Errorf("shortWorkerName(%q) = %q, want %q", tt.worker, got, tt.want)
+			t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Redesign the TUI dashboard with a factory floor theme. Each project gets a thick-bordered super box containing individual rounded-bordered oompa cards. Sprites are animated with state-specific actions, and each oompa has its own conveyor belt dots.

## Changes

- **Project super boxes**: Workers grouped by project inside thick-bordered containers. Border color reflects the busiest worker state (blue=active, red=error, orange=mixed, gray=idle)
- **Oompa cards inside super boxes**: Each worker gets its own rounded-bordered card with sprite, belt, role, and state info
- **4-line animated sprites** with state-specific animations:
  - Working: hammer swinging up/down
  - Sleeping: Z's drifting across frames
  - Rebasing: climbing a ladder, goes up and disappears, loops back
  - Reviewing: magnifying glass alternating
  - Error: stars appearing around head
  - Scheduled: moon drifting
- **Conveyor belt dots** per oompa: animated `●○` wave for active, static `○○○` for idle, blinking for error
- **State labels**: plain descriptive words (`working`, `rebasing`, `idle`, etc.) under each sprite
- **Adaptive layout**: super boxes pack into rows based on terminal width
- **Updated tests**: new tests for super box grouping, oompa card rendering, project grouping logic

## Testing

- `go test ./...` passes
- `go vet ./...` clean
- Tested with prototype at `/tmp/opencode/oompa-tui-prototype/`

## Related

Relates to #157