### PR TITLE
feat: link unrelated CI failures to existing flaky issues even when create-flaky-issues is disabled

### DIFF
--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -373,7 +373,10 @@ func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation s
 	issueNum, found := a.matchExistingFlakyIssue(ctx, task, explanation)
 	if found {
 		// Add CI lane link as a comment on the existing flaky issue
-		a.addCILaneLinkComment(ctx, task, issueNum)
+		// (respects skip-comment: flaky to suppress all flaky-related comments)
+		if !a.ShouldSkipComment("flaky") {
+			a.addCILaneLinkComment(ctx, task, issueNum)
+		}
 
 		// Reference the existing issue in the PR comment
 		if !a.ShouldSkipComment("flaky") {
@@ -429,6 +432,8 @@ func (a *Agent) matchExistingFlakyIssue(ctx context.Context, task ciTask, explan
 	}
 	matchPrompt := buildFlakyMatchPrompt(task.failures[0].Name, matchOutput, existingIssues)
 	matchResult, matchErr := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, matchPrompt, a.logger, false)
+	// Track cumulative cost even on failure — failed invocations still consume tokens.
+	task.work.SessionCostUSD += matchResult.CostUSD
 	if matchErr != nil {
 		a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
 		return 0, false
@@ -451,12 +456,11 @@ func (a *Agent) matchExistingFlakyIssue(ctx context.Context, task ciTask, explan
 // addCILaneLinkComment posts a comment on an existing flaky issue with the CI lane
 // link and PR reference, building up evidence of repeated failures.
 func (a *Agent) addCILaneLinkComment(ctx context.Context, task ciTask, issueNum int) {
-	// Build CI lane link from the check run's output (for commit statuses)
-	// or construct one from the check run ID (for GitHub Actions).
+	// Build CI lane link from the check run's HTML URL (preferred),
+	// or extract from output text (for commit statuses like Prow).
 	var ciLink string
-	if task.failures[0].ID > 0 {
-		ciLink = fmt.Sprintf("https://github.com/%s/%s/runs/%d",
-			a.cfg.Owner, a.cfg.Repo, task.failures[0].ID)
+	if task.failures[0].HTMLURL != "" {
+		ciLink = task.failures[0].HTMLURL
 	} else if url := extractURL(task.failures[0].Output); url != "" {
 		ciLink = url
 	}

--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -346,19 +346,23 @@ func (a *Agent) handleCIUnrelated(ctx context.Context, task ciTask, cleaned stri
 	task.work.LastCIStatus = "unrelated-failure"
 	task.work.LastCheckedCISHA = task.headSHA
 
-	// Create a flaky CI issue if configured
-	if a.cfg.CreateFlakyIssues {
-		a.createFlakyIssue(ctx, task, explanation)
+	// Search for existing flaky issues and optionally create new ones.
+	// When flaky-label is configured, always search for existing issues.
+	// Only create new issues when create-flaky-issues is also enabled.
+	if a.cfg.FlakyLabel != "" {
+		a.handleFlakyIssue(ctx, task, explanation)
 	}
 }
 
-// createFlakyIssue creates or matches a flaky CI issue for an unrelated failure.
-func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation string) {
-	// Skip flaky issue creation if both the check run output and the
-	// agent's explanation are too short.
+// handleFlakyIssue searches for existing flaky issues and optionally creates new ones.
+// Always runs when FlakyLabel is configured (even without CreateFlakyIssues).
+// When a match is found: references it in the PR comment, adds CI lane link to the existing issue.
+// When no match is found: creates a new issue only if CreateFlakyIssues is enabled.
+func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation string) {
+	// Skip if both the check run output and the agent's explanation are too short.
 	trimmedOutput := strings.TrimSpace(task.failures[0].Output)
 	if len(trimmedOutput) < 50 && len(explanation) < 50 {
-		a.logger.Warn("skipping flaky issue creation: insufficient context",
+		a.logger.Warn("skipping flaky issue handling: insufficient context",
 			"pr", task.work.PRNumber,
 			"check", task.failures[0].Name,
 			"output_length", len(trimmedOutput),
@@ -366,6 +370,30 @@ func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation s
 		return
 	}
 
+	issueNum, found := a.matchExistingFlakyIssue(ctx, task, explanation)
+	if found {
+		// Add CI lane link as a comment on the existing flaky issue
+		a.addCILaneLinkComment(ctx, task, issueNum)
+
+		// Reference the existing issue in the PR comment
+		if !a.ShouldSkipComment("flaky") {
+			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
+				fmt.Sprintf("Known flaky test tracked in #%d.\n\n%s", issueNum, a.botComment())); err != nil {
+				a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
+			}
+		}
+		return
+	}
+
+	// No existing match — create a new issue only if enabled
+	if a.cfg.CreateFlakyIssues {
+		a.createNewFlakyIssue(ctx, task, explanation)
+	}
+}
+
+// matchExistingFlakyIssue searches for an existing open issue with the flaky label
+// that matches the failing test. Returns the issue number and true if found.
+func (a *Agent) matchExistingFlakyIssue(ctx context.Context, task ciTask, explanation string) (int, bool) {
 	failingTest := parseFailingTest(explanation)
 	var issueTitle string
 	if failingTest != "" {
@@ -374,64 +402,88 @@ func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation s
 		issueTitle = fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
 	}
 
-	// Search for existing open issues with the flaky label
-	searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%s",
+	searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%q",
 		a.cfg.Owner, a.cfg.Repo, a.cfg.FlakyLabel)
 	existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
-
-	var issueNum int
 	if err != nil {
 		a.logger.Warn("failed to search for existing flaky issues", "error", err)
-	} else if len(existingIssues) > 0 {
-		// Fast path: exact title match skips LLM matching entirely.
-		for _, existing := range existingIssues {
-			if existing.Title == issueTitle {
-				issueNum = existing.Number
-				a.logger.Info("exact title match for existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
-				break
-			}
-		}
+		return 0, false
+	}
 
-		// If no exact title match, ask the agent for root-cause matching.
-		if issueNum == 0 {
-			matchOutput := task.failures[0].Output
-			if len(strings.TrimSpace(matchOutput)) < 50 {
-				matchOutput = explanation
-			}
-			matchPrompt := buildFlakyMatchPrompt(task.failures[0].Name, matchOutput, existingIssues)
-			matchResult, matchErr := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, matchPrompt, a.logger, false)
-			if matchErr != nil {
-				a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
-			} else {
-				matchResponse := strings.TrimSpace(matchResult.Result)
-				if matchedNum, ok := parseFlakyMatch(matchResponse); ok {
-					for _, existing := range existingIssues {
-						if existing.Number == matchedNum {
-							issueNum = matchedNum
-							break
-						}
-					}
-					if issueNum > 0 {
-						a.logger.Info("agent matched existing flaky CI issue", "issue", issueNum, "check", task.failures[0].Name)
-					} else {
-						a.logger.Warn("agent returned MATCH for unknown issue", "matched_issue", matchedNum, "check", task.failures[0].Name)
-					}
-				}
-			}
-		}
+	if len(existingIssues) == 0 {
+		return 0, false
+	}
 
-		if issueNum > 0 {
-			if !a.ShouldSkipComment("flaky") {
-				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-					fmt.Sprintf("This appears to be a duplicate of existing flaky test issue #%d.\n\n%s", issueNum, a.botComment())); err != nil {
-					a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
-				}
-			}
-			return
+	// Fast path: exact title match skips LLM matching entirely.
+	for _, existing := range existingIssues {
+		if existing.Title == issueTitle {
+			a.logger.Info("exact title match for existing flaky CI issue", "issue", existing.Number, "check", task.failures[0].Name)
+			return existing.Number, true
 		}
 	}
 
-	// No existing issue matched, create a new one
+	// If no exact title match, ask the agent for root-cause matching.
+	matchOutput := task.failures[0].Output
+	if len(strings.TrimSpace(matchOutput)) < 50 {
+		matchOutput = explanation
+	}
+	matchPrompt := buildFlakyMatchPrompt(task.failures[0].Name, matchOutput, existingIssues)
+	matchResult, matchErr := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, matchPrompt, a.logger, false)
+	if matchErr != nil {
+		a.logger.Warn("failed to run agent for flaky issue matching", "error", matchErr)
+		return 0, false
+	}
+
+	matchResponse := strings.TrimSpace(matchResult.Result)
+	if matchedNum, ok := parseFlakyMatch(matchResponse); ok {
+		for _, existing := range existingIssues {
+			if existing.Number == matchedNum {
+				a.logger.Info("agent matched existing flaky CI issue", "issue", matchedNum, "check", task.failures[0].Name)
+				return matchedNum, true
+			}
+		}
+		a.logger.Warn("agent returned MATCH for unknown issue", "matched_issue", matchedNum, "check", task.failures[0].Name)
+	}
+
+	return 0, false
+}
+
+// addCILaneLinkComment posts a comment on an existing flaky issue with the CI lane
+// link and PR reference, building up evidence of repeated failures.
+func (a *Agent) addCILaneLinkComment(ctx context.Context, task ciTask, issueNum int) {
+	// Build CI lane link from the check run's output (for commit statuses)
+	// or construct one from the check run ID (for GitHub Actions).
+	var ciLink string
+	if task.failures[0].ID > 0 {
+		ciLink = fmt.Sprintf("https://github.com/%s/%s/runs/%d",
+			a.cfg.Owner, a.cfg.Repo, task.failures[0].ID)
+	} else if url := extractURL(task.failures[0].Output); url != "" {
+		ciLink = url
+	}
+
+	comment := fmt.Sprintf("CI failure on PR #%d (commit %s) matches this flaky test.\n\n"+
+		"**CI lane:** `%s`",
+		task.work.PRNumber, shortSHA(task.headSHA), task.failures[0].Name)
+	if ciLink != "" {
+		comment += fmt.Sprintf("\n**Link:** %s", ciLink)
+	}
+	comment += "\n\n" + a.botComment()
+
+	if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issueNum, comment); err != nil {
+		a.logger.Error("failed to post CI lane link comment on flaky issue", "issue", issueNum, "error", err)
+	}
+}
+
+// createNewFlakyIssue creates a new flaky CI issue for an unrelated failure.
+func (a *Agent) createNewFlakyIssue(ctx context.Context, task ciTask, explanation string) {
+	failingTest := parseFailingTest(explanation)
+	var issueTitle string
+	if failingTest != "" {
+		issueTitle = fmt.Sprintf("Flaky CI: %s / %s", task.failures[0].Name, failingTest)
+	} else {
+		issueTitle = fmt.Sprintf("Flaky CI: %s", task.failures[0].Name)
+	}
+
 	testNameForBody := task.failures[0].Name
 	if failingTest != "" {
 		testNameForBody = failingTest
@@ -462,7 +514,7 @@ func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation s
 		task.failures[0].Name, task.work.PRNumber, shortSHA(task.headSHA),
 		testNameForBody, time.Now().Format("2006-01-02"), cleanedExplanation,
 		a.botComment())
-	issueNum, err = a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
+	issueNum, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
 	if err != nil {
 		a.logger.Error("failed to create flaky CI issue", "error", err)
 	} else {
@@ -474,6 +526,16 @@ func (a *Agent) createFlakyIssue(ctx context.Context, task ciTask, explanation s
 			}
 		}
 	}
+}
+
+// extractURL extracts the first URL from a string.
+func extractURL(s string) string {
+	for word := range strings.FieldsSeq(s) {
+		if strings.HasPrefix(word, "https://") || strings.HasPrefix(word, "http://") {
+			return strings.TrimRight(word, ".,;)]}")
+		}
+	}
+	return ""
 }
 
 // handleCIRelated handles a CI failure classified as related to PR changes.

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -282,6 +282,7 @@ func (g *GoGitHubClient) GetCheckRuns(ctx context.Context, owner, repo, ref stri
 			Status:     r.GetStatus(),
 			Conclusion: r.GetConclusion(),
 			Output:     output,
+			HTMLURL:    r.GetHTMLURL(),
 		})
 	}
 	return runs, nil

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1599,14 +1599,22 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 		t.Errorf("expected 0 created issues (should reference existing), got %d", len(gh.createdIssues))
 	}
 
