### PR TITLE
feat: consolidate CI failure comments into a single PR comment per commit

### DIFF
--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -10,6 +10,16 @@ import (
 
 const maxCIFixAttempts = 3
 
+// ciResult holds the result of investigating a single CI check failure.
+// Results for the same PR+SHA are consolidated into a single comment.
+type ciResult struct {
+	check       string // check name
+	category    string // "related", "unrelated", "infrastructure"
+	explanation string // agent's explanation
+	flakyIssue  int    // linked flaky issue number (0 if none)
+	pushed      bool   // whether a fix was pushed
+}
+
 // ProcessCIFailures checks CI status for open PRs and invokes Claude to fix failures.
 func (a *Agent) ProcessCIFailures(ctx context.Context) {
 	a.emit(Event{
@@ -188,7 +198,18 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		}
 	}
 
-	// Sequential phase: Claude invocations and post-processing
+	// Collect results grouped by PR+SHA for consolidated commenting.
+	// Key format: "prNumber:headSHA"
+	type resultGroup struct {
+		work    *IssueWork
+		headSHA string
+		results []ciResult
+	}
+	groups := make(map[string]*resultGroup)
+	// Track insertion order to preserve the task processing sequence.
+	var groupOrder []string
+
+	// Sequential phase: Claude invocations and result collection
 	runSequential(ctx, tasks, func(ctx context.Context, task ciTask) {
 		// Re-check cost guard before each invocation — multiple tasks can be
 		// enqueued for the same PR, and earlier invocations may have pushed
@@ -266,23 +287,35 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			return
 		}
 
-		if foundKeyword == "INFRASTRUCTURE" {
-			a.handleCIInfrastructure(ctx, task, cleaned)
-			return
+		var res ciResult
+		switch foundKeyword {
+		case "INFRASTRUCTURE":
+			res = a.classifyCIInfrastructure(ctx, task, cleaned)
+		case "UNRELATED":
+			res = a.classifyCIUnrelated(ctx, task, cleaned)
+		case "RELATED":
+			res = a.classifyCIRelated(ctx, task, cleaned)
 		}
 
-		if foundKeyword == "UNRELATED" {
-			a.handleCIUnrelated(ctx, task, cleaned)
-			return
+		// Collect result into the group for this PR+SHA
+		key := fmt.Sprintf("%d:%s", task.work.PRNumber, task.headSHA)
+		if groups[key] == nil {
+			groups[key] = &resultGroup{work: task.work, headSHA: task.headSHA}
+			groupOrder = append(groupOrder, key)
 		}
-
-		// Claude said RELATED
-		a.handleCIRelated(ctx, task, cleaned)
+		groups[key].results = append(groups[key].results, res)
 	})
+
+	// Post consolidated comments for each PR+SHA group
+	for _, key := range groupOrder {
+		g := groups[key]
+		a.postConsolidatedCIComment(ctx, g.work, g.headSHA, g.results)
+	}
 }
 
-// handleCIInfrastructure handles a CI failure classified as an infrastructure issue.
-func (a *Agent) handleCIInfrastructure(ctx context.Context, task ciTask, cleaned string) {
+// classifyCIInfrastructure handles a CI failure classified as an infrastructure issue.
+// Returns a ciResult for consolidation; does NOT post a comment.
+func (a *Agent) classifyCIInfrastructure(_ context.Context, task ciTask, cleaned string) ciResult {
 	a.logger.Info("CI failure is an infrastructure issue", "pr", task.work.PRNumber)
 	a.emit(Event{
 		Type:      EventAgentCompleted,
@@ -294,28 +327,26 @@ func (a *Agent) handleCIInfrastructure(ctx context.Context, task ciTask, cleaned
 	})
 	idx := strings.Index(cleaned, "INFRASTRUCTURE")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "INFRASTRUCTURE"), " :—–-"))
-	marker := ciMarker(task.headSHA, task.failures[0].Name)
+
 	if a.ShouldSkipComment("ci-infrastructure") {
 		a.logger.Info("skipping CI infrastructure comment (--skip-comment)", "pr", task.work.PRNumber)
 		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-	} else {
-		comment := fmt.Sprintf("CI check `%s` failed on commit %s due to an infrastructure issue (not a flaky test).", task.failures[0].Name, shortSHA(task.headSHA))
-		if explanation != "" {
-			comment += "\n\n" + explanation
-		}
-		comment += "\n\n" + marker
-		if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
-			a.logger.Error("failed to post CI infrastructure comment", "pr", task.work.PRNumber, "error", err)
-			task.work.LastCIStatus = "investigation-inconclusive"
-			return
-		}
 	}
+
 	task.work.LastCIStatus = "infrastructure-failure"
 	task.work.LastCheckedCISHA = task.headSHA
+
+	return ciResult{
+		check:       task.failures[0].Name,
+		category:    "infrastructure",
+		explanation: explanation,
+	}
 }
 
-// handleCIUnrelated handles a CI failure classified as unrelated to PR changes.
-func (a *Agent) handleCIUnrelated(ctx context.Context, task ciTask, cleaned string) {
+// classifyCIUnrelated handles a CI failure classified as unrelated to PR changes.
+// Returns a ciResult for consolidation; does NOT post a comment.
+// Flaky issue handling (search/create) is performed as a per-check side effect.
+func (a *Agent) classifyCIUnrelated(ctx context.Context, task ciTask, cleaned string) ciResult {
 	a.logger.Info("CI failure is unrelated to PR changes", "pr", task.work.PRNumber)
 	a.emit(Event{
 		Type:      EventAgentCompleted,
@@ -327,38 +358,39 @@ func (a *Agent) handleCIUnrelated(ctx context.Context, task ciTask, cleaned stri
 	})
 	idx := strings.Index(cleaned, "UNRELATED")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "UNRELATED"), " :—–-"))
