### PR TITLE
feat: add event categories and filtering to oompa status

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,29 @@
+Fixes #160
+
+## Summary
+
+Add event categories and filtering to `oompa status` so routine noise (poll cycles, routine checks, cleanup) is hidden by default, and users can drill down by project, role, PR number, or event category.
+
+## Changes
+
+- Add `EventCategory` enum with 13 categories (poll, check, cleanup, rebase, ci, review, conflict, agent, issue, triage, comment, error, skip)
+- Add `Category` field to `Event` struct with `omitempty` JSON tag
+- Add helper functions: `DefaultEventCategories()`, `AllEventCategories()`, `ParseEventCategories()`
+- Set `Category` on all event emissions in `loop.go`, `ci.go`, `review.go`, `conflicts.go`, `issues.go`
+- Add filtering flags to `oompa status`: `--events`, `--project`, `--role`, `--pr`, `--all-events`
+- Filter both worker table and activity log with AND logic across all filters
+- Show category tags (e.g. `[ci]`, `[agent]`) in activity log output
+- Filter TUI activity log by default categories (hides poll/check/cleanup/skip noise)
+- Update `specs/event.md` and `specs/tui.md` with category and filtering documentation
+- Add comprehensive tests for categories, filtering, and rendering
+
+## Testing
+
+- [x] `go test ./...` passes
+- [x] `go vet ./...` passes
+- [x] `go fix ./...` produces no changes
+- [ ] Manual testing (if applicable)
+
+## Related Issues
+
+Fixes #160

--- a/cmd/oompa/status.go
+++ b/cmd/oompa/status.go
@@ -4,18 +4,75 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/qinqon/oompa/pkg/agent"
 )
 