-	// Check that comments were added (unrelated notice + duplicate reference)
-	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+	// Check that comments were added:
+	// 1. unrelated notice on PR
+	// 2. CI lane link on the flaky issue (#50)
+	// 3. "Known flaky test" reference on PR
+	if len(gh.addedComments) != 3 {
+		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
 	}
 
-	// Verify the duplicate reference comment
-	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #50") {
-		t.Errorf("expected duplicate reference comment, got: %q", gh.addedComments[1])
+	// Verify the CI lane link comment (posted on the flaky issue)
+	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	}
+
+	// Verify the flaky reference comment on the PR
+	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #50") {
+		t.Errorf("expected flaky reference comment, got: %q", gh.addedComments[2])
 	}
 }
 
@@ -1654,14 +1662,22 @@ func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
 		t.Errorf("expected 1 claude call (CI investigation only, no LLM matching), got %d", claudeCalls)
 	}
 
-	// Should have 2 comments: unrelated notice + duplicate reference
-	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + duplicate reference), got %d", len(gh.addedComments))
+	// Should have 3 comments:
+	// 1. unrelated notice on PR
+	// 2. CI lane link on the flaky issue (#99)
+	// 3. "Known flaky test" reference on PR
+	if len(gh.addedComments) != 3 {
+		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
 	}
 