-	marker := ciMarker(task.headSHA, task.failures[0].Name)
+
 	if a.ShouldSkipComment("ci-unrelated") {
 		a.logger.Info("skipping CI unrelated comment (--skip-comment)", "pr", task.work.PRNumber)
 		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-	} else {
-		comment := fmt.Sprintf("CI check `%s` failed on commit %s but appears unrelated to this PR's changes.", task.failures[0].Name, shortSHA(task.headSHA))
-		if explanation != "" {
-			comment += "\n\n" + explanation
-		}
-		comment += "\n\n" + marker
-		if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, comment); err != nil {
-			a.logger.Error("failed to post CI unrelated comment", "pr", task.work.PRNumber, "error", err)
-			task.work.LastCIStatus = "investigation-inconclusive"
-			return
-		}
 	}
+
 	task.work.LastCIStatus = "unrelated-failure"
 	task.work.LastCheckedCISHA = task.headSHA
+
+	res := ciResult{
+		check:       task.failures[0].Name,
+		category:    "unrelated",
+		explanation: explanation,
+	}
 
 	// Search for existing flaky issues and optionally create new ones.
 	// When flaky-label is configured, always search for existing issues.
 	// Only create new issues when create-flaky-issues is also enabled.
+	// Flaky issue handling is a per-check side effect, not consolidated.
 	if a.cfg.FlakyLabel != "" {
-		a.handleFlakyIssue(ctx, task, explanation)
+		res.flakyIssue = a.handleFlakyIssue(ctx, task, explanation)
 	}
+
+	return res
 }
 
 // handleFlakyIssue searches for existing flaky issues and optionally creates new ones.
 // Always runs when FlakyLabel is configured (even without CreateFlakyIssues).
-// When a match is found: references it in the PR comment, adds CI lane link to the existing issue.
+// When a match is found: adds CI lane link to the existing issue.
 // When no match is found: creates a new issue only if CreateFlakyIssues is enabled.
-func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation string) {
+// Returns the linked/created flaky issue number (0 if none).
+// The PR reference comment is now part of the consolidated CI comment.
+func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation string) int {
 	// Skip if both the check run output and the agent's explanation are too short.
 	trimmedOutput := strings.TrimSpace(task.failures[0].Output)
 	if len(trimmedOutput) < 50 && len(explanation) < 50 {
@@ -367,7 +399,7 @@ func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation s
 			"check", task.failures[0].Name,
 			"output_length", len(trimmedOutput),
 			"explanation_length", len(explanation))
-		return
+		return 0
 	}
 
 	issueNum, found := a.matchExistingFlakyIssue(ctx, task, explanation)
@@ -377,21 +409,14 @@ func (a *Agent) handleFlakyIssue(ctx context.Context, task ciTask, explanation s
 		if !a.ShouldSkipComment("flaky") {
 			a.addCILaneLinkComment(ctx, task, issueNum)
 		}
-
-		// Reference the existing issue in the PR comment
-		if !a.ShouldSkipComment("flaky") {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Known flaky test tracked in #%d.\n\n%s", issueNum, a.botComment())); err != nil {
-				a.logger.Error("failed to post existing flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
-			}
-		}
-		return
+		return issueNum
 	}
 
 	// No existing match — create a new issue only if enabled
 	if a.cfg.CreateFlakyIssues {
-		a.createNewFlakyIssue(ctx, task, explanation)
+		return a.createNewFlakyIssue(ctx, task, explanation)
 	}
+	return 0
 }
 
 // matchExistingFlakyIssue searches for an existing open issue with the flaky label
@@ -479,7 +504,9 @@ func (a *Agent) addCILaneLinkComment(ctx context.Context, task ciTask, issueNum 
 }
 
 // createNewFlakyIssue creates a new flaky CI issue for an unrelated failure.
-func (a *Agent) createNewFlakyIssue(ctx context.Context, task ciTask, explanation string) {
+// Returns the created issue number (0 on failure).
+// The PR reference comment is now part of the consolidated CI comment.
+func (a *Agent) createNewFlakyIssue(ctx context.Context, task ciTask, explanation string) int {
 	failingTest := parseFailingTest(explanation)
 	var issueTitle string
 	if failingTest != "" {
@@ -521,15 +548,10 @@ func (a *Agent) createNewFlakyIssue(ctx context.Context, task ciTask, explanatio
 	issueNum, err := a.gh.CreateIssue(ctx, a.cfg.Owner, a.cfg.Repo, issueTitle, issueBody, []string{a.cfg.FlakyLabel})
 	if err != nil {
 		a.logger.Error("failed to create flaky CI issue", "error", err)
-	} else {
-		a.logger.Info("created flaky CI issue", "issue", issueNum)
-		if !a.ShouldSkipComment("flaky") {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("Opened issue #%d to track this flaky test.\n\n%s", issueNum, a.botComment())); err != nil {
-				a.logger.Error("failed to post flaky issue reference comment", "pr", task.work.PRNumber, "error", err)
-			}
-		}
+		return 0
 	}
+	a.logger.Info("created flaky CI issue", "issue", issueNum)
+	return issueNum
 }
 
 // extractURL extracts the first URL from a string.
@@ -542,8 +564,9 @@ func extractURL(s string) string {
 	return ""
 }
 
-// handleCIRelated handles a CI failure classified as related to PR changes.
-func (a *Agent) handleCIRelated(ctx context.Context, task ciTask, cleaned string) {
+// classifyCIRelated handles a CI failure classified as related to PR changes.
+// Returns a ciResult for consolidation; does NOT post a comment.
+func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned string) ciResult {
 	a.emit(Event{
 		Type:      EventAgentCompleted,
 		Category:  CategoryCI,
@@ -552,25 +575,24 @@ func (a *Agent) handleCIRelated(ctx context.Context, task ciTask, cleaned string
 		Action:    fmt.Sprintf("CI related: %s", task.failures[0].Name),
 		PRNumbers: []int{task.work.PRNumber},
 	})
+
+	idx := strings.Index(cleaned, "RELATED")
+	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "RELATED"), " :—–-"))
+
 	if a.cfg.SkipFix {
-		// Skip-fix mode: just post the analysis, don't try to fix or push
+		// Skip-fix mode: just record the analysis, don't try to fix or push
 		a.logger.Info("CI failure is related (skip-fix mode, not pushing)", "pr", task.work.PRNumber)
-		idx := strings.Index(cleaned, "RELATED")
-		analysis := strings.TrimPrefix(cleaned[idx:], "RELATED")
-		analysis = strings.TrimSpace(analysis)
-		marker := ciMarker(task.headSHA, task.failures[0].Name)
 		if a.ShouldSkipComment("ci-related") {
 			a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
 			a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-		} else {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("CI check `%s` is failing on commit %s and appears related to this PR's changes.\n\n%s\n\n%s", task.failures[0].Name, shortSHA(task.headSHA), analysis, marker)); err != nil {
-				a.logger.Error("failed to post CI analysis comment", "pr", task.work.PRNumber, "error", err)
-			}
 		}
 		task.work.LastCIStatus = "related-skip-fix"
 		task.work.LastCheckedCISHA = task.headSHA
-		return
+		return ciResult{
+			check:       task.failures[0].Name,
+			category:    "related",
+			explanation: explanation,
+		}
 	}
 
 	// Check if there are fixup commits, amended commits, or uncommitted changes