+// statusFilters holds the parsed filter flags for the status command.
+type statusFilters struct {
+	categories map[agent.EventCategory]bool // nil = use default set
+	allEvents  bool                         // show all categories
+	project    string                       // partial match against worker project
+	role       string                       // exact match against worker role
+	prNumbers  []int                        // match events with these PR numbers
+}
+
 func runStatusCommand(args []string) {
 	fs := flag.NewFlagSet("status", flag.ExitOnError)
 	since := fs.Duration("since", 4*time.Hour, "Lookback window for recent events")
 	socketPath := fs.String("socket", "", "Override socket path (default: auto-detect)")
+	allEvents := fs.Bool("all-events", false, "Show all events including poll cycles and routine checks")
+	eventsFlag := fs.String("events", "", "Comma-separated event categories to show (e.g. ci,error,agent)")
+	projectFlag := fs.String("project", "", "Filter by project (partial match against owner/repo)")
+	roleFlag := fs.String("role", "", "Filter by worker role (e.g. prs, issues, triage)")
+	prFlag := fs.String("pr", "", "Filter by PR number(s), comma-separated")
 	fs.Parse(args) //nolint:errcheck // ExitOnError flag set handles parse errors
+
+	// Parse filters
+	var filters statusFilters
+	filters.allEvents = *allEvents
+
+	if *eventsFlag != "" {
+		if filters.allEvents {
+			fmt.Fprintf(os.Stderr, "Error: --all-events and --events cannot be used together\n")
+			os.Exit(1)
+		}
+		cats, err := agent.ParseEventCategories(*eventsFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		filters.categories = cats
+	}
+
+	// Precompute effective category set so matchesEventFilter doesn't
+	// allocate DefaultEventCategories() on every call.
+	if !filters.allEvents && filters.categories == nil {
+		filters.categories = agent.DefaultEventCategories()
+	}
+
+	filters.project = *projectFlag
+	filters.role = *roleFlag
+
+	if *prFlag != "" {
+		for s := range strings.SplitSeq(*prFlag, ",") {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			n, err := strconv.Atoi(s)
+			if err != nil || n <= 0 {
+				fmt.Fprintf(os.Stderr, "Error: invalid PR number %q\n", s)
+				os.Exit(1)
+			}
+			filters.prNumbers = append(filters.prNumbers, n)
+		}
+	}
 
 	sock := *socketPath
 	if sock == "" {
@@ -36,26 +93,129 @@ func runStatusCommand(args []string) {
 		os.Exit(1)
 	}
 
-	printStatus(snap, *since)
+	printStatus(snap, *since, filters)
 }
 
-func printStatus(snap agent.StatusSnapshot, since time.Duration) {
+// workerProject extracts the project part from a worker name (before ":").
+func workerProject(worker string) string {
+	if idx := strings.LastIndex(worker, ":"); idx >= 0 {
+		return worker[:idx]
+	}
+	return worker
+}
+
+// workerRole extracts the role part from a worker name (after ":").
+func workerRole(worker string) string {
+	if idx := strings.LastIndex(worker, ":"); idx >= 0 {
+		return worker[idx+1:]
+	}
+	return ""
+}
+
+// matchesWorkerFilter returns true if the worker matches the project/role/pr filters.
+func matchesWorkerFilter(w agent.WorkerState, filters statusFilters) bool {
+	if filters.project != "" {
+		project := workerProject(w.Worker)
+		if !strings.Contains(strings.ToLower(project), strings.ToLower(filters.project)) {
+			return false
+		}
+	}
+	if filters.role != "" {
+		role := workerRole(w.Worker)
+		if !strings.EqualFold(role, filters.role) {
+			return false
+		}
+	}
+	if len(filters.prNumbers) > 0 {
+		matched := false
+		for _, pr := range filters.prNumbers {
+			if slices.Contains(w.PRNumbers, pr) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+// matchesEventFilter returns true if the event passes all active filters.
+func matchesEventFilter(e agent.Event, filters statusFilters) bool {
+	// Category filter (categories is precomputed at parse time; nil only when allEvents is true)
+	if !filters.allEvents {
+		if !filters.categories[e.Category] {
+			return false
+		}
+	}
+
+	// Project filter
+	if filters.project != "" {
+		project := workerProject(e.Worker)
+		if !strings.Contains(strings.ToLower(project), strings.ToLower(filters.project)) {
+			return false
+		}
+	}
+
+	// Role filter
+	if filters.role != "" {
+		role := workerRole(e.Worker)
+		if !strings.EqualFold(role, filters.role) {
+			return false
+		}
+	}
+
+	// PR filter
+	if len(filters.prNumbers) > 0 {
+		matched := false
+		for _, pr := range filters.prNumbers {
+			if slices.Contains(e.PRNumbers, pr) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+func printStatus(snap agent.StatusSnapshot, since time.Duration, filters statusFilters) {
+	// Filter workers
+	var workers []agent.WorkerState
+	for _, w := range snap.Workers {
+		if matchesWorkerFilter(w, filters) {
+			workers = append(workers, w)
+		}
+	}
+
 	uptime := time.Duration(snap.Uptime * float64(time.Second))
 	hours := int(uptime.Hours())
 	minutes := int(uptime.Minutes()) % 60
 
-	fmt.Printf("\nOOMPA STATUS (%d workers, uptime %dh %02dm)\n\n", len(snap.Workers), hours, minutes)
+	// Build header with filter info
+	header := fmt.Sprintf("\nOOMPA STATUS (%d workers, uptime %dh %02dm", len(workers), hours, minutes)
+	filterParts := buildFilterDescription(filters)
+	if filterParts != "" {
+		header += ", filter: " + filterParts
+	}
+	header += ")\n"
+	fmt.Print(header)
+	fmt.Println()
 
 	// Sort workers by name
-	sort.Slice(snap.Workers, func(i, j int) bool {
-		return snap.Workers[i].Worker < snap.Workers[j].Worker
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].Worker < workers[j].Worker
 	})
 
 	// Table header
 	fmt.Printf("%-40s %-14s %-30s %s\n", "WORKER", "STATE", "CURRENT ACTION", "LAST EVENT")
 	fmt.Println(strings.Repeat("\u2500", 105))
 
-	for _, w := range snap.Workers {
+	for _, w := range workers {
 		icon := stateIcon(w.State)
 		ago := formatAgo(w.LastEvent)
 		prInfo := ""
@@ -71,33 +231,75 @@ func printStatus(snap agent.StatusSnapshot, since time.Duration) {
 		fmt.Printf("%-40s %s %-12s %-30s %s\n", workerCol, icon, w.State, action, ago)
 	}
 
-	// Recent activity
-	fmt.Printf("\nRECENT ACTIVITY (last %s, %d events)\n\n", formatDuration(since), len(snap.Events))
-
-	// Sort events by time descending
-	sort.Slice(snap.Events, func(i, j int) bool {
-		return snap.Events[i].Timestamp.After(snap.Events[j].Timestamp)
-	})
-
-	maxEvents := min(len(snap.Events), 20)
-
-	for _, e := range snap.Events[:maxEvents] {
-		ts := e.Timestamp.Local().Format("15:04")
-		action := e.Action
-		if e.Detail != "" {
-			action += " — " + e.Detail
+	// Filter events
+	var events []agent.Event
+	for _, e := range snap.Events {
+		if matchesEventFilter(e, filters) {
+			events = append(events, e)
 		}
-		if len(action) > 70 {
-			action = action[:67] + "..."
-		}
-		fmt.Printf("  %s  %-20s %s\n", ts, e.Worker, action)
 	}
 
-	remaining := len(snap.Events) - maxEvents
+	// Recent activity
+	fmt.Printf("\nRECENT ACTIVITY (last %s, %d events)\n\n", formatDuration(since), len(events))
+
+	// Sort events by time descending
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Timestamp.After(events[j].Timestamp)
+	})
+
+	maxEvents := min(len(events), 20)
+
+	for _, e := range events[:maxEvents] {
+		ts := e.Timestamp.Local().Format("15:04")
+		catTag := ""
+		if e.Category != "" {
+			catTag = fmt.Sprintf("[%-8s]", e.Category)
+		} else {
+			catTag = fmt.Sprintf("%-10s", "")
+		}
+		action := e.Action
+		if e.Detail != "" {
+			action += " \u2014 " + e.Detail
+		}
+		action = truncateRunes(action, 60)
+		fmt.Printf("  %s  %s %-18s %s\n", ts, catTag, e.Worker, action)
+	}
+
+	remaining := len(events) - maxEvents
 	if remaining > 0 {
 		fmt.Printf("  ...\n  (%d more events)\n", remaining)
 	}
 	fmt.Println()
+}
+
+// buildFilterDescription creates a human-readable description of active filters.
+func buildFilterDescription(filters statusFilters) string {
+	var parts []string
+	if filters.project != "" {
+		parts = append(parts, "project="+filters.project)
+	}
+	if filters.role != "" {
+		parts = append(parts, "role="+filters.role)
+	}
+	if len(filters.prNumbers) > 0 {
+		nums := make([]string, len(filters.prNumbers))
+		for i, n := range filters.prNumbers {
+			nums[i] = fmt.Sprintf("#%d", n)
+		}
+		parts = append(parts, "pr="+strings.Join(nums, ","))
+	}
+	if filters.categories != nil {
+		var cats []string
+		for c := range filters.categories {
+			cats = append(cats, string(c))
+		}
+		sort.Strings(cats)
+		parts = append(parts, "events="+strings.Join(cats, ","))
+	}
+	if filters.allEvents {
+		parts = append(parts, "all-events")
+	}
+	return strings.Join(parts, ", ")
 }
 
 func stateIcon(state string) string {

--- a/cmd/oompa/status_test.go
+++ b/cmd/oompa/status_test.go
@@ -50,7 +50,7 @@ func TestStatusCommand_Connects(t *testing.T) {
 	}
 
 	// Verify printStatus doesn't panic
-	printStatus(snap, 1*time.Hour)
+	printStatus(snap, 1*time.Hour, statusFilters{})
 }
 
 func TestStatusCommand_NoSocket(t *testing.T) {
@@ -60,4 +60,324 @@ func TestStatusCommand_NoSocket(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when connecting to non-existent socket")
 	}
+}
+
+// Helper to build test events.
+func testEvents() []agent.Event {
+	now := time.Now()
+	return []agent.Event{
+		{Type: agent.EventPollCycleStart, Category: agent.CategoryPollCycle, Worker: "owner/repo:prs", Action: "Poll cycle started", Timestamp: now.Add(-10 * time.Minute)},
+		{Type: agent.EventActionStarted, Category: agent.CategoryCheck, Worker: "owner/repo:prs", Action: "Checking CI status", Timestamp: now.Add(-9 * time.Minute)},
+		{Type: agent.EventActionCompleted, Category: agent.CategoryCI, Worker: "owner/repo:prs", Action: "CI unrelated", PRNumbers: []int{42}, Timestamp: now.Add(-8 * time.Minute)},
+		{Type: agent.EventError, Category: agent.CategoryError, Worker: "nmstate/kube:prs", Action: "Agent failed", PRNumbers: []int{100}, Timestamp: now.Add(-7 * time.Minute)},
+		{Type: agent.EventAgentCompleted, Category: agent.CategoryAgent, Worker: "nmstate/kube:issues", Action: "Agent completed", PRNumbers: []int{200}, Timestamp: now.Add(-6 * time.Minute)},
+		{Type: agent.EventActionCompleted, Category: agent.CategoryReview, Worker: "owner/repo:prs", Action: "Review addressed", PRNumbers: []int{42}, Timestamp: now.Add(-5 * time.Minute)},
+		{Type: agent.EventPollCycleEnd, Category: agent.CategoryPollCycle, Worker: "owner/repo:prs", Action: "Poll cycle completed", Timestamp: now.Add(-4 * time.Minute)},
+		{Type: agent.EventActionStarted, Category: agent.CategoryCleanup, Worker: "owner/repo:prs", Action: "Cleanup complete", Timestamp: now.Add(-3 * time.Minute)},
+		{Type: agent.EventActionStarted, Category: agent.CategorySkip, Worker: "owner/repo:prs", Action: "Skipped CI check", Timestamp: now.Add(-2 * time.Minute)},
+		{Type: agent.EventActionStarted, Category: agent.CategoryTriage, Worker: "nmstate/kube:triage", Action: "Triage run", Timestamp: now.Add(-1 * time.Minute)},
+	}
+}
+
+func TestDefaultFilterExcludesPollCheckCleanupSkip(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{categories: agent.DefaultEventCategories()}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	// poll, check, cleanup, skip should be excluded (4 events)
+	// ci, error, agent, review, triage should be included (5 events)
+	if len(filtered) != 5 {
+		t.Errorf("expected 5 events with default filter, got %d", len(filtered))
+		for _, e := range filtered {
+			t.Logf("  %s: %s", e.Category, e.Action)
+		}
+	}
+
+	// Verify excluded categories are not present
+	for _, e := range filtered {
+		switch e.Category {
+		case agent.CategoryPollCycle, agent.CategoryCheck, agent.CategoryCleanup, agent.CategorySkip:
+			t.Errorf("expected category %q to be excluded", e.Category)
+		}
+	}
+}
+
+func TestAllEventsShowsEverything(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{allEvents: true}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	if len(filtered) != len(events) {
+		t.Errorf("expected all %d events with --all-events, got %d", len(events), len(filtered))
+	}
+}
+
+func TestEventsCategoryFilter(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{
+		categories: map[agent.EventCategory]bool{
+			agent.CategoryCI:    true,
+			agent.CategoryError: true,
+		},
+	}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 events with ci,error filter, got %d", len(filtered))
+		for _, e := range filtered {
+			t.Logf("  %s: %s", e.Category, e.Action)
+		}
+	}
+}
+
+func TestProjectFilter(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{allEvents: true, project: "nmstate"}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	// nmstate/kube:prs and nmstate/kube:issues and nmstate/kube:triage = 3 events
+	if len(filtered) != 3 {
+		t.Errorf("expected 3 nmstate events, got %d", len(filtered))
+		for _, e := range filtered {
+			t.Logf("  %s: %s (%s)", e.Worker, e.Action, e.Category)
+		}
+	}
+}
+
+func TestRoleFilter(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{allEvents: true, role: "triage"}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 triage event, got %d", len(filtered))
+	}
+	if len(filtered) > 0 && filtered[0].Worker != "nmstate/kube:triage" {
+		t.Errorf("expected nmstate/kube:triage, got %s", filtered[0].Worker)
+	}
+}
+
+func TestPRFilter(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{allEvents: true, prNumbers: []int{42}}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	// PR #42 appears in 2 events (ci and review)
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 events for PR #42, got %d", len(filtered))
+		for _, e := range filtered {
+			t.Logf("  %s: %s (%v)", e.Worker, e.Action, e.PRNumbers)
+		}
+	}
+}
+
+func TestCombinedFiltersUseAND(t *testing.T) {
+	events := testEvents()
+	filters := statusFilters{
+		allEvents: true,
+		project:   "nmstate",
+		role:      "prs",
+	}
+
+	var filtered []agent.Event
+	for _, e := range events {
+		if matchesEventFilter(e, filters) {
+			filtered = append(filtered, e)
+		}
+	}
+
+	// Only nmstate/kube:prs events = 1 (error event)
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 event for nmstate+prs, got %d", len(filtered))
+		for _, e := range filtered {
+			t.Logf("  %s: %s", e.Worker, e.Action)
+		}
+	}
+}
+
+func TestWorkerFilterByProject(t *testing.T) {
+	workers := []agent.WorkerState{
+		{Worker: "owner/repo:prs", State: "idle"},
+		{Worker: "nmstate/kube:prs", State: "idle"},
+		{Worker: "nmstate/kube:issues", State: "working"},
+		{Worker: "nmstate/kube:triage", State: "idle"},
+	}
+	filters := statusFilters{project: "nmstate"}
+
+	var filtered []agent.WorkerState
+	for _, w := range workers {
+		if matchesWorkerFilter(w, filters) {
+			filtered = append(filtered, w)
+		}
+	}
+
+	if len(filtered) != 3 {
+		t.Errorf("expected 3 nmstate workers, got %d", len(filtered))
+	}
+}
+
+func TestWorkerFilterByRole(t *testing.T) {
+	workers := []agent.WorkerState{
+		{Worker: "owner/repo:prs", State: "idle"},
+		{Worker: "nmstate/kube:prs", State: "idle"},
+		{Worker: "nmstate/kube:triage", State: "idle"},
+	}
+	filters := statusFilters{role: "prs"}
+
+	var filtered []agent.WorkerState
+	for _, w := range workers {
+		if matchesWorkerFilter(w, filters) {
+			filtered = append(filtered, w)
+		}
+	}
+
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 prs workers, got %d", len(filtered))
+	}
+}
+
+func TestWorkerFilterByPR(t *testing.T) {
+	workers := []agent.WorkerState{
+		{Worker: "owner/repo:prs", State: "idle", PRNumbers: []int{42, 43}},
+		{Worker: "nmstate/kube:prs", State: "idle", PRNumbers: []int{100}},
+		{Worker: "nmstate/kube:issues", State: "working"},
+	}
+	filters := statusFilters{prNumbers: []int{42}}
+
+	var filtered []agent.WorkerState
+	for _, w := range workers {
+		if matchesWorkerFilter(w, filters) {
+			filtered = append(filtered, w)
+		}
+	}
+
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 worker with PR #42, got %d", len(filtered))
+	}
+	if len(filtered) > 0 && filtered[0].Worker != "owner/repo:prs" {
+		t.Errorf("expected owner/repo:prs, got %s", filtered[0].Worker)
+	}
+}
+
+func TestWorkerProject(t *testing.T) {
+	tests := []struct {
+		worker string
+		want   string
+	}{
+		{"owner/repo:prs", "owner/repo"},
+		{"nmstate/kube:triage", "nmstate/kube"},
+		{"legacy-worker", "legacy-worker"},
+	}
+	for _, tt := range tests {
+		got := workerProject(tt.worker)
+		if got != tt.want {
+			t.Errorf("workerProject(%q) = %q, want %q", tt.worker, got, tt.want)
+		}
+	}
+}
+
+func TestWorkerRole(t *testing.T) {
+	tests := []struct {
+		worker string
+		want   string
+	}{
+		{"owner/repo:prs", "prs"},
+		{"nmstate/kube:triage", "triage"},
+		{"legacy-worker", ""},
+	}
+	for _, tt := range tests {
+		got := workerRole(tt.worker)
+		if got != tt.want {
+			t.Errorf("workerRole(%q) = %q, want %q", tt.worker, got, tt.want)
+		}
+	}
+}
+
+func TestBuildFilterDescription(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters statusFilters
+		want    string
+	}{
+		{
+			name:    "no filters",
+			filters: statusFilters{},
+			want:    "",
+		},
+		{
+			name:    "project only",
+			filters: statusFilters{project: "nmstate"},
+			want:    "project=nmstate",
+		},
+		{
+			name:    "all-events",
+			filters: statusFilters{allEvents: true},
+			want:    "all-events",
+		},
+		{
+			name:    "combined",
+			filters: statusFilters{project: "nmstate", role: "prs"},
+			want:    "project=nmstate, role=prs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFilterDescription(tt.filters)
+			if got != tt.want {
+				t.Errorf("buildFilterDescription() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCategoryTagsRendered(t *testing.T) {
+	// Verify printStatus with categories doesn't panic
+	snap := agent.StatusSnapshot{
+		Uptime: 3600,
+		Workers: []agent.WorkerState{
+			{Worker: "test/repo:prs", State: "idle", Action: "Idle", LastEvent: time.Now()},
+		},
+		Events: []agent.Event{
+			{Type: agent.EventActionCompleted, Category: agent.CategoryCI, Worker: "test/repo:prs", Action: "CI unrelated", Timestamp: time.Now()},
+			{Type: agent.EventAgentCompleted, Category: agent.CategoryAgent, Worker: "test/repo:prs", Action: "Agent done", Timestamp: time.Now()},
+		},
+	}
+	// Should not panic
+	printStatus(snap, 1*time.Hour, statusFilters{})
 }

--- a/cmd/oompa/tui.go
+++ b/cmd/oompa/tui.go
@@ -658,14 +658,25 @@ func (m TUIModel) View() string {
 	return b.String()
 }
 
+// defaultCategories caches the default set once for the TUI activity log filter.
+var tuiDefaultCategories = agent.DefaultEventCategories()
+
 func (m TUIModel) renderTUIActivityLog(height int) string {
-	title := fmt.Sprintf(" Activity Log (%d events)", len(m.events))
+	// Count displayable events (those passing the default category filter)
+	displayCount := 0
+	for _, e := range m.events {
+		if e.Category == "" || tuiDefaultCategories[e.Category] {
+			displayCount++
+		}
+	}
+
+	title := fmt.Sprintf(" Activity Log (%d events)", displayCount)
 
 	// Iterate in reverse (newest first) instead of copying and sorting.
 	// Events are appended chronologically, so reverse iteration gives newest first.
 	maxEntries := max(height-2, 0)
 	// Clamp offset so we always show at least some events when available
-	maxOffset := max(len(m.events)-maxEntries, 0)
+	maxOffset := max(displayCount-maxEntries, 0)
 	startFromEnd := min(m.logOffset, maxOffset)
 	var lines []string
 	lines = append(lines, tuiTitleStyle.Render(title))
@@ -673,20 +684,28 @@ func (m TUIModel) renderTUIActivityLog(height int) string {
 	count := 0
 	skipped := 0
 	for i := len(m.events) - 1; i >= 0 && count < maxEntries; i-- {
+		e := m.events[i]
+		// Filter out routine noise in the TUI activity log
+		if e.Category != "" && !tuiDefaultCategories[e.Category] {
+			continue
+		}
 		if skipped < startFromEnd {
 			skipped++
 			continue
 		}
-		e := m.events[i]
 		ts := e.Timestamp.Local().Format("15:04:05")
+		catTag := ""
+		if e.Category != "" {
+			catTag = fmt.Sprintf("[%-8s] ", e.Category)
+		}
 		action := e.Action
 		if e.Detail != "" {
 			action += " - " + e.Detail
 		}
-		maxActionLen := max(m.width-35, 20)
+		maxActionLen := max(m.width-45, 20)
 		action = truncateRunes(action, maxActionLen)
 		worker := truncateRunes(e.Worker, 18)
-		line := fmt.Sprintf(" %s  %-18s %s", tuiDimStyle.Render(ts), worker, action)
+		line := fmt.Sprintf(" %s  %s%-18s %s", tuiDimStyle.Render(ts), catTag, worker, action)
 		lines = append(lines, line)
 		count++
 	}

--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -13,16 +13,18 @@ const maxCIFixAttempts = 3
 // ProcessCIFailures checks CI status for open PRs and invokes Claude to fix failures.
 func (a *Agent) ProcessCIFailures(ctx context.Context) {
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		State:  "working",
-		Action: "Checking CI status",
+		Type:     EventActionStarted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "working",
+		Action:   "Checking CI status",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "CI check complete",
+		Type:     EventActionCompleted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "CI check complete",
 	})
 	// Sequential phase: GitHub API calls, check run fetching, worktree setup
 	var tasks []ciTask
@@ -178,10 +180,27 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 
 	// Sequential phase: Claude invocations and post-processing
 	runSequential(ctx, tasks, func(ctx context.Context, task ciTask) {
+		a.emit(Event{
+			Type:      EventAgentInvocation,
+			Category:  CategoryCI,
+			Worker:    a.workerName(),
+			State:     "working",
+			Action:    fmt.Sprintf("Investigating CI failure: %s", task.failures[0].Name),
+			PRNumbers: []int{task.work.PRNumber},
+		})
 		prompt := buildCIFixPrompt(*task.work, task.failures, task.diff, task.commits, a.cfg.SignedOffBy, a.cfg.SkipFix)
 		result, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
 		if err != nil {
 			a.logger.Error("agent failed to investigate CI", "pr", task.work.PRNumber, "error", err)
+			a.emit(Event{
+				Type:      EventError,
+				Category:  CategoryError,
+				Worker:    a.workerName(),
+				State:     "error",
+				Action:    "CI investigation failed",
+				PRNumbers: []int{task.work.PRNumber},
+				Error:     err.Error(),
+			})
 			task.work.CIFixAttempts++
 			task.work.LastCIStatus = "failure"
 			task.work.LastCheckedCISHA = task.headSHA
@@ -240,6 +259,14 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 // handleCIInfrastructure handles a CI failure classified as an infrastructure issue.
 func (a *Agent) handleCIInfrastructure(ctx context.Context, task ciTask, cleaned string) {
 	a.logger.Info("CI failure is an infrastructure issue", "pr", task.work.PRNumber)
+	a.emit(Event{
+		Type:      EventAgentCompleted,
+		Category:  CategoryCI,
+		Worker:    a.workerName(),
+		State:     "idle",
+		Action:    fmt.Sprintf("CI infrastructure: %s", task.failures[0].Name),
+		PRNumbers: []int{task.work.PRNumber},
+	})
 	idx := strings.Index(cleaned, "INFRASTRUCTURE")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "INFRASTRUCTURE"), " :—–-"))
 	marker := ciMarker(task.headSHA, task.failures[0].Name)
@@ -265,6 +292,14 @@ func (a *Agent) handleCIInfrastructure(ctx context.Context, task ciTask, cleaned
 // handleCIUnrelated handles a CI failure classified as unrelated to PR changes.
 func (a *Agent) handleCIUnrelated(ctx context.Context, task ciTask, cleaned string) {
 	a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
+	a.emit(Event{
+		Type:      EventAgentCompleted,
+		Category:  CategoryCI,
+		Worker:    a.workerName(),
+		State:     "idle",
+		Action:    fmt.Sprintf("CI unrelated: %s", task.failures[0].Name),
+		PRNumbers: []int{task.work.PRNumber},
+	})
 	idx := strings.Index(cleaned, "UNRELATED")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "UNRELATED"), " :—–-"))
 	marker := ciMarker(task.headSHA, task.failures[0].Name)
@@ -418,6 +453,14 @@ func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation s
 
 // handleCIRelated handles a CI failure classified as related to PR changes.
 func (a *Agent) handleCIRelated(ctx context.Context, task ciTask, cleaned string) {
+	a.emit(Event{
+		Type:      EventAgentCompleted,
+		Category:  CategoryCI,
+		Worker:    a.workerName(),
+		State:     "working",
+		Action:    fmt.Sprintf("CI related: %s", task.failures[0].Name),
+		PRNumbers: []int{task.work.PRNumber},
+	})
 	if a.cfg.SkipFix {
 		// Skip-fix mode: just post the analysis, don't try to fix or push
 		a.logger.Info("CI failure is related (skip-fix mode, not pushing)", "pr", task.work.PRNumber)

--- a/pkg/agent/conflicts.go
+++ b/pkg/agent/conflicts.go
@@ -9,16 +9,18 @@ import (
 // For simple rebases when a PR is just behind the base branch, use ProcessRebase instead.
 func (a *Agent) ProcessConflicts(ctx context.Context) {
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		State:  "working",
-		Action: "Checking for merge conflicts",
+		Type:     EventActionStarted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "working",
+		Action:   "Checking for merge conflicts",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Conflict check complete",
+		Type:     EventActionCompleted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Conflict check complete",
 	})
 	// Sequential phase: GitHub API calls, worktree setup, git fetch, automatic rebase attempts
 	var tasks []conflictTask
@@ -65,6 +67,14 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 				a.logger.Error("failed to push after rebase", "pr", work.PRNumber, "error", pushErr)
 			} else {
 				a.logger.Info("rebased and pushed successfully", "pr", work.PRNumber)
+				a.emit(Event{
+					Type:      EventActionCompleted,
+					Category:  CategoryRebase,
+					Worker:    a.workerName(),
+					State:     "idle",
+					Action:    "Rebased and pushed",
+					PRNumbers: []int{work.PRNumber},
+				})
 				if !a.ShouldSkipComment("conflict") {
 					_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
 						fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), a.botComment()))
@@ -94,16 +104,18 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 // If a rebase fails due to conflicts, this delegates to the conflict resolution flow.
 func (a *Agent) ProcessRebase(ctx context.Context) {
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		State:  "rebasing",
-		Action: "Checking for outdated PRs",
+		Type:     EventActionStarted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "rebasing",
+		Action:   "Checking for outdated PRs",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Rebase check complete",
+		Type:     EventActionCompleted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Rebase check complete",
 	})
 	// Sequential phase: check states, try automatic rebase, collect failed conflicts into tasks
 	var tasks []conflictTask
@@ -175,6 +187,14 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 			a.logger.Error("failed to push after rebase", "pr", work.PRNumber, "error", pushErr)
 		} else {
 			a.logger.Info("rebased and pushed successfully", "pr", work.PRNumber)
+			a.emit(Event{
+				Type:      EventActionCompleted,
+				Category:  CategoryRebase,
+				Worker:    a.workerName(),
+				State:     "idle",
+				Action:    "Rebased and pushed",
+				PRNumbers: []int{work.PRNumber},
+			})
 			if !a.ShouldSkipComment("rebase") {
 				_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
 					fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), a.botComment()))
@@ -189,6 +209,15 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 // resolveConflictsSequential invokes the coding agent to resolve conflicts for a list of tasks sequentially.
 func (a *Agent) resolveConflictsSequential(ctx context.Context, tasks []conflictTask) {
 	runSequential(ctx, tasks, func(ctx context.Context, task conflictTask) {
+		a.emit(Event{
+			Type:      EventAgentInvocation,
+			Category:  CategoryConflict,
+			Worker:    a.workerName(),
+			State:     "working",
+			Action:    "Resolving merge conflicts",
+			PRNumbers: []int{task.work.PRNumber},
+		})
+
 		// Get commit count before invoking agent and validate capture
 		commitsBefore := a.getPRCommits(ctx, task.work.WorktreePath)
 		if commitsBefore == nil {
@@ -201,6 +230,15 @@ func (a *Agent) resolveConflictsSequential(ctx context.Context, tasks []conflict
 		_, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
 		if err != nil {
 			a.logger.Error("agent failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)
+			a.emit(Event{
+				Type:      EventError,
+				Category:  CategoryError,
+				Worker:    a.workerName(),
+				State:     "error",
+				Action:    "Conflict resolution failed",
+				PRNumbers: []int{task.work.PRNumber},
+				Error:     err.Error(),
+			})
 			// Post a hidden marker so deduplication skips this SHA on the next cycle
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
 				fmt.Sprintf("<!-- oompa-bot rebase:%s -->", shortSHA(task.headSHA)))
@@ -234,10 +272,20 @@ func (a *Agent) resolveConflictsSequential(ctx context.Context, tasks []conflict
 			// Post a hidden marker so deduplication skips this SHA on the next cycle
 			_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
 				fmt.Sprintf("<!-- oompa-bot rebase:%s -->", shortSHA(task.headSHA)))
-		} else if !a.ShouldSkipComment("conflict") {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), a.botComment())); err != nil {
-				a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
+		} else {
+			a.emit(Event{
+				Type:      EventActionCompleted,
+				Category:  CategoryConflict,
+				Worker:    a.workerName(),
+				State:     "idle",
+				Action:    "Conflicts resolved",
+				PRNumbers: []int{task.work.PRNumber},
+			})
+			if !a.ShouldSkipComment("conflict") {
+				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+					fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), a.botComment())); err != nil {
+					a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
+				}
 			}
 		}
 	})

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -22,18 +23,95 @@ const (
 	EventError             EventType = "error"
 )
 
+// EventCategory classifies events for filtering in the status/TUI views.
+type EventCategory string
+
+const (
+	CategoryPollCycle EventCategory = "poll"     // poll cycle start/end
+	CategoryCheck     EventCategory = "check"    // routine checks (CI, conflicts, rebase, review)
+	CategoryCleanup   EventCategory = "cleanup"  // worktree cleanup
+	CategoryRebase    EventCategory = "rebase"   // rebase performed
+	CategoryCI        EventCategory = "ci"       // CI investigation/fix
+	CategoryReview    EventCategory = "review"   // review feedback addressed
+	CategoryConflict  EventCategory = "conflict" // conflict resolution
+	CategoryAgent     EventCategory = "agent"    // agent invocation/completion
+	CategoryIssue     EventCategory = "issue"    // new issue processing
+	CategoryTriage    EventCategory = "triage"   // triage job processing
+	CategoryComment   EventCategory = "comment"  // comment posted
+	CategoryError     EventCategory = "error"    // errors/warnings
+	CategorySkip      EventCategory = "skip"     // skipped checks/comments
+)
+
+// DefaultEventCategories returns the set of categories shown by default in oompa status.
+// Excludes routine noise: poll, check, cleanup, skip.
+func DefaultEventCategories() map[EventCategory]bool {
+	return map[EventCategory]bool{
+		CategoryRebase:   true,
+		CategoryCI:       true,
+		CategoryReview:   true,
+		CategoryConflict: true,
+		CategoryAgent:    true,
+		CategoryIssue:    true,
+		CategoryTriage:   true,
+		CategoryComment:  true,
+		CategoryError:    true,
+	}
+}
+
+// AllEventCategories returns the set of all valid event categories.
+func AllEventCategories() map[EventCategory]bool {
+	return map[EventCategory]bool{
+		CategoryPollCycle: true,
+		CategoryCheck:     true,
+		CategoryCleanup:   true,
+		CategoryRebase:    true,
+		CategoryCI:        true,
+		CategoryReview:    true,
+		CategoryConflict:  true,
+		CategoryAgent:     true,
+		CategoryIssue:     true,
+		CategoryTriage:    true,
+		CategoryComment:   true,
+		CategoryError:     true,
+		CategorySkip:      true,
+	}
+}
+
+// ParseEventCategories parses a comma-separated string of category names into a set.
+// Returns an error if any category name is invalid.
+func ParseEventCategories(s string) (map[EventCategory]bool, error) {
+	all := AllEventCategories()
+	result := make(map[EventCategory]bool)
+	for part := range strings.SplitSeq(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		cat := EventCategory(part)
+		if !all[cat] {
+			return nil, fmt.Errorf("invalid event category %q", part)
+		}
+		result[cat] = true
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no valid event categories provided")
+	}
+	return result, nil
+}
+
 // Event represents a structured event emitted by the agent.
 type Event struct {
-	Type      EventType `json:"type"`
-	Timestamp time.Time `json:"timestamp"`
-	Worker    string    `json:"worker"`                // e.g. "ovn-k/prs"
-	State     string    `json:"state,omitempty"`       // idle, working, reviewing, rebasing, error, sleeping
-	Action    string    `json:"action,omitempty"`      // human-readable description
-	Detail    string    `json:"detail,omitempty"`      // extra context
-	PRNumbers []int     `json:"prNumbers,omitempty"`   // associated PR numbers
-	CostUSD   float64   `json:"costUSD,omitempty"`     // agent invocation cost
-	Duration  float64   `json:"durationSec,omitempty"` // duration in seconds
-	Error     string    `json:"error,omitempty"`       // error message
+	Type      EventType     `json:"type"`
+	Category  EventCategory `json:"category,omitempty"` // event category for filtering
+	Timestamp time.Time     `json:"timestamp"`
+	Worker    string        `json:"worker"`                // e.g. "ovn-k/prs"
+	State     string        `json:"state,omitempty"`       // idle, working, reviewing, rebasing, error, sleeping
+	Action    string        `json:"action,omitempty"`      // human-readable description
+	Detail    string        `json:"detail,omitempty"`      // extra context
+	PRNumbers []int         `json:"prNumbers,omitempty"`   // associated PR numbers
+	CostUSD   float64       `json:"costUSD,omitempty"`     // agent invocation cost
+	Duration  float64       `json:"durationSec,omitempty"` // duration in seconds
+	Error     string        `json:"error,omitempty"`       // error message
 }
 
 // EventEmitter is the interface for emitting events.

--- a/pkg/agent/event_test.go
+++ b/pkg/agent/event_test.go
@@ -78,6 +78,146 @@ func TestRingBuffer_EventsSince(t *testing.T) {
 	}
 }
 
+func TestDefaultEventCategories(t *testing.T) {
+	defaults := DefaultEventCategories()
+
+	// Should include actionable categories
+	actionable := []EventCategory{CategoryRebase, CategoryCI, CategoryReview, CategoryConflict, CategoryAgent, CategoryIssue, CategoryTriage, CategoryComment, CategoryError}
+	for _, cat := range actionable {
+		if !defaults[cat] {
+			t.Errorf("expected default categories to include %q", cat)
+		}
+	}
+
+	// Should exclude noise categories
+	noise := []EventCategory{CategoryPollCycle, CategoryCheck, CategoryCleanup, CategorySkip}
+	for _, cat := range noise {
+		if defaults[cat] {
+			t.Errorf("expected default categories to exclude %q", cat)
+		}
+	}
+}
+
+func TestAllEventCategories(t *testing.T) {
+	all := AllEventCategories()
+
+	expected := []EventCategory{
+		CategoryPollCycle, CategoryCheck, CategoryCleanup, CategoryRebase,
+		CategoryCI, CategoryReview, CategoryConflict, CategoryAgent,
+		CategoryIssue, CategoryTriage, CategoryComment, CategoryError, CategorySkip,
+	}
+	if len(all) != len(expected) {
+		t.Errorf("expected %d categories, got %d", len(expected), len(all))
+	}
+	for _, cat := range expected {
+		if !all[cat] {
+			t.Errorf("expected all categories to include %q", cat)
+		}
+	}
+}
+
+func TestParseEventCategories(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[EventCategory]bool
+		wantErr bool
+	}{
+		{
+			name:  "single category",
+			input: "ci",
+			want:  map[EventCategory]bool{CategoryCI: true},
+		},
+		{
+			name:  "multiple categories",
+			input: "ci,error,agent",
+			want:  map[EventCategory]bool{CategoryCI: true, CategoryError: true, CategoryAgent: true},
+		},
+		{
+			name:  "with spaces",
+			input: " ci , error ",
+			want:  map[EventCategory]bool{CategoryCI: true, CategoryError: true},
+		},
+		{
+			name:    "invalid category",
+			input:   "ci,invalid",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "only commas",
+			input:   ",,",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseEventCategories(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseEventCategories() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseEventCategories() = %v, want %v", got, tt.want)
+				return
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("ParseEventCategories() missing category %q", k)
+				}
+			}
+		})
+	}
+}
+
+func TestEventCategoryJSONRoundTrip(t *testing.T) {
+	event := Event{
+		Type:     EventActionStarted,
+		Category: CategoryCI,
+		Worker:   "test/repo:prs",
+		Action:   "Checking CI",
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Verify category is in the JSON
+	if !strings.Contains(string(data), `"category":"ci"`) {
+		t.Errorf("expected category in JSON, got: %s", string(data))
+	}
+
+	var decoded Event
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if decoded.Category != CategoryCI {
+		t.Errorf("expected category ci, got %q", decoded.Category)
+	}
+}
+
+func TestEventCategoryOmitEmpty(t *testing.T) {
+	event := Event{
+		Type:   EventActionStarted,
+		Worker: "test/repo",
+		Action: "Test action",
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if strings.Contains(string(data), `"category"`) {
+		t.Errorf("expected category field to be omitted when empty, got: %s", string(data))
+	}
+}
+
 func TestDefaultSocketPath(t *testing.T) {
 	// Test with XDG_RUNTIME_DIR set
 	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -14,22 +14,24 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 	}
 
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		State:  "working",
-		Action: "Scanning for new issues",
+		Type:     EventActionStarted,
+		Category: CategoryIssue,
+		Worker:   a.workerName(),
+		State:    "working",
+		Action:   "Scanning for new issues",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Issue scanning complete",
+		Type:     EventActionCompleted,
+		Category: CategoryIssue,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Issue scanning complete",
 	})
 
 	issues, err := a.gh.ListLabeledIssues(ctx, a.cfg.Owner, a.cfg.Repo, a.cfg.Label)
 	if err != nil {
 		a.logger.Error("failed to list issues", "error", err)
-		a.emit(Event{Type: EventError, Worker: a.workerName(), State: "error", Error: "failed to list issues: " + err.Error()})
+		a.emit(Event{Type: EventError, Category: CategoryError, Worker: a.workerName(), State: "error", Error: "failed to list issues: " + err.Error()})
 		return
 	}
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -195,35 +195,39 @@ func (a *Agent) workerName() string {
 // EmitPollCycleStart emits a poll cycle start event.
 func (a *Agent) EmitPollCycleStart() {
 	a.emit(Event{
-		Type:   EventPollCycleStart,
-		Worker: a.workerName(),
-		State:  "working",
-		Action: "Poll cycle started",
+		Type:     EventPollCycleStart,
+		Category: CategoryPollCycle,
+		Worker:   a.workerName(),
+		State:    "working",
+		Action:   "Poll cycle started",
 	})
 }
 
 // EmitPollCycleEnd emits a poll cycle end event.
 func (a *Agent) EmitPollCycleEnd() {
 	a.emit(Event{
-		Type:   EventPollCycleEnd,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Poll cycle completed",
+		Type:     EventPollCycleEnd,
+		Category: CategoryPollCycle,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Poll cycle completed",
 	})
 }
 
 // CleanupDone removes worktrees for merged or closed PRs.
 func (a *Agent) CleanupDone(ctx context.Context) {
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		Action: "Cleaning up merged/closed PRs",
+		Type:     EventActionStarted,
+		Category: CategoryCleanup,
+		Worker:   a.workerName(),
+		Action:   "Cleaning up merged/closed PRs",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Cleanup complete",
+		Type:     EventActionCompleted,
+		Category: CategoryCleanup,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Cleanup complete",
 	})
 	for key, work := range a.state.ActiveIssues {
 		if work.PRNumber == 0 {

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -9,16 +9,18 @@ import (
 // ProcessReviewComments checks for new review comments and review bodies, then runs Claude to address them.
 func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	a.emit(Event{
-		Type:   EventActionStarted,
-		Worker: a.workerName(),
-		State:  "reviewing",
-		Action: "Checking for review comments",
+		Type:     EventActionStarted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "reviewing",
+		Action:   "Checking for review comments",
 	})
 	defer a.emit(Event{
-		Type:   EventActionCompleted,
-		Worker: a.workerName(),
-		State:  "idle",
-		Action: "Review check complete",
+		Type:     EventActionCompleted,
+		Category: CategoryCheck,
+		Worker:   a.workerName(),
+		State:    "idle",
+		Action:   "Review check complete",
 	})
 	// Sequential phase: filter comments, prepare worktrees, add reactions, build tasks
 	var tasks []reviewTask
@@ -143,6 +145,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	runSequential(ctx, tasks, func(ctx context.Context, task reviewTask) {
 		a.emit(Event{
 			Type:      EventAgentInvocation,
+			Category:  CategoryAgent,
 			Worker:    a.workerName(),
 			State:     "reviewing",
 			Action:    "Addressing review feedback",
@@ -163,6 +166,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			a.logger.Error("agent failed to address review", "pr", task.work.PRNumber, "error", err)
 			a.emit(Event{
 				Type:      EventError,
+				Category:  CategoryError,
 				Worker:    a.workerName(),
 				State:     "error",
 				Action:    "Agent failed to address review",
@@ -174,6 +178,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		}
 		a.emit(Event{
 			Type:      EventAgentCompleted,
+			Category:  CategoryAgent,
 			Worker:    a.workerName(),
 			State:     "idle",
 			Action:    "Review feedback addressed",

--- a/specs/event.md
+++ b/specs/event.md
@@ -23,20 +23,77 @@ const (
 )
 ```
 
+## Event Categories
+
+Each event carries a `Category` field that classifies it for filtering:
+
+```go
+type EventCategory string
+
+const (
+    CategoryPollCycle EventCategory = "poll"     // poll cycle start/end
+    CategoryCheck     EventCategory = "check"    // routine checks (CI, conflicts, rebase, review)
+    CategoryCleanup   EventCategory = "cleanup"  // worktree cleanup
+    CategoryRebase    EventCategory = "rebase"   // rebase performed
+    CategoryCI        EventCategory = "ci"       // CI investigation/fix
+    CategoryReview    EventCategory = "review"   // review feedback addressed
+    CategoryConflict  EventCategory = "conflict" // conflict resolution
+    CategoryAgent     EventCategory = "agent"    // agent invocation/completion
+    CategoryIssue     EventCategory = "issue"    // new issue processing
+    CategoryTriage    EventCategory = "triage"   // triage job processing
+    CategoryComment   EventCategory = "comment"  // comment posted
+    CategoryError     EventCategory = "error"    // errors/warnings
+    CategorySkip      EventCategory = "skip"     // skipped checks/comments
+)
+```
+
+### Default filtering
+
+`oompa status` shows only actionable categories by default:
+
+**Default set:** `rebase, ci, review, conflict, agent, issue, triage, comment, error`
+
+**Excluded by default:** `poll, check, cleanup, skip`
+
+### Category assignment guidelines
+
+| Category | When to use |
+|----------|-------------|
+| `poll` | `EmitPollCycleStart()`, `EmitPollCycleEnd()` |
+| `check` | "Checking CI status", "Checking for merge conflicts", "Checking for review comments", etc. |
+| `cleanup` | "Cleaning up merged/closed PRs", "Cleanup complete" |
+| `rebase` | Rebase attempted, rebase succeeded, rebase failed |
+| `ci` | CI failure detected, CI investigation result |
+| `review` | Review comments detected, review feedback addressed |
+| `conflict` | Conflict detected, conflict resolution attempted/succeeded/failed |
+| `agent` | Agent invoked, agent completed (with cost/duration) |
+| `issue` | New issue discovered, branch created, PR created |
+| `triage` | Triage job started, flaky test found, issue opened |
+| `comment` | Comment posted to PR, flaky issue opened/referenced |
+| `error` | Any error or warning |
+| `skip` | Skipped CI checks, skipped comments |
+
+### Helper functions
+
+- `DefaultEventCategories() map[EventCategory]bool` -- returns the default filter set
+- `AllEventCategories() map[EventCategory]bool` -- returns all valid categories
+- `ParseEventCategories(s string) (map[EventCategory]bool, error)` -- parses comma-separated category names
+
 ## Event Struct
 
 ```go
 type Event struct {
-    Type      EventType `json:"type"`
-    Timestamp time.Time `json:"timestamp"`
-    Worker    string    `json:"worker"`              // e.g. "ovn-kubernetes/ovn-kubernetes:prs" (owner/repo:role)
-    State     string    `json:"state,omitempty"`      // idle, working, reviewing, rebasing, error, sleeping
-    Action    string    `json:"action,omitempty"`     // human-readable description
-    Detail    string    `json:"detail,omitempty"`     // extra context
-    PRNumbers []int     `json:"prNumbers,omitempty"`  // associated PR numbers
-    CostUSD   float64   `json:"costUSD,omitempty"`    // agent invocation cost
-    Duration  float64   `json:"durationSec,omitempty"` // duration in seconds
-    Error     string    `json:"error,omitempty"`      // error message
+    Type      EventType     `json:"type"`
+    Category  EventCategory `json:"category,omitempty"`    // event category for filtering
+    Timestamp time.Time     `json:"timestamp"`
+    Worker    string        `json:"worker"`                // e.g. "ovn-kubernetes/ovn-kubernetes:prs" (owner/repo:role)
+    State     string        `json:"state,omitempty"`       // idle, working, reviewing, rebasing, error, sleeping
+    Action    string        `json:"action,omitempty"`      // human-readable description
+    Detail    string        `json:"detail,omitempty"`      // extra context
+    PRNumbers []int         `json:"prNumbers,omitempty"`   // associated PR numbers
+    CostUSD   float64       `json:"costUSD,omitempty"`     // agent invocation cost
+    Duration  float64       `json:"durationSec,omitempty"` // duration in seconds
+    Error     string        `json:"error,omitempty"`       // error message
 }
 ```
 
@@ -115,7 +172,7 @@ Default buffer size: 1000 events.
 
 ## Protocol
 
-JSON-lines over Unix socket at `$XDG_RUNTIME_DIR/oompa/oompa.sock` (fallback: `/tmp/oompa/oompa.sock`).
+JSON-lines over Unix socket at `$XDG_RUNTIME_DIR/oompa/oompa.sock` (fallback: `/tmp/oompa-<uid>/oompa.sock`).
 
 ### Client Request
 
@@ -155,6 +212,11 @@ Uses `$XDG_RUNTIME_DIR/oompa/oompa.sock`, falls back to a per-user path under `o
 - `TestRingBuffer_Add` -- events are stored and retrievable
 - `TestRingBuffer_Overflow` -- old events are evicted when buffer is full
 - `TestRingBuffer_EventsSince` -- time-windowed retrieval works correctly
+- `TestDefaultEventCategories` -- default set includes actionable categories and excludes noise
+- `TestAllEventCategories` -- all categories are present
+- `TestParseEventCategories` -- comma-separated parsing works, rejects invalid categories
+- `TestEventCategoryJSONRoundTrip` -- category serializes/deserializes correctly
+- `TestEventCategoryOmitEmpty` -- empty category is omitted from JSON
 - `TestSocketEventServer_Snapshot` -- server returns correct snapshot
 - `TestSocketEventServer_Stream` -- server streams events to connected clients
 - `TestSocketEventServer_MultipleClients` -- multiple clients receive events

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -25,13 +25,21 @@ Otherwise, fall through to existing daemon startup.
 
 - `--since <duration>` (default: `4h`) -- lookback window for recent events
 - `--socket <path>` -- override socket path (default: auto-detect)
+- `--all-events` -- show all events including poll cycles and routine checks
+- `--events <categories>` -- comma-separated event categories to show (e.g. `ci,error,agent`)
+- `--project <name>` -- filter by project (partial match against `owner/repo`)
+- `--role <name>` -- filter by worker role (e.g. `prs`, `issues`, `triage`)
+- `--pr <numbers>` -- filter by PR number(s), comma-separated
+
+All filters are AND -- an event must match ALL specified filters.
 
 ### Behavior
 
 1. Connect to Unix socket
 2. Send `{"type": "snapshot", "since": "<duration>"}`
 3. Read `StatusSnapshot` response
-4. Print formatted colored table and exit
+4. Apply filters to workers and events
+5. Print formatted colored table with category tags and exit
 
 ### Output Format
 
@@ -44,7 +52,7 @@ worker/name [PR#,PR#]      ● Working      Description               Xm ago
 
 RECENT ACTIVITY (last Xh, N events)
 
-  HH:MM  worker/name    Event description
+  HH:MM  [category ] worker/name    Event description
   ...
 ```
 
@@ -163,6 +171,20 @@ type EventClient struct {
 
 - `TestStatusCommand_Connects` -- connects to socket and prints output
 - `TestStatusCommand_NoSocket` -- prints error when daemon not running
+- `TestDefaultFilterExcludesPollCheckCleanupSkip` -- default filter excludes noise categories
+- `TestAllEventsShowsEverything` -- `--all-events` shows all categories
+- `TestEventsCategoryFilter` -- `--events ci,error` shows only matching categories
+- `TestProjectFilter` -- `--project nmstate` filters events by project
+- `TestRoleFilter` -- `--role triage` filters events by role
+- `TestPRFilter` -- `--pr 42` matches events with that PR number
+- `TestCombinedFiltersUseAND` -- combined filters use AND logic
+- `TestWorkerFilterByProject` -- worker table filtered by project
+- `TestWorkerFilterByRole` -- worker table filtered by role
+- `TestWorkerFilterByPR` -- worker table filtered by PR number
+- `TestWorkerProject` -- parses project from worker name
+- `TestWorkerRole` -- parses role from worker name
+- `TestBuildFilterDescription` -- human-readable filter summary
+- `TestCategoryTagsRendered` -- category tags render in activity log
 
 ### `tui_test.go`
 


### PR DESCRIPTION
Fixes #160

## Summary

Add event categories and filtering to `oompa status` so routine noise (poll cycles, routine checks, cleanup) is hidden by default, and users can drill down by project, role, PR number, or event category.

## Changes

- Add `EventCategory` enum with 13 categories (poll, check, cleanup, rebase, ci, review, conflict, agent, issue, triage, comment, error, skip)
- Add `Category` field to `Event` struct with `omitempty` JSON tag
- Add helper functions: `DefaultEventCategories()`, `AllEventCategories()`, `ParseEventCategories()`
- Set `Category` on all event emissions in `loop.go`, `ci.go`, `review.go`, `conflicts.go`, `issues.go`
- Add filtering flags to `oompa status`: `--events`, `--project`, `--role`, `--pr`, `--all-events`
- Filter both worker table and activity log with AND logic across all filters
- Show category tags (e.g. `[ci]`, `[agent]`) in activity log output
- Filter TUI activity log by default categories (hides poll/check/cleanup/skip noise)
- Update `specs/event.md` and `specs/tui.md` with category and filtering documentation
- Add comprehensive tests for categories, filtering, and rendering

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #160

<!-- oompa-bot v:ee20a34 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `oompa status` supports filtering with --all-events, --events, --project, --role, and --pr.
  * Events are categorized (multiple category types) and recent activity shows category tags.
  * TUI activity log now hides routine-noise events by default and paginates relative to filtered results.

* **Documentation**
  * Event and status command documentation updated to cover categories and filtering behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/161)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->