-	// Verify the duplicate reference points to issue #99
-	if !strings.Contains(gh.addedComments[1], "duplicate of existing flaky test issue #99") {
-		t.Errorf("expected duplicate reference to issue #99, got: %q", gh.addedComments[1])
+	// Verify the CI lane link comment (posted on the flaky issue)
+	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	}
+
+	// Verify the flaky reference points to issue #99
+	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #99") {
+		t.Errorf("expected flaky reference to issue #99, got: %q", gh.addedComments[2])
 	}
 }
 
@@ -1747,6 +1763,265 @@ func TestProcessCIFailures_CreatesIssueWhenClaudeSaysNone(t *testing.T) {
 	}
 	if gh.createdIssues[0].Title != "Flaky CI: integration-tests" {
 		t.Errorf("expected title 'Flaky CI: integration-tests', got %q", gh.createdIssues[0].Title)
+	}
+}
+
+func TestProcessCIFailures_SearchAndLinkWithoutCreateFlakyIssues(t *testing.T) {
+	// Issue #171: create-flaky-issues=false + flaky-label set + matching issue exists
+	// → PR comment references the issue, CI lane link added to the issue, no new issue created.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
+		searchResults: []Issue{
+			{Number: 1234, Title: "Flaky CI: integration-tests", Labels: []string{"kind/ci-flake"}},
+		},
+	}
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false       // Disabled — don't create new issues
+	agent.cfg.FlakyLabel = "kind/ci-flake"    // But label is set — enables search-and-link
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// No new issue should be created
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues (create-flaky-issues=false), got %d", len(gh.createdIssues))
+	}
+
+	// Should have 3 comments:
+	// 1. unrelated notice on PR
+	// 2. CI lane link comment on the existing flaky issue (#1234)
+	// 3. "Known flaky test" reference on PR
+	if len(gh.addedComments) != 3 {
+		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
+	}
+
+	// Verify unrelated comment
+	if !strings.Contains(gh.addedComments[0], "appears unrelated") {
+		t.Errorf("expected unrelated comment, got: %q", gh.addedComments[0])
+	}
+
+	// Verify CI lane link on the flaky issue
+	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	}
+	if !strings.Contains(gh.addedComments[1], "integration-tests") {
+		t.Errorf("expected CI lane link to mention CI lane name, got: %q", gh.addedComments[1])
+	}
+
+	// Verify the PR reference comment
+	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #1234") {
+		t.Errorf("expected flaky reference to issue #1234, got: %q", gh.addedComments[2])
+	}
+}
+
+func TestProcessCIFailures_NoMatchNoCreateWhenDisabled(t *testing.T) {
+	// Issue #171: create-flaky-issues=false + flaky-label set + no matching issue
+	// → regular unrelated comment, no issue created.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
+		searchResults: []Issue{}, // No matching issues
+	}
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false
+	agent.cfg.FlakyLabel = "kind/ci-flake"
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// No issue should be created
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues (create-flaky-issues=false, no match), got %d", len(gh.createdIssues))
+	}
+
+	// Only the unrelated comment should be posted
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment (unrelated notice only), got %d", len(gh.addedComments))
+	}
+	if !strings.Contains(gh.addedComments[0], "appears unrelated") {
+		t.Errorf("expected unrelated comment, got: %q", gh.addedComments[0])
+	}
+}
+
+func TestProcessCIFailures_NoSearchWhenFlakyLabelEmpty(t *testing.T) {
+	// Issue #171: flaky-label not set → no search, no linking.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test database connection times out intermittently"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
+	}
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.FlakyLabel = ""             // No flaky label
+	agent.cfg.CreateFlakyIssues = false
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// No issue should be created
+	if len(gh.createdIssues) != 0 {
+		t.Errorf("expected 0 created issues, got %d", len(gh.createdIssues))
+	}
+
+	// Only the unrelated comment
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment (unrelated notice only), got %d", len(gh.addedComments))
+	}
+}
+
+func TestProcessCIFailures_CILaneLinkIncludesJobURL(t *testing.T) {
+	// Issue #171: CI lane link comment includes the correct job URL and PR reference.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test timed out intermittently due to a flaky network connection in the CI environment"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 67890, Name: "e2e (control-plane, HA, shared, ipv4)", Status: "completed", Conclusion: "failure", Output: "Error: test timed out waiting for condition"},
+		},
+		checkRunLogs: map[int64]string{
+			67890: "Running e2e tests...\nTimeout: waiting for pod to be ready\nTest failed after 300s\nStack trace:\n  at e2e.waitForPod(e2e.go:142)",
+		},
+		searchResults: []Issue{
+			{Number: 5678, Title: "Flaky CI: e2e (control-plane, HA, shared, ipv4)", Labels: []string{"kind/ci-flake"}},
+		},
+	}
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false
+	agent.cfg.FlakyLabel = "kind/ci-flake"
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Verify CI lane link comment was posted on the flaky issue
+	if len(gh.addedComments) < 2 {
+		t.Fatalf("expected at least 2 comments, got %d", len(gh.addedComments))
+	}
+
+	ciLaneComment := gh.addedComments[1]
+	if !strings.Contains(ciLaneComment, "CI failure on PR #100") {
+		t.Errorf("expected CI lane link to reference PR #100, got: %q", ciLaneComment)
+	}
+	if !strings.Contains(ciLaneComment, "e2e (control-plane, HA, shared, ipv4)") {
+		t.Errorf("expected CI lane link to mention check name, got: %q", ciLaneComment)
+	}
+	// GitHub Actions check runs have ID > 0, so a link should be constructed
+	if !strings.Contains(ciLaneComment, "**Link:**") {
+		t.Errorf("expected CI lane link to include a job link, got: %q", ciLaneComment)
+	}
+}
+
+func TestProcessCIFailures_CommitStatusCILaneLink(t *testing.T) {
+	// Issue #171: commit status entries (Prow) use target_url as the CI link.
+	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test timed out intermittently on the Prow CI infrastructure"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{},
+		commitStatuses: []CheckRun{
+			// Commit status: ID=0, Output contains target_url
+			{ID: 0, Name: "pull-unit-test", Status: "completed", Conclusion: "failure", Output: "Build failed\nhttps://prow.ci.kubevirt.io/view/gs/logs/1234"},
+		},
+		searchResults: []Issue{
+			{Number: 999, Title: "Flaky CI: pull-unit-test", Labels: []string{"flaky-test"}},
+		},
+	}
+	runner := &mockCommandRunner{stdout: ciResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Verify CI lane link uses the Prow URL extracted from the output
+	if len(gh.addedComments) < 2 {
+		t.Fatalf("expected at least 2 comments, got %d", len(gh.addedComments))
+	}
+
+	ciLaneComment := gh.addedComments[1]
+	if !strings.Contains(ciLaneComment, "https://prow.ci.kubevirt.io/view/gs/logs/1234") {
+		t.Errorf("expected CI lane link to include Prow URL, got: %q", ciLaneComment)
+	}
+}
+
+func TestExtractURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://prow.ci.kubevirt.io/view/gs/logs/1234", "https://prow.ci.kubevirt.io/view/gs/logs/1234"},
+		{"Build failed\nhttps://prow.ci.kubevirt.io/view/gs/logs/1234", "https://prow.ci.kubevirt.io/view/gs/logs/1234"},
+		{"Build failed", ""},
+		{"", ""},
+		{"Error: timeout http://example.com/logs more text", "http://example.com/logs"},
+		// Trailing punctuation is trimmed
+		{"Check logs at https://example.com/log.", "https://example.com/log"},
+		{"See https://example.com/log, then retry", "https://example.com/log"},
+		{"See https://example.com/log) for details", "https://example.com/log"},
+	}
+	for _, tt := range tests {
+		got := extractURL(tt.input)
+		if got != tt.want {
+			t.Errorf("extractURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -17,7 +17,8 @@ type mockGitHubClient struct {
 	issueComments   []ReviewComment
 	prState         string
 	prs             []PR
-	addedComments   []string
+	addedComments      []string
+	addedCommentTargets []int // issue/PR number each comment was posted to
 	addedLabels     []string
 	removedLabels   []string
 	addedReactions  []string
@@ -70,8 +71,9 @@ func (m *mockGitHubClient) GetPRState(_ context.Context, _, _ string, _ int) (st
 	return m.prState, nil
 }
 
-func (m *mockGitHubClient) AddIssueComment(_ context.Context, _, _ string, _ int, body string) error {
+func (m *mockGitHubClient) AddIssueComment(_ context.Context, _, _ string, issueNum int, body string) error {
 	m.addedComments = append(m.addedComments, body)
+	m.addedCommentTargets = append(m.addedCommentTargets, issueNum)
 	return nil
 }
 
@@ -1607,14 +1609,20 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
 	}
 
-	// Verify the CI lane link comment (posted on the flaky issue)
+	// Verify the CI lane link comment (posted on the flaky issue #50)
 	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
 		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
 	}
+	if gh.addedCommentTargets[1] != 50 {
+		t.Errorf("expected CI lane link comment posted to issue #50, got #%d", gh.addedCommentTargets[1])
+	}
 
-	// Verify the flaky reference comment on the PR
+	// Verify the flaky reference comment on the PR (#100)
 	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #50") {
 		t.Errorf("expected flaky reference comment, got: %q", gh.addedComments[2])
+	}
+	if gh.addedCommentTargets[2] != 100 {
+		t.Errorf("expected flaky reference comment posted to PR #100, got #%d", gh.addedCommentTargets[2])
 	}
 }
 