@@ -622,31 +644,162 @@ func (a *Agent) handleCIRelated(ctx context.Context, task ciTask, cleaned string
 		}
 	}
 
-	marker := ciMarker(task.headSHA, task.failures[0].Name)
 	if pushed {
 		a.logger.Info("CI failure is related, pushed a fix", "pr", task.work.PRNumber)
-		if a.ShouldSkipComment("ci-related") {
-			a.logger.Info("skipping CI fix-pushed comment (--skip-comment)", "pr", task.work.PRNumber)
-			a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-		} else {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("CI check `%s` was failing on commit %s. Pushed a fix.\n\n%s", task.failures[0].Name, shortSHA(task.headSHA), marker)); err != nil {
-				a.logger.Error("failed to post CI fix comment", "pr", task.work.PRNumber, "error", err)
-			}
-		}
 	} else {
 		a.logger.Warn("Claude said RELATED but no changes to push", "pr", task.work.PRNumber)
-		if a.ShouldSkipComment("ci-related") {
-			a.logger.Info("skipping CI fix-failed comment (--skip-comment)", "pr", task.work.PRNumber)
-			a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-		} else {
-			if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-				fmt.Sprintf("CI check `%s` is failing on commit %s. Investigated but could not push a fix.\n\n%s", task.failures[0].Name, shortSHA(task.headSHA), marker)); err != nil {
-				a.logger.Error("failed to post CI investigation comment", "pr", task.work.PRNumber, "error", err)
-			}
-		}
 	}
+
+	if a.ShouldSkipComment("ci-related") {
+		a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
+		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
+	}
+
 	task.work.CIFixAttempts++
 	task.work.LastCIStatus = "failure"
 	task.work.LastCheckedCISHA = currentHeadSHA
