### PR TITLE
fix: pass prompts via stdin instead of CLI arguments to avoid argument list too long

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -17,23 +17,23 @@ type ClaudeCodeAgent struct{}
 
 // Run invokes Claude Code in headless mode with streaming output and parses the result.
 // If resume is true, --continue is passed to resume the most recent session in workDir.
+// The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
 func (c *ClaudeCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, resume bool) (AgentResult, error) {
 	args := []string{"-p", "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions"}
 	if resume {
 		args = append(args, "--continue")
 	}
-	args = append(args, prompt)
 
 	var stdout, stderr []byte
 	var err error
 
 	if sr, ok := runner.(StreamingRunner); ok && logger != nil {
-		stdout, stderr, err = sr.RunStream(ctx, workDir, func(line []byte) {
+		stdout, stderr, err = sr.RunStreamWithStdin(ctx, workDir, prompt, func(line []byte) {
 			logStreamEvent(logger, line)
 		}, "claude", args...)
 	} else {
-		stdout, stderr, err = runner.Run(ctx, workDir, "claude", args...)
+		stdout, stderr, err = runner.RunWithStdin(ctx, workDir, prompt, "claude", args...)
 	}
 
 	if err != nil {

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -8,18 +8,30 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 	"sync"
+)
+
+const (
+	// scannerInitBufSize is the initial buffer size for the bufio.Scanner
+	// used when streaming command output (64 KB).
+	scannerInitBufSize = 64 * 1024
+	// scannerMaxBufSize is the maximum buffer size the scanner will grow to
+	// when reading long lines from command output (10 MB).
+	scannerMaxBufSize = 10 * 1024 * 1024
 )
 
 // CommandRunner executes external commands.
 type CommandRunner interface {
 	Run(ctx context.Context, workDir string, name string, args ...string) (stdout []byte, stderr []byte, err error)
+	RunWithStdin(ctx context.Context, workDir string, stdin string, name string, args ...string) (stdout []byte, stderr []byte, err error)
 }
 
 // StreamingRunner extends CommandRunner with line-by-line stdout streaming.
 type StreamingRunner interface {
 	CommandRunner
 	RunStream(ctx context.Context, workDir string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
+	RunStreamWithStdin(ctx context.Context, workDir string, stdin string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
 }
 
 // ExecRunner is the concrete CommandRunner using os/exec.
@@ -65,9 +77,35 @@ func (r *ExecRunner) Run(ctx context.Context, workDir, name string, args ...stri
 	return stdout, stderr, err
 }
 
-func (r *ExecRunner) RunStream(ctx context.Context, workDir string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
+func (r *ExecRunner) RunWithStdin(ctx context.Context, workDir, stdin, name string, args ...string) (stdout, stderr []byte, err error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = workDir
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	r.mu.RLock()
+	if len(r.Env) > 0 {
+		cmd.Env = append(cmd.Environ(), r.Env...)
+	}
+	r.mu.RUnlock()
+
+	stdout, err = cmd.Output()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = exitErr.Stderr
+	}
+	return stdout, stderr, err
+}
+
+func (r *ExecRunner) RunStream(ctx context.Context, workDir string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
+	return r.RunStreamWithStdin(ctx, workDir, "", onLine, name, args...)
+}
+
+func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = workDir
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 	r.mu.RLock()
 	if len(r.Env) > 0 {
 		cmd.Env = append(cmd.Environ(), r.Env...)
@@ -88,7 +126,7 @@ func (r *ExecRunner) RunStream(ctx context.Context, workDir string, onLine func(
 
 	var stdoutBuf bytes.Buffer
 	scanner := bufio.NewScanner(pipe)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	scanner.Buffer(make([]byte, 0, scannerInitBufSize), scannerMaxBufSize)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		stdoutBuf.Write(line)
@@ -97,9 +135,16 @@ func (r *ExecRunner) RunStream(ctx context.Context, workDir string, onLine func(
 			onLine(append([]byte{}, line...))
 		}
 	}
+	scanErr := scanner.Err()
 
-	err = cmd.Wait()
-	return stdoutBuf.Bytes(), stderrBuf.Bytes(), err
+	// Always call Wait to release child process resources and avoid zombies.
+	waitErr := cmd.Wait()
+
+	// Prefer the scanner error if present -- it describes the read failure.
+	if scanErr != nil {
+		return stdoutBuf.Bytes(), stderrBuf.Bytes(), scanErr
+	}
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), waitErr
 }
 
 // streamEvent represents a single event in Claude's stream-json output.

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -12,6 +12,7 @@ type commandCall struct {
 	WorkDir string
 	Name    string
 	Args    []string
+	Stdin   string
 }
 
 type mockCommandRunner struct {
@@ -27,6 +28,23 @@ type mockCommandRunner struct {
 func (m *mockCommandRunner) Run(_ context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
 	m.mu.Lock()
 	m.calls = append(m.calls, commandCall{WorkDir: workDir, Name: name, Args: args})
+	stdout = m.stdout
+	if name == "claude" && len(m.claudeResults) > 0 {
+		if m.claudeIndex < len(m.claudeResults) {
+			stdout = m.claudeResults[m.claudeIndex]
+		} else {
+			stdout = m.claudeResults[len(m.claudeResults)-1]
+		}
+		m.claudeIndex++
+	}
+	stderr, err = m.stderr, m.err
+	m.mu.Unlock()
+	return stdout, stderr, err
+}
+
+func (m *mockCommandRunner) RunWithStdin(_ context.Context, workDir, stdin, name string, args ...string) (stdout, stderr []byte, err error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, commandCall{WorkDir: workDir, Name: name, Args: args, Stdin: stdin})
 	stdout = m.stdout
 	if name == "claude" && len(m.claudeResults) > 0 {
 		if m.claudeIndex < len(m.claudeResults) {
@@ -111,6 +129,15 @@ func TestClaudeCodeAgent_RequiredFlags(t *testing.T) {
 		if !strings.Contains(args, want) {
 			t.Errorf("args missing %q: %v", want, call.Args)
 		}
+	}
+
+	// Verify prompt is passed via stdin, not as a CLI argument
+	if call.Stdin != "fix" {
+		t.Errorf("expected prompt %q on stdin, got %q", "fix", call.Stdin)
+	}
+	// Verify prompt is NOT in args
+	if strings.Contains(args, "fix") {
+		t.Errorf("prompt should not be in args when using stdin: %v", call.Args)
 	}
 }
 

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -388,6 +388,10 @@ func (f *fakeClaudeRunner) Run(_ context.Context, workDir, name string, args ...
 	return stdout, stderr, runErr
 }
 
+func (f *fakeClaudeRunner) RunWithStdin(ctx context.Context, workDir, stdin, name string, args ...string) (stdout, stderr []byte, runErr error) {
+	return f.Run(ctx, workDir, name, args...)
+}
+
 func TestIntegration_FullIssueLifecycle(t *testing.T) {
 	ctx := context.Background()
 	cloneDir := initBareRepo(t)

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3087,9 +3087,7 @@ func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
 	var claudePrompts []string
 	for _, c := range runner.calls {
 		if c.Name == "claude" {
-			if len(c.Args) > 0 {
-				claudePrompts = append(claudePrompts, c.Args[len(c.Args)-1])
-			}
+			claudePrompts = append(claudePrompts, c.Stdin)
 		}
 	}
 	if len(claudePrompts) != 2 {
@@ -3145,7 +3143,7 @@ func TestProcessCIFailures_SkipChecksExcludesFromFailures(t *testing.T) {
 		if c.Name == "claude" {
 			claudeCalls++
 			// Verify the prompt does NOT mention the skipped check
-			if strings.Contains(c.Args[len(c.Args)-1], "can-be-merged") {
+			if strings.Contains(c.Stdin, "can-be-merged") {
 				t.Error("skipped check 'can-be-merged' should not appear in claude prompt")
 			}
 		}

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -179,6 +179,7 @@ func parseOpencodeResult(stdout []byte) (AgentResult, error) {
 
 // Run invokes OpenCode CLI with JSON output and parses the result.
 // If resume is true, --continue is passed to resume the most recent session in workDir.
+// The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
 func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, resume bool) (AgentResult, error) {
 	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
@@ -188,17 +189,16 @@ func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, 
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
 	}
-	args = append(args, prompt)
 
 	var stdout, stderr []byte
 	var err error
 
 	if sr, ok := runner.(StreamingRunner); ok && logger != nil {
-		stdout, stderr, err = sr.RunStream(ctx, workDir, func(line []byte) {
+		stdout, stderr, err = sr.RunStreamWithStdin(ctx, workDir, prompt, func(line []byte) {
 			logOpencodeEvent(logger, line)
 		}, "opencode", args...)
 	} else {
-		stdout, stderr, err = runner.Run(ctx, workDir, "opencode", args...)
+		stdout, stderr, err = runner.RunWithStdin(ctx, workDir, prompt, "opencode", args...)
 	}
 
 	if err != nil {

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -156,6 +156,15 @@ func TestOpenCodeAgent_Run_Success(t *testing.T) {
 			t.Errorf("args missing %q: %v", want, call.Args)
 		}
 	}
+
+	// Verify prompt is passed via stdin, not as a CLI argument
+	if call.Stdin != "do something" {
+		t.Errorf("expected prompt %q on stdin, got %q", "do something", call.Stdin)
+	}
+	// Verify prompt is NOT in args
+	if strings.Contains(args, "do something") {
+		t.Errorf("prompt should not be in args when using stdin: %v", call.Args)
+	}
 }
 
 // TestOpenCodeAgent_Run_WithResume tests the --continue flag is passed when resume=true.
@@ -170,9 +179,14 @@ func TestOpenCodeAgent_Run_WithResume(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	args := strings.Join(runner.calls[0].Args, " ")
+	call := runner.calls[0]
+	args := strings.Join(call.Args, " ")
 	if !strings.Contains(args, "--continue") {
-		t.Errorf("expected --continue flag when resume=true, got: %v", runner.calls[0].Args)
+		t.Errorf("expected --continue flag when resume=true, got: %v", call.Args)
+	}
+	// Verify prompt is passed via stdin even when resuming
+	if call.Stdin != "continue work" {
+		t.Errorf("expected prompt %q on stdin, got %q", "continue work", call.Stdin)
 	}
 }
 


### PR DESCRIPTION
Fixes #169

## Summary

Pass agent prompts via stdin instead of CLI arguments to avoid `argument list too long` errors when prompts exceed the Linux `ARG_MAX` limit (~2MB). This was causing fatal failures on repos with large diffs (e.g., `openshift/release`).

## Changes

- Added `RunWithStdin` method to `CommandRunner` interface and `RunStreamWithStdin` to `StreamingRunner` interface in `pkg/agent/claude.go`
- Implemented both methods on `ExecRunner`, piping stdin to the subprocess
- Refactored `ExecRunner.RunStream` to delegate to `RunStreamWithStdin` to avoid code duplication
- Updated `ClaudeCodeAgent.Run` (`pkg/agent/agent.go`) to pass the prompt via stdin instead of appending it to CLI args
- Updated `OpenCodeAgent.Run` (`pkg/agent/opencode.go`) with the same stdin approach
- Updated `mockCommandRunner` to implement `RunWithStdin` and record stdin in `commandCall`
- Updated `fakeClaudeRunner` in integration tests to implement `RunWithStdin`
- Fixed tests that previously read prompts from CLI args to read from `commandCall.Stdin` instead
- Added new test assertions verifying prompts are passed via stdin and not in args

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #169

<!-- oompa-bot v:104c12b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Claude and OpenCode command execution to pass prompts via stdin instead of CLI arguments
  * Enhanced command runner abstraction to support stdin input for subprocess execution

* **Tests**
  * Updated test cases to verify prompts are delivered via stdin rather than command-line arguments

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/170)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->