@@ -1918,7 +1926,7 @@ func TestProcessCIFailures_CILaneLinkIncludesJobURL(t *testing.T) {
 	ciResult := streamResultJSON(AgentResult{Result: "UNRELATED The test timed out intermittently due to a flaky network connection in the CI environment"})
 	gh := &mockGitHubClient{
 		checkRuns: []CheckRun{
-			{ID: 67890, Name: "e2e (control-plane, HA, shared, ipv4)", Status: "completed", Conclusion: "failure", Output: "Error: test timed out waiting for condition"},
+			{ID: 67890, Name: "e2e (control-plane, HA, shared, ipv4)", Status: "completed", Conclusion: "failure", Output: "Error: test timed out waiting for condition", HTMLURL: "https://github.com/owner/repo/actions/runs/12345/job/67890"},
 		},
 		checkRunLogs: map[int64]string{
 			67890: "Running e2e tests...\nTimeout: waiting for pod to be ready\nTest failed after 300s\nStack trace:\n  at e2e.waitForPod(e2e.go:142)",

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -80,6 +80,7 @@ type CheckRun struct {
 	Status     string // queued, in_progress, completed
 	Conclusion string // success, failure, neutral, cancelled, skipped, timed_out, action_required
 	Output     string // summary/text from the check run, or target_url for commit statuses
+	HTMLURL    string // direct link to the check run page on GitHub
 }
 
 // JobRun represents a CI job run (periodic or triggered).


### PR DESCRIPTION
Fixes #171

## Summary

Link unrelated CI failures to existing flaky issues even when `create-flaky-issues` is disabled. When `flaky-label` is configured, oompa now always searches for existing matching issues and references them in PR comments with CI lane links, regardless of whether `create-flaky-issues` is enabled.

## Changes

- Split `createFlakyIssue` into three focused functions: `handleFlakyIssue` (orchestrator), `matchExistingFlakyIssue` (search), and `createNewFlakyIssue` (creation)
- Gate flaky issue logic on `FlakyLabel != ""` instead of `CreateFlakyIssues`, so search-and-link always runs when a flaky label is configured
- Add `addCILaneLinkComment` to post CI failure evidence on existing flaky issues, building up a history of repeated failures
- Change PR comment from "duplicate of existing flaky test issue" to "Known flaky test tracked in #N" for clearer messaging
- Add `extractURL` helper to extract URLs from commit status output (for Prow CI links)
- Add 6 new tests covering all scenarios from the issue
- Update 2 existing tests to match new comment structure (CI lane link + flaky reference)

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #171

<!-- oompa-bot v:104c12b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Flaky issue detection now automatically searches for and links to existing related issues.
  * CI lane information is included in comments connecting test failures to tracked flaky issues.
  * Enhanced configuration flexibility for flaky issue workflows and handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->