+
+	return ciResult{
+		check:       task.failures[0].Name,
+		category:    "related",
+		explanation: explanation,
+		pushed:      pushed,
+	}
+}
+
+// postConsolidatedCIComment builds and posts a single comment for all CI results
+// on a given PR+SHA. Each check gets its own dedup marker within the comment.
+func (a *Agent) postConsolidatedCIComment(ctx context.Context, work *IssueWork, headSHA string, results []ciResult) {
+	if len(results) == 0 {
+		return
+	}
+
+	// Group results by category
+	var infrastructure, unrelated, related []ciResult
+	for _, r := range results {
+		switch r.category {
+		case "infrastructure":
+			infrastructure = append(infrastructure, r)
+		case "unrelated":
+			unrelated = append(unrelated, r)
+		case "related":
+			related = append(related, r)
+		}
+	}
+
+	var comment strings.Builder
+	fmt.Fprintf(&comment, "CI failures on commit %s:\n", shortSHA(headSHA))
+
+	// Infrastructure section
+	if len(infrastructure) > 0 && !a.ShouldSkipComment("ci-infrastructure") {
+		fmt.Fprintf(&comment, "\n### Infrastructure Issues (%d)\n\n", len(infrastructure))
+		comment.WriteString("| Check | Summary |\n|-------|--------|\n")
+		for _, r := range infrastructure {
+			summary := escapeTableCell(firstSentence(r.explanation))
+			fmt.Fprintf(&comment, "| `%s` | %s |\n", escapeTableCell(r.check), summary)
+		}
+	}
+
+	// Unrelated section
+	if len(unrelated) > 0 && !a.ShouldSkipComment("ci-unrelated") {
+		hasFlakyIssues := false
+		for _, r := range unrelated {
+			if r.flakyIssue != 0 {
+				hasFlakyIssues = true
+				break
+			}
+		}
+		fmt.Fprintf(&comment, "\n### Unrelated Failures (%d)\n\n", len(unrelated))
+		if hasFlakyIssues && !a.ShouldSkipComment("flaky") {
+			comment.WriteString("| Check | Summary | Flaky Issue |\n|-------|---------|-------------|\n")
+			for _, r := range unrelated {
+				summary := escapeTableCell(firstSentence(r.explanation))
+				flakyRef := ""
+				if r.flakyIssue != 0 {
+					flakyRef = fmt.Sprintf("#%d", r.flakyIssue)
+				}
+				fmt.Fprintf(&comment, "| `%s` | %s | %s |\n", escapeTableCell(r.check), summary, flakyRef)
+			}
+		} else {
+			comment.WriteString("| Check | Summary |\n|-------|--------|\n")
+			for _, r := range unrelated {
+				summary := escapeTableCell(firstSentence(r.explanation))
+				fmt.Fprintf(&comment, "| `%s` | %s |\n", escapeTableCell(r.check), summary)
+			}
+		}
+	}
+
+	// Related section
+	if len(related) > 0 && !a.ShouldSkipComment("ci-related") {
+		fmt.Fprintf(&comment, "\n### Related Failures (%d)\n\n", len(related))
+		comment.WriteString("| Check | Summary |\n|-------|--------|\n")
+		for _, r := range related {
+			summary := escapeTableCell(firstSentence(r.explanation))
+			fmt.Fprintf(&comment, "| `%s` | %s |\n", escapeTableCell(r.check), summary)
+		}
+
+		// Note any fixes that were pushed
+		pushedChecks := 0
+		for _, r := range related {
+			if r.pushed {
+				pushedChecks++
+			}
+		}
+		if pushedChecks > 0 {
+			comment.WriteString("\nPushed a fix for the related failure")
+			if pushedChecks > 1 {
+				comment.WriteString("s")
+			}
+			comment.WriteString(".\n")
+		}
+	}
+
+	// Check if we have any visible content (non-skipped sections)
+	hasVisibleContent := (len(infrastructure) > 0 && !a.ShouldSkipComment("ci-infrastructure")) ||
+		(len(unrelated) > 0 && !a.ShouldSkipComment("ci-unrelated")) ||
+		(len(related) > 0 && !a.ShouldSkipComment("ci-related"))
+
+	if !hasVisibleContent {
+		return
+	}
+
+	// Append per-check dedup markers so alreadyCheckedCI still works
+	comment.WriteString("\n")
+	for _, r := range results {
+		comment.WriteString(ciMarker(headSHA, r.check) + "\n")
+	}
+
+	if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, comment.String()); err != nil {
+		a.logger.Error("failed to post consolidated CI comment", "pr", work.PRNumber, "error", err)
+	}
+}
+
+// escapeTableCell escapes characters that break markdown table rendering.
+func escapeTableCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+// firstSentence returns text up to the first period-followed-by-space, newline, or 120 chars.
+func firstSentence(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Take up to first newline
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = s[:idx]
+	}
+	// Take up to first period followed by space or end.
+	// If the string already ends with a period, keep it as-is.
+	if idx := strings.Index(s, ". "); idx >= 0 {
+		s = s[:idx+1]
+	}
+	// Truncate if too long
+	if len(s) > 120 {
+		s = s[:120] + "..."
+	}
+	return s
 }

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1302,9 +1302,13 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 		t.Errorf("expected FAILING_TEST: line to be stripped from issue body, got %q", issue.Body)
 	}
 
-	// Check that a comment was added to the PR
-	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + issue link), got %d", len(gh.addedComments))
+	// Check that a single consolidated comment was added to the PR
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+	// Consolidated comment should mention the flaky issue
+	if !strings.Contains(gh.addedComments[0], "#1") {
+		t.Errorf("expected consolidated comment to reference flaky issue #1, got: %q", gh.addedComments[0])
 	}
 }
 
@@ -1339,14 +1343,14 @@ func TestProcessCIFailures_InfrastructureSkipsFlakyIssue(t *testing.T) {
 		t.Errorf("expected 0 created issues for INFRASTRUCTURE classification, got %d", len(gh.createdIssues))
 	}
 
-	// Check that exactly 1 comment was posted (the infrastructure notice)
+	// Check that exactly 1 consolidated comment was posted
 	if len(gh.addedComments) != 1 {
-		t.Fatalf("expected 1 comment (infrastructure notice), got %d", len(gh.addedComments))
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
 	}
 
 	// Verify the comment mentions infrastructure
-	if !strings.Contains(gh.addedComments[0], "infrastructure issue") {
-		t.Errorf("expected comment to mention infrastructure issue, got: %q", gh.addedComments[0])
+	if !strings.Contains(gh.addedComments[0], "Infrastructure Issues") {
+		t.Errorf("expected comment to mention Infrastructure Issues, got: %q", gh.addedComments[0])
 	}
 	if !strings.Contains(gh.addedComments[0], "Build-PR") {
 		t.Errorf("expected comment to mention the check name, got: %q", gh.addedComments[0])
@@ -1473,12 +1477,10 @@ func TestProcessCIFailures_SkipCommentCIUnrelated_StillCreatesFlakyIssue(t *test
 		t.Fatalf("expected 1 created flaky issue, got %d", len(gh.createdIssues))
 	}
 
-	// Should have only flaky issue reference comment (no marker, no unrelated comment)
-	if len(gh.addedComments) != 1 {
-		t.Fatalf("expected 1 comment (flaky issue ref only), got %d", len(gh.addedComments))
-	}
-	if !strings.Contains(gh.addedComments[0], "Opened issue") {
-		t.Errorf("expected flaky issue reference comment, got: %q", gh.addedComments[0])
+	// No comments should be posted — the unrelated section is skipped (ci-unrelated),
+	// so the consolidated comment has no visible content and is suppressed.
+	if len(gh.addedComments) != 0 {
+		t.Fatalf("expected 0 comments (ci-unrelated skipped, no visible sections), got %d: %v", len(gh.addedComments), gh.addedComments)
 	}
 }
 
@@ -1556,12 +1558,16 @@ func TestProcessCIFailures_SkipCommentFlaky(t *testing.T) {
 		t.Fatalf("expected 1 created flaky issue, got %d", len(gh.createdIssues))
 	}
 
-	// Should have only the unrelated comment (not the "Opened issue #N" cross-reference)
+	// Should have only the consolidated comment (flaky issue column suppressed by skip-comment: flaky)
 	if len(gh.addedComments) != 1 {
-		t.Fatalf("expected 1 comment (unrelated notice only, flaky ref suppressed), got %d", len(gh.addedComments))
+		t.Fatalf("expected 1 consolidated comment (flaky ref suppressed), got %d", len(gh.addedComments))
 	}
-	if !strings.Contains(gh.addedComments[0], "appears unrelated") {
-		t.Errorf("expected unrelated comment, got: %q", gh.addedComments[0])
+	if !strings.Contains(gh.addedComments[0], "Unrelated Failures") {
+		t.Errorf("expected unrelated section in consolidated comment, got: %q", gh.addedComments[0])
+	}
+	// With flaky comment skipped, the issue reference should NOT appear in the table
+	if strings.Contains(gh.addedComments[0], "Flaky Issue") {
+		t.Errorf("expected flaky issue column to be suppressed when skip-comment: flaky, got: %q", gh.addedComments[0])
 	}
 }
 
@@ -1602,27 +1608,26 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 	}
 
 	// Check that comments were added:
-	// 1. unrelated notice on PR
-	// 2. CI lane link on the flaky issue (#50)
-	// 3. "Known flaky test" reference on PR
-	if len(gh.addedComments) != 3 {
-		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
+	// 1. CI lane link on the flaky issue (#50) — per-check side effect
+	// 2. consolidated comment on PR with flaky issue reference in table
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (CI lane link + consolidated), got %d", len(gh.addedComments))
 	}
 
 	// Verify the CI lane link comment (posted on the flaky issue #50)
-	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
-		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	if !strings.Contains(gh.addedComments[0], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[0])
 	}
-	if gh.addedCommentTargets[1] != 50 {
-		t.Errorf("expected CI lane link comment posted to issue #50, got #%d", gh.addedCommentTargets[1])
+	if gh.addedCommentTargets[0] != 50 {
+		t.Errorf("expected CI lane link comment posted to issue #50, got #%d", gh.addedCommentTargets[0])
 	}
 
-	// Verify the flaky reference comment on the PR (#100)
-	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #50") {
-		t.Errorf("expected flaky reference comment, got: %q", gh.addedComments[2])
+	// Verify the consolidated comment on the PR references the flaky issue
+	if !strings.Contains(gh.addedComments[1], "#50") {
+		t.Errorf("expected consolidated comment to reference flaky issue #50, got: %q", gh.addedComments[1])
 	}
-	if gh.addedCommentTargets[2] != 100 {
-		t.Errorf("expected flaky reference comment posted to PR #100, got #%d", gh.addedCommentTargets[2])
+	if gh.addedCommentTargets[1] != 100 {
+		t.Errorf("expected consolidated comment posted to PR #100, got #%d", gh.addedCommentTargets[1])
 	}
 }
 
@@ -1670,22 +1675,21 @@ func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
 		t.Errorf("expected 1 claude call (CI investigation only, no LLM matching), got %d", claudeCalls)
 	}
 
-	// Should have 3 comments:
-	// 1. unrelated notice on PR
-	// 2. CI lane link on the flaky issue (#99)
-	// 3. "Known flaky test" reference on PR
-	if len(gh.addedComments) != 3 {
-		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
+	// Should have 2 comments:
+	// 1. CI lane link on the flaky issue (#99) — per-check side effect
+	// 2. consolidated comment on PR with flaky issue reference in table
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (CI lane link + consolidated), got %d", len(gh.addedComments))
 	}
 
 	// Verify the CI lane link comment (posted on the flaky issue)
-	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
-		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	if !strings.Contains(gh.addedComments[0], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[0])
 	}
 
-	// Verify the flaky reference points to issue #99
-	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #99") {
-		t.Errorf("expected flaky reference to issue #99, got: %q", gh.addedComments[2])
+	// Verify the consolidated comment references flaky issue #99
+	if !strings.Contains(gh.addedComments[1], "#99") {
+		t.Errorf("expected consolidated comment to reference flaky issue #99, got: %q", gh.addedComments[1])
 	}
 }
 
@@ -1729,9 +1733,12 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 		t.Errorf("expected labels ['flaky-test'], got %v", issue.Labels)
 	}
 
-	// Check that comments were added (unrelated notice + new issue reference)
-	if len(gh.addedComments) != 2 {
-		t.Fatalf("expected 2 comments (unrelated + issue link), got %d", len(gh.addedComments))
+	// Check that a single consolidated comment was added referencing the new flaky issue
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+	if !strings.Contains(gh.addedComments[0], "#1") {
+		t.Errorf("expected consolidated comment to reference flaky issue #1, got: %q", gh.addedComments[0])
 	}
 }
 
@@ -1811,30 +1818,24 @@ func TestProcessCIFailures_SearchAndLinkWithoutCreateFlakyIssues(t *testing.T) {
 		t.Errorf("expected 0 created issues (create-flaky-issues=false), got %d", len(gh.createdIssues))
 	}
 
-	// Should have 3 comments:
-	// 1. unrelated notice on PR
-	// 2. CI lane link comment on the existing flaky issue (#1234)
-	// 3. "Known flaky test" reference on PR
-	if len(gh.addedComments) != 3 {
-		t.Fatalf("expected 3 comments (unrelated + CI lane link + flaky reference), got %d", len(gh.addedComments))
-	}
-
-	// Verify unrelated comment
-	if !strings.Contains(gh.addedComments[0], "appears unrelated") {
-		t.Errorf("expected unrelated comment, got: %q", gh.addedComments[0])
+	// Should have 2 comments:
+	// 1. CI lane link comment on the existing flaky issue (#1234) — per-check side effect
+	// 2. consolidated comment on PR with flaky issue reference in table
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (CI lane link + consolidated), got %d", len(gh.addedComments))
 	}
 
 	// Verify CI lane link on the flaky issue
-	if !strings.Contains(gh.addedComments[1], "CI failure on PR #100") {
-		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[1])
+	if !strings.Contains(gh.addedComments[0], "CI failure on PR #100") {
+		t.Errorf("expected CI lane link comment, got: %q", gh.addedComments[0])
 	}
-	if !strings.Contains(gh.addedComments[1], "integration-tests") {
-		t.Errorf("expected CI lane link to mention CI lane name, got: %q", gh.addedComments[1])
+	if !strings.Contains(gh.addedComments[0], "integration-tests") {
+		t.Errorf("expected CI lane link to mention CI lane name, got: %q", gh.addedComments[0])
 	}
 
-	// Verify the PR reference comment
-	if !strings.Contains(gh.addedComments[2], "Known flaky test tracked in #1234") {
-		t.Errorf("expected flaky reference to issue #1234, got: %q", gh.addedComments[2])
+	// Verify the consolidated comment references flaky issue #1234
+	if !strings.Contains(gh.addedComments[1], "#1234") {
+		t.Errorf("expected consolidated comment to reference flaky issue #1234, got: %q", gh.addedComments[1])
 	}
 }
 
@@ -1873,12 +1874,12 @@ func TestProcessCIFailures_NoMatchNoCreateWhenDisabled(t *testing.T) {
 		t.Errorf("expected 0 created issues (create-flaky-issues=false, no match), got %d", len(gh.createdIssues))
 	}
 
-	// Only the unrelated comment should be posted
+	// Only the consolidated unrelated comment should be posted
 	if len(gh.addedComments) != 1 {
-		t.Fatalf("expected 1 comment (unrelated notice only), got %d", len(gh.addedComments))
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
 	}
-	if !strings.Contains(gh.addedComments[0], "appears unrelated") {
-		t.Errorf("expected unrelated comment, got: %q", gh.addedComments[0])
+	if !strings.Contains(gh.addedComments[0], "Unrelated Failures") {
+		t.Errorf("expected consolidated comment with unrelated section, got: %q", gh.addedComments[0])
 	}
 }
 
@@ -1952,12 +1953,14 @@ func TestProcessCIFailures_CILaneLinkIncludesJobURL(t *testing.T) {
 
 	agent.ProcessCIFailures(context.Background())
 
-	// Verify CI lane link comment was posted on the flaky issue
-	if len(gh.addedComments) < 2 {
-		t.Fatalf("expected at least 2 comments, got %d", len(gh.addedComments))
+	// Should have 2 comments:
+	// 1. CI lane link on the flaky issue (#5678) — per-check side effect
+	// 2. consolidated comment on PR with flaky issue reference in table
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (CI lane link + consolidated), got %d", len(gh.addedComments))
 	}
 
-	ciLaneComment := gh.addedComments[1]
+	ciLaneComment := gh.addedComments[0]
 	if !strings.Contains(ciLaneComment, "CI failure on PR #100") {
 		t.Errorf("expected CI lane link to reference PR #100, got: %q", ciLaneComment)
 	}
@@ -1999,12 +2002,14 @@ func TestProcessCIFailures_CommitStatusCILaneLink(t *testing.T) {
 
 	agent.ProcessCIFailures(context.Background())
 
-	// Verify CI lane link uses the Prow URL extracted from the output
-	if len(gh.addedComments) < 2 {
-		t.Fatalf("expected at least 2 comments, got %d", len(gh.addedComments))
+	// Should have 2 comments:
+	// 1. CI lane link on the flaky issue (#999) — per-check side effect
+	// 2. consolidated comment on PR
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments (CI lane link + consolidated), got %d", len(gh.addedComments))
 	}
 
-	ciLaneComment := gh.addedComments[1]
+	ciLaneComment := gh.addedComments[0]
 	if !strings.Contains(ciLaneComment, "https://prow.ci.kubevirt.io/view/gs/logs/1234") {
 		t.Errorf("expected CI lane link to include Prow URL, got: %q", ciLaneComment)
 	}
@@ -2229,12 +2234,12 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 		WorktreePath: "/tmp/worktree",
 	}
 
-	// First poll cycle: should investigate and post comment
+	// First poll cycle: should investigate and post consolidated comment
 	agent.ProcessCIFailures(context.Background())
 	if len(gh.addedComments) != 1 {
 		t.Fatalf("expected 1 comment on first poll, got %d", len(gh.addedComments))
 	}
-	if !strings.Contains(gh.addedComments[0], "CI check `test` failed on commit abc123 but appears unrelated") {
+	if !strings.Contains(gh.addedComments[0], "Unrelated Failures") || !strings.Contains(gh.addedComments[0], "`test`") {
 		t.Errorf("unexpected comment body: %s", gh.addedComments[0])
 	}
 
@@ -3505,6 +3510,310 @@ func TestProcessCIFailures_SkipChecksDoesNotAffectAllCompleted(t *testing.T) {
 	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCheckedCISHA != "abc123" {
 		t.Errorf("expected LastCheckedCISHA to be set when skipped check is the only non-completed, got %q", work.LastCheckedCISHA)
+	}
+}
+
+func TestProcessCIFailures_ConsolidatesMultipleFailuresIntoSingleComment(t *testing.T) {
+	// Issue #173: Multiple CI failures on the same SHA should produce a single consolidated comment.
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test-deploy", Status: "completed", Conclusion: "failure", Output: "GitHub git server returned HTTP 500"},
+			{ID: 2, Name: "check-license-header", Status: "completed", Conclusion: "failure", Output: "GitHub git server returned HTTP 500"},
+			{ID: 3, Name: "e2e-dual-conversion", Status: "completed", Conclusion: "failure", Output: "GitHub git server returned HTTP 500"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Cloning repository...\nfatal: unable to access: HTTP 500 Internal Server Error",
+			2: "Cloning repository...\nfatal: unable to access: HTTP 500 Internal Server Error",
+			3: "Cloning repository...\nfatal: unable to access: HTTP 500 Internal Server Error",
+		},
+	}
+	// All three failures are INFRASTRUCTURE
+	infraResult := streamResultJSON(AgentResult{Result: "INFRASTRUCTURE GitHub git server returned HTTP 500"})
+	runner := &mockCommandRunner{stdout: infraResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// All three failures investigated independently
+	claudeCalls := countClaudeCalls(runner.calls)
+	if claudeCalls != 3 {
+		t.Fatalf("expected 3 claude calls (one per failure), got %d", claudeCalls)
+	}
+
+	// Only ONE consolidated comment should be posted
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+
+	comment := gh.addedComments[0]
+	// Should mention all three checks
+	if !strings.Contains(comment, "test-deploy") {
+		t.Errorf("expected comment to mention test-deploy")
+	}
+	if !strings.Contains(comment, "check-license-header") {
+		t.Errorf("expected comment to mention check-license-header")
+	}
+	if !strings.Contains(comment, "e2e-dual-conversion") {
+		t.Errorf("expected comment to mention e2e-dual-conversion")
+	}
+	// Should have infrastructure section with count
+	if !strings.Contains(comment, "Infrastructure Issues (3)") {
+		t.Errorf("expected Infrastructure Issues (3), got: %q", comment)
+	}
+	// Should have per-check dedup markers
+	if !strings.Contains(comment, ciMarker("abc123", "test-deploy")) {
+		t.Errorf("expected per-check dedup marker for test-deploy")
+	}
+	if !strings.Contains(comment, ciMarker("abc123", "check-license-header")) {
+		t.Errorf("expected per-check dedup marker for check-license-header")
+	}
+}
+
+func TestProcessCIFailures_ConsolidatesMixedCategories(t *testing.T) {
+	// Issue #173: Mixed categories (infrastructure + unrelated + related) in one consolidated comment.
+	infraResult := streamResultJSON(AgentResult{Result: "INFRASTRUCTURE GitHub git server returned HTTP 500"})
+	unrelatedResult := streamResultJSON(AgentResult{Result: "UNRELATED BGP peering timeout in e2e test"})
+	relatedResult := streamResultJSON(AgentResult{Result: "RELATED Test assertion failed in kubevirt handler"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test-deploy", Status: "completed", Conclusion: "failure", Output: "GitHub git server returned HTTP 500 with a bunch of other text to make it 50 chars"},
+			{ID: 2, Name: "e2e-bgp", Status: "completed", Conclusion: "failure", Output: "BGP peering timeout in e2e test with more detail padding to exceed fifty characters"},
+			{ID: 3, Name: "e2e-control-plane", Status: "completed", Conclusion: "failure", Output: "Test assertion failed in kubevirt handler extra padding for the fifty char check"},
+		},
+		prHeadSHAs: []string{"sha-before", "sha-after"},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{infraResult, unrelatedResult, relatedResult}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should have exactly ONE consolidated comment on the PR
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+
+	comment := gh.addedComments[0]
+	// All three sections should be present
+	if !strings.Contains(comment, "Infrastructure Issues (1)") {
+		t.Errorf("expected Infrastructure Issues section, got: %q", comment)
+	}
+	if !strings.Contains(comment, "Unrelated Failures (1)") {
+		t.Errorf("expected Unrelated Failures section, got: %q", comment)
+	}
+	if !strings.Contains(comment, "Related Failures (1)") {
+		t.Errorf("expected Related Failures section, got: %q", comment)
+	}
+	// Related section should mention the fix was pushed
+	if !strings.Contains(comment, "Pushed a fix") {
+		t.Errorf("expected 'Pushed a fix' note, got: %q", comment)
+	}
+}
+
+func TestProcessCIFailures_SingleFailureStillConsolidated(t *testing.T) {
+	// Issue #173: A single failure should still use the consolidated format.
+	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED Flaky network test with detailed explanation exceeding fifty characters for the output check"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "e2e-network", Status: "completed", Conclusion: "failure", Output: "timeout connecting to service with some extra text to exceed the threshold"},
+		},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(gh.addedComments))
+	}
+	comment := gh.addedComments[0]
+	// Should use the consolidated format (with header and table)
+	if !strings.Contains(comment, "CI failures on commit") {
+		t.Errorf("expected consolidated format header, got: %q", comment)
+	}
+	if !strings.Contains(comment, "Unrelated Failures (1)") {
+		t.Errorf("expected Unrelated Failures section, got: %q", comment)
+	}
+	if !strings.Contains(comment, "`e2e-network`") {
+		t.Errorf("expected check name in table, got: %q", comment)
+	}
+}
+
+func TestProcessCIFailures_ConsolidatedSkipsInfrastructureSection(t *testing.T) {
+	// Issue #173: skip-comment ci-infrastructure should suppress the infrastructure section
+	// but still include other sections.
+	infraResult := streamResultJSON(AgentResult{Result: "INFRASTRUCTURE GitHub git server returned HTTP 500"})
+	unrelatedResult := streamResultJSON(AgentResult{Result: "UNRELATED Flaky test timeout exceeding the minimum chars check for the fifty character threshold"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test-deploy", Status: "completed", Conclusion: "failure", Output: "GitHub git server returned HTTP 500 with a bunch of extra text to be above threshold"},
+			{ID: 2, Name: "e2e-bgp", Status: "completed", Conclusion: "failure", Output: "BGP peering timeout in test with a bunch of extra padding for length threshold"},
+		},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{infraResult, unrelatedResult}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SkipComments = []string{"ci-infrastructure"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should have exactly 1 consolidated comment
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+
+	comment := gh.addedComments[0]
+	// Infrastructure section should be absent
+	if strings.Contains(comment, "Infrastructure Issues") {
+		t.Errorf("expected no Infrastructure Issues section (skipped), got: %q", comment)
+	}
+	// Unrelated section should be present
+	if !strings.Contains(comment, "Unrelated Failures (1)") {
+		t.Errorf("expected Unrelated Failures section, got: %q", comment)
+	}
+	// Infrastructure check's dedup marker should still be present
+	if !strings.Contains(comment, ciMarker("abc123", "test-deploy")) {
+		t.Errorf("expected dedup marker for skipped infrastructure check")
+	}
+}
+
+func TestProcessCIFailures_FlakyIssueLinkInConsolidatedComment(t *testing.T) {
+	// Issue #173: Flaky issue links should appear in the unrelated section table.
+	ciResult1 := streamResultJSON(AgentResult{Result: "UNRELATED Flaky test timeout exceeding the minimum chars check for the fifty character threshold"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "integration-tests", Status: "completed", Conclusion: "failure", Output: "Error: connection timeout with additional text for the fifty character threshold"},
+		},
+		checkRunLogs: map[int64]string{
+			1: "Starting integration tests...\nConnecting to database...\nError: connection timeout after 30s\nStack trace:\n  at TestDB.connect(db.go:42)\n  at TestSuite.setUp(suite.go:15)",
+		},
+		searchResults: []Issue{
+			{Number: 42, Title: "Flaky CI: integration-tests", Labels: []string{"flaky-test"}},
+		},
+	}
+	runner := &mockCommandRunner{stdout: ciResult1}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.CreateFlakyIssues = false
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 99)] = &IssueWork{
+		IssueNumber:  99,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-99",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	// Should have 2 comments: CI lane link on flaky issue + consolidated on PR
+	if len(gh.addedComments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(gh.addedComments))
+	}
+
+	// Consolidated comment should include a Flaky Issue column with #42
+	consolidated := gh.addedComments[1]
+	if !strings.Contains(consolidated, "Flaky Issue") {
+		t.Errorf("expected Flaky Issue column header, got: %q", consolidated)
+	}
+	if !strings.Contains(consolidated, "#42") {
+		t.Errorf("expected flaky issue #42 reference, got: %q", consolidated)
+	}
+}
+
+func TestProcessCIFailures_RelatedPushedFixNoteInConsolidated(t *testing.T) {
+	// Issue #173: When a fix is pushed for a related failure, the consolidated
+	// comment should note "Pushed a fix for the related failure."
+	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed the kubevirt handler test assertion"})
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "e2e-control-plane", Status: "completed", Conclusion: "failure", Output: "Test assertion failed in kubevirt handler extra text to exceed fifty characters"},
+		},
+		prHeadSHAs: []string{"sha-before", "sha-after"}, // different SHAs = fix pushed
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessCIFailures(context.Background())
+
+	if len(gh.addedComments) != 1 {
+		t.Fatalf("expected 1 consolidated comment, got %d", len(gh.addedComments))
+	}
+
+	comment := gh.addedComments[0]
+	if !strings.Contains(comment, "Related Failures (1)") {
+		t.Errorf("expected Related Failures section, got: %q", comment)
+	}
+	if !strings.Contains(comment, "Pushed a fix for the related failure.") {
+		t.Errorf("expected pushed fix note, got: %q", comment)
+	}
+}
+
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"GitHub git server returned HTTP 500. Detailed analysis follows.", "GitHub git server returned HTTP 500."},
+		{"Simple explanation", "Simple explanation"},
+		{"", ""},
+		{"First line\nSecond line", "First line"},
+		{strings.Repeat("x", 200), strings.Repeat("x", 120) + "..."},
+	}
+	for _, tt := range tests {
+		got := firstSentence(tt.input)
+		if got != tt.want {
+			t.Errorf("firstSentence(%q) = %q, want %q", tt.input, got, tt.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #173

## Summary

Consolidates CI failure comments into a single PR comment per commit instead of posting one comment per failing check. When multiple CI checks fail on the same commit, all investigation results are now grouped into a single comment with sections for Infrastructure Issues, Unrelated Failures, and Related Failures.

## Changes

- Add `ciResult` struct to hold per-check investigation results (category, explanation, flaky issue link, pushed status)
- Refactor `handleCIInfrastructure`, `handleCIUnrelated`, `handleCIRelated` into `classifyCIInfrastructure`, `classifyCIUnrelated`, `classifyCIRelated` that return `ciResult` instead of posting comments directly
- Add result collection phase in `ProcessCIFailures` that groups results by PR+SHA
- Add `postConsolidatedCIComment` method that builds a single markdown comment with categorized tables
- Update `handleFlakyIssue` and `createNewFlakyIssue` to return issue numbers instead of posting PR reference comments (flaky issue references are now in the consolidated table)
- Add `firstSentence` helper for extracting concise summaries for table rows
- Per-check dedup markers (`ciMarker`) are appended to the consolidated comment so `alreadyCheckedCI` still works
- Flaky issue side effects (CI lane link comments, issue creation) remain per-check
- Skip-comment categories still respected per-section (e.g., `ci-infrastructure` suppresses only the infrastructure section)

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests added:
  - `TestProcessCIFailures_ConsolidatesMultipleFailuresIntoSingleComment` — 3 infrastructure failures → 1 comment
  - `TestProcessCIFailures_ConsolidatesMixedCategories` — infrastructure + unrelated + related → all sections in 1 comment
  - `TestProcessCIFailures_SingleFailureStillConsolidated` — single failure uses consolidated format
  - `TestProcessCIFailures_ConsolidatedSkipsInfrastructureSection` — skip-comment suppresses section
  - `TestProcessCIFailures_FlakyIssueLinkInConsolidatedComment` — flaky issue links in table
  - `TestProcessCIFailures_RelatedPushedFixNoteInConsolidated` — pushed fix note in related section
  - `TestFirstSentence` — unit test for summary extraction

## Related Issues

Fixes #173

<!-- oompa-bot v:b525c01 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CI failures now generate a single consolidated comment per pull request instead of multiple separate comments, with failures organized by category (infrastructure, unrelated, related) and deduplication markers to reduce clutter.
  * Flaky issue numbers are now displayed in a dedicated column within the CI failure table for quick reference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->