### PR TITLE
feat: Slack reporting per poll cycle with GitHub links

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -98,6 +98,8 @@ func parseConfig() (cfg agent.Config, exitOnNewVersion, configPath string) {
 	flag.StringVar(&cfg.FlakyLabel, "flaky-label", envOrDefault("OOMPA_FLAKY_LABEL", "flaky-test"), "Label to apply to flaky CI issues")
 	flag.BoolVar(&cfg.OnlyAssigned, "only-assigned", envOrDefault("OOMPA_ONLY_ASSIGNED", "") == "true", "Only process issues assigned to the agent user")
 
+	cfg.SlackWebhookURL = os.Getenv("OOMPA_SLACK_WEBHOOK")
+
 	var forkFlag string
 	flag.StringVar(&forkFlag, "fork", envOrDefault("OOMPA_FORK", ""), "Fork repo as owner/repo for pushing (e.g. qinqon/ovn-kubernetes)")
 
@@ -493,6 +495,12 @@ func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, token
 		a.SetTokenFunc(tokenFunc)
 	}
 
+	if cfg.SlackWebhookURL != "" {
+		slack := agent.NewSlackReporter(cfg.SlackWebhookURL, cfg.Owner, cfg.Repo, logger)
+		a.SetSlackReporter(slack)
+		logger.Info("Slack reporting enabled")
+	}
+
 	return a
 }
 
@@ -816,6 +824,13 @@ func runLoop(ctx context.Context, a *agent.Agent, logger *slog.Logger) {
 
 	// ProcessTriageJobs is independent of other reactions and runs when triage jobs are configured
 	a.ProcessTriageJobs(ctx)
+
+	// Slack reporting: run report-only checks for reactions NOT in the active list,
+	// then post consolidated findings to Slack.
+	if a.SlackEnabled() {
+		findings := a.RunReportOnlyChecks(ctx)
+		a.ReportToSlack(ctx, findings)
+	}
 
 	a.EmitPollCycleEnd()
 	logger.Debug("poll cycle complete")

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	SkipChecks        []string // CI check names to ignore entirely (filtered before investigation)
 	MaxReviewNoOps    int      // consecutive no-op review cycles before pausing review processing (default: 3)
 	MaxPRSessionCost  float64  // max cumulative agent cost per PR per session before pausing (default: 0 = unlimited)
+	SlackWebhookURL   string   // Slack Incoming Webhook URL for per-cycle reporting (empty = disabled)
 
 	// GitHub App authentication (alternative to GITHUB_TOKEN)
 	GitHubAppID             int64

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -63,6 +63,7 @@ type Agent struct {
 	tokenFunc func(context.Context) (string, error) // optional: provides fresh GitHub tokens (for App auth)
 	codeAgent CodeAgent                             // coding agent backend (Claude Code or OpenCode)
 	emitter   EventEmitter                          // optional: event emitter for observability (default: NoopEmitter)
+	slack     *SlackReporter                        // optional: Slack reporting (nil = disabled)
 }
 
 // botComment returns the bot marker with the agent version embedded.
@@ -157,6 +158,73 @@ func NewAgent(gh GitHubClient, runner CommandRunner, worktrees WorktreeManager, 
 		codeAgent: codeAgent,
 		emitter:   &NoopEmitter{},
 	}
+}
+
+// SetSlackReporter sets the Slack reporter for per-cycle reporting.
+// If not called, no Slack messages are sent.
+func (a *Agent) SetSlackReporter(slack *SlackReporter) {
+	a.slack = slack
+}
+
+// SlackEnabled returns true if the Slack reporter is configured and enabled.
+func (a *Agent) SlackEnabled() bool {
+	return a.slack != nil && a.slack.IsEnabled()
+}
+
+// ReportToSlack sends findings to Slack if the reporter is configured.
+func (a *Agent) ReportToSlack(ctx context.Context, findings []SlackFinding) {
+	if a.slack == nil {
+		return
+	}
+	a.slack.Report(ctx, findings)
+}
+
+// RunReportOnlyChecks runs lightweight check methods for reactions NOT in the active
+// reactions list and returns findings. Only called when Slack reporting is enabled.
+func (a *Agent) RunReportOnlyChecks(ctx context.Context) []SlackFinding {
+	var findings []SlackFinding
+
+	if a.ShouldCheckReaction("ci") {
+		findings = append(findings, a.CheckCIStatus(ctx)...)
+	}
+
+	// Prefetch mergeable states once when both conflict and rebase checks are needed,
+	// avoiding redundant GitHub API calls for the same PRs.
+	checkConflicts := a.ShouldCheckReaction("conflicts")
+	checkRebase := a.ShouldCheckReaction("rebase")
+	if checkConflicts || checkRebase {
+		states := a.fetchMergeableStates(ctx)
+		if checkConflicts {
+			findings = append(findings, a.checkConflictsWithStates(ctx, states)...)
+		}
+		if checkRebase {
+			findings = append(findings, a.checkRebaseNeededWithStates(ctx, states)...)
+		}
+	}
+
+	if a.ShouldCheckReaction("reviews") {
+		findings = append(findings, a.CheckNewReviews(ctx)...)
+	}
+
+	return findings
+}
+
+// fetchMergeableStates fetches the mergeable state for all active open PRs.
+// Returns a map of PR number to mergeable state string.
+func (a *Agent) fetchMergeableStates(ctx context.Context) map[int]string {
+	states := make(map[int]string)
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != StatusPROpen {
+			continue
+		}
+		mergeState, err := a.gh.GetPRMergeable(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			a.logger.Error("failed to get PR mergeable state", "pr", work.PRNumber, "error", err)
+			continue
+		}
+		states[work.PRNumber] = mergeState
+	}
+	return states
 }
 
 // SetEmitter sets the event emitter for observability.
@@ -267,6 +335,21 @@ func (a *Agent) ShouldRunReaction(reaction string) bool {
 		return true
 	}
 	return slices.Contains(a.cfg.Reactions, reaction)
+}
+
+// ShouldCheckReaction returns true if a report-only check should run for the given reaction.
+// This is true when the Slack webhook is set AND the reaction is NOT in the active reactions list.
+// When Reactions is empty (all enabled), no report-only checks run because all reactions
+// are already being processed by their full Process* methods.
+func (a *Agent) ShouldCheckReaction(reaction string) bool {
+	if a.cfg.SlackWebhookURL == "" {
+		return false
+	}
+	if len(a.cfg.Reactions) == 0 {
+		// All reactions enabled → nothing is report-only
+		return false
+	}
+	return !slices.Contains(a.cfg.Reactions, reaction)
 }
 
 // ShouldSkipComment returns true if the given comment category should be suppressed.
@@ -461,6 +544,192 @@ func isConflictError(stderr string) bool {
 // unstaged changes are blocking the rebase (e.g. upstream file deletions).
 func isUnstagedChangesError(stderr string) bool {
 	return strings.Contains(strings.ToLower(stderr), "unstaged changes")
+}
+
+// CheckCIStatus is a lightweight report-only check that fetches CI check runs
+// and returns findings for any failures. No agent invocation, no fixes.
+func (a *Agent) CheckCIStatus(ctx context.Context) []SlackFinding {
+	var findings []SlackFinding
+
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != StatusPROpen {
+			continue
+		}
+
+		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			a.logger.Error("check CI: failed to get PR head SHA", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		runs, err := a.gh.GetCheckRuns(ctx, a.cfg.Owner, a.cfg.Repo, headSHA)
+		if err != nil {
+			a.logger.Error("check CI: failed to get check runs", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		for _, r := range runs {
+			if slices.Contains(a.cfg.SkipChecks, r.Name) {
+				continue
+			}
+			if r.Status == "completed" && r.Conclusion == "failure" {
+				link := r.HTMLURL
+				if link == "" {
+					link = fmt.Sprintf("https://github.com/%s/%s/commit/%s/checks", a.cfg.Owner, a.cfg.Repo, headSHA)
+				}
+				msg := fmt.Sprintf("🔴 <%s|%s> failed", link, r.Name)
+				findings = append(findings, SlackFinding{
+					PRNumber: work.PRNumber,
+					PRTitle:  work.IssueTitle,
+					PRURL:    prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber),
+					Category: "ci",
+					Message:  msg,
+					DedupKey: fmt.Sprintf("ci:%s:%s", headSHA, r.Name),
+				})
+			}
+		}
+	}
+
+	return findings
+}
+
+// CheckRebaseNeeded is a lightweight report-only check that inspects PR mergeable state
+// and returns findings for PRs that are behind the base branch.
+// Fetches mergeable states from GitHub. Use checkRebaseNeededWithStates when states
+// are already available to avoid redundant API calls.
+func (a *Agent) CheckRebaseNeeded(ctx context.Context) []SlackFinding {
+	return a.checkRebaseNeededWithStates(ctx, a.fetchMergeableStates(ctx))
+}
+
+// checkRebaseNeededWithStates checks for outdated PRs using precomputed mergeable states.
+func (a *Agent) checkRebaseNeededWithStates(ctx context.Context, states map[int]string) []SlackFinding {
+	var findings []SlackFinding
+
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != StatusPROpen {
+			continue
+		}
+
+		mergeState, ok := states[work.PRNumber]
+		if !ok {
+			continue
+		}
+
+		needsRebase := mergeState == "behind"
+		if !needsRebase && mergeState != "dirty" {
+			behind, err := a.gh.IsPRBehind(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+			if err != nil {
+				a.logger.Warn("check rebase: failed to check if PR is behind", "pr", work.PRNumber, "error", err)
+			}
+			needsRebase = behind
+		}
+
+		if needsRebase {
+			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+			findings = append(findings, SlackFinding{
+				PRNumber: work.PRNumber,
+				PRTitle:  work.IssueTitle,
+				PRURL:    pURL,
+				Category: "rebase",
+				Message:  fmt.Sprintf("⚠️ <%s|PR #%d> is behind %s", pURL, work.PRNumber, a.defaultBranch()),
+				DedupKey: fmt.Sprintf("rebase-needed:%d", work.PRNumber),
+			})
+		}
+	}
+
+	return findings
+}
+
+// CheckConflicts is a lightweight report-only check that inspects PR mergeable state
+// and returns findings for PRs with merge conflicts.
+// Fetches mergeable states from GitHub. Use checkConflictsWithStates when states
+// are already available to avoid redundant API calls.
+func (a *Agent) CheckConflicts(ctx context.Context) []SlackFinding {
+	return a.checkConflictsWithStates(ctx, a.fetchMergeableStates(ctx))
+}
+
+// checkConflictsWithStates checks for merge conflicts using precomputed mergeable states.
+func (a *Agent) checkConflictsWithStates(_ context.Context, states map[int]string) []SlackFinding {
+	var findings []SlackFinding
+
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != StatusPROpen {
+			continue
+		}
+
+		mergeState, ok := states[work.PRNumber]
+		if !ok {
+			continue
+		}
+
+		if mergeState == "dirty" {
+			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+			findings = append(findings, SlackFinding{
+				PRNumber: work.PRNumber,
+				PRTitle:  work.IssueTitle,
+				PRURL:    pURL,
+				Category: "conflict",
+				Message:  fmt.Sprintf("⚠️ <%s|PR #%d> has merge conflicts", pURL, work.PRNumber),
+				DedupKey: fmt.Sprintf("conflict:%d", work.PRNumber),
+			})
+		}
+	}
+
+	return findings
+}
+
+// CheckNewReviews is a lightweight report-only check that counts new review comments
+// and returns findings when new comments exist.
+func (a *Agent) CheckNewReviews(ctx context.Context) []SlackFinding {
+	var findings []SlackFinding
+
+	for _, work := range a.state.ActiveIssues {
+		if work.PRNumber == 0 || work.Status != StatusPROpen {
+			continue
+		}
+
+		comments, err := a.gh.GetPRReviewComments(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, work.LastCommentID)
+		if err != nil {
+			a.logger.Error("check reviews: failed to get PR comments", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		// Filter out bot comments, replies, and non-whitelisted reviewers
+		// (same filtering as ProcessReviewComments to avoid noise)
+		var humanComments []ReviewComment
+		for _, c := range comments {
+			if c.InReplyToID != 0 {
+				continue
+			}
+			if strings.Contains(c.Body, botMarker) {
+				continue
+			}
+			if !a.isAllowedReviewer(c.User) {
+				continue
+			}
+			humanComments = append(humanComments, c)
+		}
+
+		if len(humanComments) > 0 {
+			var maxID int64
+			for _, c := range humanComments {
+				if c.ID > maxID {
+					maxID = c.ID
+				}
+			}
+			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+			findings = append(findings, SlackFinding{
+				PRNumber: work.PRNumber,
+				PRTitle:  work.IssueTitle,
+				PRURL:    pURL,
+				Category: "review",
+				Message:  fmt.Sprintf("💬 <%s|PR #%d> has %d new review comment(s)", pURL, work.PRNumber, len(humanComments)),
+				DedupKey: fmt.Sprintf("review:%d:%d", work.PRNumber, maxID),
+			})
+		}
+	}
+
+	return findings
 }
 
 // markIssueFailed marks an issue as failed, unassigns the agent, and adds the ai-failed label.

--- a/pkg/agent/slack.go
+++ b/pkg/agent/slack.go
@@ -1,0 +1,236 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// slackRequestTimeout is the HTTP timeout for Slack webhook requests.
+	// Prevents a hanging Slack request from blocking the entire poll loop.
+	slackRequestTimeout = 15 * time.Second
+
+	// maxDedupEntries is the maximum number of dedup entries to keep in memory.
+	// When exceeded, the map is cleared to prevent unbounded growth in long-running agents.
+	// 1000 entries is generous — each entry is a small string key, so memory is negligible.
+	maxDedupEntries = 1000
+)
+
+// SlackFinding represents a single reportable finding from a poll cycle.
+// Findings should have a PR context (PRNumber, PRURL) when available.
+type SlackFinding struct {
+	PRNumber int    // PR number this finding relates to
+	PRTitle  string // PR title for display
+	PRURL    string // clickable PR URL
+	Category string // "ci", "rebase", "conflict", "review", "error"
+	Message  string // Slack mrkdwn formatted message line (e.g. "🔴 <url|name> failed")
+	DedupKey string // unique key for dedup (e.g. "ci:sha:checkName")
+}
+
+// SlackReporter collects findings and posts them to a Slack webhook.
+// Zero external dependencies — uses only Go stdlib net/http + encoding/json.
+type SlackReporter struct {
+	webhookURL string
+	owner      string
+	repo       string
+	reported   map[string]bool // tracks DedupKeys already reported
+	logger     *slog.Logger
+	httpClient *http.Client // injectable for testing
+}
+
+// NewSlackReporter creates a new reporter. If webhookURL is empty, IsEnabled() returns false.
+// A nil logger defaults to slog.Default().
+func NewSlackReporter(webhookURL, owner, repo string, logger *slog.Logger) *SlackReporter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SlackReporter{
+		webhookURL: webhookURL,
+		owner:      owner,
+		repo:       repo,
+		reported:   make(map[string]bool),
+		logger:     logger,
+		httpClient: &http.Client{Timeout: slackRequestTimeout},
+	}
+}
+
+// IsEnabled returns true if the Slack webhook URL is configured.
+func (r *SlackReporter) IsEnabled() bool {
+	return r.webhookURL != ""
+}
+
+// Report deduplicates findings, formats a Slack message, and POSTs it to the webhook.
+// No-op if there are no new findings after dedup, or if the reporter is disabled.
+func (r *SlackReporter) Report(ctx context.Context, findings []SlackFinding) {
+	if !r.IsEnabled() || len(findings) == 0 {
+		return
+	}
+
+	// Prune dedup map if it has grown too large to prevent unbounded memory growth.
+	if len(r.reported) > maxDedupEntries {
+		r.logger.Info("pruning Slack dedup map", "entries", len(r.reported))
+		clear(r.reported)
+	}
+
+	// Dedup: filter out findings already reported
+	var newFindings []SlackFinding
+	for _, f := range findings {
+		if f.DedupKey == "" || !r.reported[f.DedupKey] {
+			newFindings = append(newFindings, f)
+		}
+	}
+
+	if len(newFindings) == 0 {
+		return
+	}
+
+	body := formatSlackMessage(r.owner, r.repo, newFindings)
+	if body == nil {
+		return
+	}
+
+	if err := postToSlack(ctx, r.httpClient, r.webhookURL, body); err != nil {
+		r.logger.Error("failed to post to Slack", "error", err)
+		return
+	}
+
+	// Mark as reported only after successful POST
+	for _, f := range newFindings {
+		if f.DedupKey != "" {
+			r.reported[f.DedupKey] = true
+		}
+	}
+
+	r.logger.Info("posted Slack report", "findings", len(newFindings))
+}
+
+// slackBlock represents a Slack Block Kit block.
+type slackBlock struct {
+	Type string     `json:"type"`
+	Text *slackText `json:"text,omitempty"`
+}
+
+// slackText represents a Slack Block Kit text object.
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// slackMessage represents a Slack webhook message payload.
+type slackMessage struct {
+	Blocks []slackBlock `json:"blocks"`
+}
+
+// formatSlackMessage builds a Slack Block Kit JSON payload grouped by PR.
+// Returns nil if there are no findings.
+func formatSlackMessage(owner, repo string, findings []SlackFinding) []byte {
+	if len(findings) == 0 {
+		return nil
+	}
+
+	// Group findings by PR number, sorted for deterministic output.
+	type prGroup struct {
+		prNumber int
+		prTitle  string
+		prURL    string
+		messages []string
+	}
+	groupMap := make(map[int]*prGroup)
+	var order []int
+
+	for _, f := range findings {
+		g, ok := groupMap[f.PRNumber]
+		if !ok {
+			g = &prGroup{
+				prNumber: f.PRNumber,
+				prTitle:  f.PRTitle,
+				prURL:    f.PRURL,
+			}
+			groupMap[f.PRNumber] = g
+			order = append(order, f.PRNumber)
+		}
+		g.messages = append(g.messages, f.Message)
+	}
+
+	// Sort by PR number for deterministic output
+	sort.Ints(order)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "🏭 oompa — %s/%s\n", owner, repo)
+
+	for _, prNum := range order {
+		g := groupMap[prNum]
+		sb.WriteString("\n")
+		if g.prURL != "" {
+			fmt.Fprintf(&sb, "📋 <%s|PR #%d> — %s\n", g.prURL, g.prNumber, g.prTitle)
+		} else {
+			fmt.Fprintf(&sb, "📋 PR #%d — %s\n", g.prNumber, g.prTitle)
+		}
+		for _, msg := range g.messages {
+			fmt.Fprintf(&sb, "  %s\n", msg)
+		}
+	}
+
+	msg := slackMessage{
+		Blocks: []slackBlock{
+			{
+				Type: "section",
+				Text: &slackText{
+					Type: "mrkdwn",
+					Text: sb.String(),
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return nil
+	}
+	return body
+}
+
+// postToSlack sends a JSON payload to a Slack Incoming Webhook URL.
+func postToSlack(ctx context.Context, client *http.Client, webhookURL string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("creating Slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting to Slack: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("slack webhook returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// prURL returns the GitHub URL for a PR.
+func prURL(owner, repo string, prNumber int) string {
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repo, prNumber)
+}
+
+// commitURL returns the GitHub URL for a commit.
+func commitURL(owner, repo, sha string) string {
+	return fmt.Sprintf("https://github.com/%s/%s/commit/%s", owner, repo, sha)
+}
+
+// issueURL returns the GitHub URL for an issue.
+func issueURL(owner, repo string, issueNumber int) string {
+	return fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, issueNumber)
+}

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -1,0 +1,429 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
+	findings := []SlackFinding{
+		{PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 <https://example.com/job/1|e2e-test> failed"},
+		{PRNumber: 200, PRTitle: "Add feature", PRURL: "https://github.com/org/repo/pull/200", Category: "conflict", Message: "⚠️ Merge conflicts"},
+		{PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "rebase", Message: "⚠️ 15 commits behind main"},
+	}
+
+	body := formatSlackMessage("org", "repo", findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(msg.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(msg.Blocks))
+	}
+
+	text := msg.Blocks[0].Text.Text
+
+	// PR #100 should appear before PR #200 (sorted by PR number)
+	idx100 := strings.Index(text, "PR #100")
+	idx200 := strings.Index(text, "PR #200")
+	if idx100 == -1 || idx200 == -1 {
+		t.Fatalf("expected both PRs in output, got: %s", text)
+	}
+	if idx100 > idx200 {
+		t.Errorf("PR #100 should appear before PR #200")
+	}
+
+	// Both findings for PR #100 should be grouped together
+	if !strings.Contains(text, "e2e-test") {
+		t.Error("expected e2e-test finding")
+	}
+	if !strings.Contains(text, "15 commits behind main") {
+		t.Error("expected rebase finding")
+	}
+	if !strings.Contains(text, "Merge conflicts") {
+		t.Error("expected conflict finding")
+	}
+
+	// Header should contain owner/repo
+	if !strings.Contains(text, "org/repo") {
+		t.Error("expected owner/repo in header")
+	}
+}
+
+func TestFormatSlackMessage_EmptyFindings(t *testing.T) {
+	body := formatSlackMessage("org", "repo", nil)
+	if body != nil {
+		t.Error("expected nil body for empty findings")
+	}
+
+	body = formatSlackMessage("org", "repo", []SlackFinding{})
+	if body != nil {
+		t.Error("expected nil body for empty slice")
+	}
+}
+
+func TestSlackReporter_Dedup(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter.httpClient = ts.Client()
+
+	findings := []SlackFinding{
+		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
+	}
+
+	ctx := context.Background()
+
+	// First report should send
+	reporter.Report(ctx, findings)
+	if postCount != 1 {
+		t.Errorf("expected 1 POST, got %d", postCount)
+	}
+
+	// Second report with same DedupKey should be suppressed
+	reporter.Report(ctx, findings)
+	if postCount != 1 {
+		t.Errorf("expected still 1 POST after dedup, got %d", postCount)
+	}
+}
+
+func TestSlackReporter_DedupReset(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// First finding
+	reporter.Report(ctx, []SlackFinding{
+		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
+	})
+	if postCount != 1 {
+		t.Errorf("expected 1 POST, got %d", postCount)
+	}
+
+	// Different DedupKey (new SHA) should re-send
+	reporter.Report(ctx, []SlackFinding{
+		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:def456:e2e"},
+	})
+	if postCount != 2 {
+		t.Errorf("expected 2 POSTs after new DedupKey, got %d", postCount)
+	}
+}
+
+func TestSlackReporter_Disabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter("", "org", "repo", logger)
+
+	if reporter.IsEnabled() {
+		t.Error("expected IsEnabled() to be false with empty webhook URL")
+	}
+
+	// Should not panic or error when disabled
+	reporter.Report(context.Background(), []SlackFinding{
+		{PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "test"},
+	})
+}
+
+func TestPostToSlack_Success(t *testing.T) {
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	payload := []byte(`{"text":"hello"}`)
+	err := postToSlack(context.Background(), ts.Client(), ts.URL, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedBody != `{"text":"hello"}` {
+		t.Errorf("unexpected body: %s", receivedBody)
+	}
+}
+
+func TestPostToSlack_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	err := postToSlack(context.Background(), ts.Client(), ts.URL, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for non-200 status")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status code, got: %v", err)
+	}
+}
+
+func TestCheckCIStatus_ReportsFailures(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "failure", HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
+			{ID: 2, Name: "unit-test", Status: "completed", Conclusion: "success"},
+		},
+		prHeadSHAs: []string{"abc123"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckCIStatus(context.Background())
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Category != "ci" {
+		t.Errorf("expected category ci, got %s", findings[0].Category)
+	}
+	if !strings.Contains(findings[0].Message, "e2e-test") {
+		t.Errorf("expected message to contain check name, got: %s", findings[0].Message)
+	}
+	if !strings.Contains(findings[0].DedupKey, "abc123") {
+		t.Errorf("expected DedupKey to contain SHA, got: %s", findings[0].DedupKey)
+	}
+}
+
+func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "behind",
+		prBehind:       true,
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckRebaseNeeded(context.Background())
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Category != "rebase" {
+		t.Errorf("expected category rebase, got %s", findings[0].Category)
+	}
+	if !strings.Contains(findings[0].Message, "behind main") {
+		t.Errorf("expected message about behind main, got: %s", findings[0].Message)
+	}
+}
+
+func TestCheckConflicts_ReportsDirty(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "dirty",
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckConflicts(context.Background())
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Category != "conflict" {
+		t.Errorf("expected category conflict, got %s", findings[0].Category)
+	}
+	if !strings.Contains(findings[0].Message, "merge conflicts") {
+		t.Errorf("expected message about merge conflicts, got: %s", findings[0].Message)
+	}
+}
+
+func TestCheckNewReviews_ReportsComments(t *testing.T) {
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 10, User: "reviewer1", Body: "Please fix this"},
+			{ID: 11, User: "reviewer2", Body: "LGTM"},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckNewReviews(context.Background())
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Category != "review" {
+		t.Errorf("expected category review, got %s", findings[0].Category)
+	}
+	if !strings.Contains(findings[0].Message, "2 new review") {
+		t.Errorf("expected message about 2 new reviews, got: %s", findings[0].Message)
+	}
+}
+
+func TestCheckCIStatus_NoFailures(t *testing.T) {
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "success"},
+		},
+		prHeadSHAs: []string{"abc123"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckCIStatus(context.Background())
+
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for passing CI, got %d", len(findings))
+	}
+}
+
+func TestCheckRebaseNeeded_Clean(t *testing.T) {
+	gh := &mockGitHubClient{
+		mergeableState: "clean",
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckRebaseNeeded(context.Background())
+
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings for clean state, got %d", len(findings))
+	}
+}
+
+func TestSlackReporter_EmptyDedupKey(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// Findings with empty DedupKey should always be sent
+	findings := []SlackFinding{
+		{PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: ""},
+	}
+
+	reporter.Report(ctx, findings)
+	if postCount != 1 {
+		t.Errorf("expected 1 POST, got %d", postCount)
+	}
+
+	reporter.Report(ctx, findings)
+	if postCount != 2 {
+		t.Errorf("expected 2 POSTs (empty DedupKey never suppressed), got %d", postCount)
+	}
+}
+
+func TestURLHelpers(t *testing.T) {
+	if got := prURL("org", "repo", 42); got != "https://github.com/org/repo/pull/42" {
+		t.Errorf("prURL: %s", got)
+	}
+	if got := commitURL("org", "repo", "abc123"); got != "https://github.com/org/repo/commit/abc123" {
+		t.Errorf("commitURL: %s", got)
+	}
+	if got := issueURL("org", "repo", 7); got != "https://github.com/org/repo/issues/7" {
+		t.Errorf("issueURL: %s", got)
+	}
+}

--- a/specs/slack.md
+++ b/specs/slack.md
@@ -1,0 +1,126 @@
+# Slack Reporting
+
+## Overview
+
+Automatic Slack reporting at the end of each poll cycle. When `OOMPA_SLACK_WEBHOOK` is set, oompa posts a consolidated Slack message with concrete findings and clickable GitHub links. Silent cycles produce no Slack message.
+
+## Trigger
+
+`OOMPA_SLACK_WEBHOOK` environment variable contains a Slack Incoming Webhook URL. If not set, no Slack integration, no behavior change.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/agent/slack.go` | SlackFinding, SlackReporter, postToSlack, message formatter, dedup tracker |
+| `pkg/agent/slack_test.go` | Tests for formatting, dedup, empty findings, link construction |
+| `pkg/agent/loop.go` | Agent loop integration: Check* methods, ShouldCheckReaction, RunReportOnlyChecks, cycle-end reporting |
+| `pkg/agent/config.go` | `SlackWebhookURL` field on Config |
+| `cmd/oompa/main.go` | Read `OOMPA_SLACK_WEBHOOK` env var |
+
+## Data Types
+
+```go
+type SlackFinding struct {
+    PRNumber  int
+    PRTitle   string
+    PRURL     string
+    Category  string   // "ci", "rebase", "conflict", "review", "error"
+    Message   string   // Slack mrkdwn formatted message line
+    DedupKey  string   // unique key for dedup (e.g. "ci:sha:checkName")
+}
+
+type SlackReporter struct {
+    webhookURL string
+    owner      string
+    repo       string
+    reported   map[string]bool // tracks DedupKeys already reported
+    logger     *slog.Logger
+    httpClient *http.Client    // injectable for testing
+}
+```
+
+## SlackReporter Methods
+
+- `NewSlackReporter(webhookURL, owner, repo string, logger *slog.Logger) *SlackReporter`
+- `(r *SlackReporter) Report(ctx context.Context, findings []SlackFinding)` — dedup, format, POST
+- `(r *SlackReporter) IsEnabled() bool` — returns true if webhookURL is non-empty
+- `formatSlackMessage(owner, repo string, findings []SlackFinding) []byte` — builds Slack Block Kit JSON
+- `postToSlack(ctx context.Context, client *http.Client, webhookURL string, body []byte) error` — HTTP POST
+
+## What Gets Reported
+
+| Finding | Slack format | DedupKey |
+|---------|-------------|----------|
+| CI check failed | `🔴 <job-link\|check-name> failed` | `ci:<sha>:<checkName>` |
+| CI failed + flaky match | `🔴 <job-link\|check-name> — flaky <issue-link\|#N>` | `ci:<sha>:<checkName>` |
+| CI fix pushed | `🔧 Fixed <job-link\|check-name>, pushed <commit-link\|SHA>` | `ci-fix:<sha>:<checkName>` |
+| Rebase done | `✅ Rebased <pr-link\|PR #N> → <commit-link\|SHA>` | `rebase:<prNumber>:<newSHA>` |
+| Rebase needed (report-only) | `⚠️ <pr-link\|PR #N> is behind main` | `rebase-needed:<prNumber>` |
+| Conflicts detected | `⚠️ <pr-link\|PR #N> has merge conflicts` | `conflict:<prNumber>` |
+| Conflicts resolved | `✅ Resolved conflicts on <pr-link\|PR #N> → <commit-link\|SHA>` | `conflict-resolved:<prNumber>:<sha>` |
+| New review comments | `💬 <pr-link\|PR #N> has N new reviews` | `review:<prNumber>:<maxCommentID>` |
+| Reviews addressed | `✅ Addressed reviews on <pr-link\|PR #N> → <commit-link\|SHA>` | `review-addressed:<prNumber>:<sha>` |
+| Flaky issue created | `📋 Opened <issue-link\|#N> for flaky test` | `flaky:<issueNumber>` |
+| Error | `❌ Failed: <pr-link\|PR #N> — error message` | `error:<prNumber>:<errorHash>` |
+
+## What is NOT Reported
+
+- Poll cycle start/end
+- Routine checks that found nothing
+- Any idle/no-op cycle
+
+## Reactions Behavior with Slack
+
+| Reaction in list? | Webhook set? | Behavior |
+|-------------------|-------------|----------|
+| Yes | Yes | Fix + report to Slack |
+| Yes | No | Fix only (current behavior) |
+| No | Yes | Check status + report to Slack (no fix) |
+| No | No | Skip entirely (current behavior) |
+
+`ShouldCheckReaction(reaction)` returns true when webhook is set AND reaction is NOT in the list. Check methods are lightweight API-only calls:
+
+- `CheckCIStatus(ctx)` — fetch check runs, report failures
+- `CheckRebaseNeeded(ctx)` — check mergeable state, report if behind
+- `CheckConflicts(ctx)` — check mergeable state, report if conflicting
+- `CheckNewReviews(ctx)` — count new review comments, report if any
+
+## Slack Message Format
+
+Slack Block Kit with mrkdwn. One message per cycle, grouped by PR:
+
+```text
+🏭 oompa — owner/repo
+
+📋 <pr-link|PR #N> — title
+  🔴 <job-link|check-name> — failed
+  ⚠️ 15 commits behind main
+
+📋 <pr-link|PR #N> — title
+  💬 3 new reviews
+  ⚠️ Merge conflicts
+```
+
+## Dedup
+
+Don't re-report the same finding every poll cycle. Each finding has a DedupKey. Report once when first detected, suppress until the key changes:
+
+- CI failure: `ci:<sha>:<checkName>` — new SHA or new check → re-report
+- Rebase needed: `rebase-needed:<prNumber>` — report once, stays suppressed until resolved
+- Conflicts: `conflict:<prNumber>` — report once
+- Reviews: `review:<prNumber>:<maxCommentID>` — new comments → re-report
+
+## Tests
+
+- `TestFormatSlackMessage_GroupsByPR` — findings grouped by PR number
+- `TestFormatSlackMessage_EmptyFindings` — returns nil
+- `TestSlackReporter_Dedup` — same DedupKey suppressed on second call
+- `TestSlackReporter_DedupReset` — different DedupKey re-sends
+- `TestSlackReporter_Disabled` — no webhook → IsEnabled() false
+- `TestPostToSlack_Success` — HTTP POST with correct body
+- `TestPostToSlack_HTTPError` — non-200 status returns error
+- `TestCheckCIStatus_ReportsFailures` — report-only check produces findings
+- `TestCheckRebaseNeeded_ReportsBehind` — report-only check produces findings
+- `TestCheckConflicts_ReportsDirty` — report-only check produces findings
+- `TestCheckNewReviews_ReportsComments` — report-only check produces findings


### PR DESCRIPTION
Fixes #175

## Summary

Add automatic Slack reporting at the end of each poll cycle. When `OOMPA_SLACK_WEBHOOK` is set, oompa posts a consolidated Slack message with concrete findings and clickable GitHub links. Silent cycles produce no message. Report-only checks run for reactions not in the active list, providing visibility into CI failures, rebase needs, conflicts, and new reviews without acting on them.

## Changes

- Add `SlackWebhookURL` field to `Config` struct (`pkg/agent/config.go`)
- Create `pkg/agent/slack.go`: `SlackFinding` type, `SlackReporter` with dedup tracking, Slack Block Kit message formatter, zero-dependency webhook poster using stdlib `net/http` + `encoding/json`
- Create `pkg/agent/slack_test.go`: Tests for message formatting, dedup, disabled reporter, HTTP posting, Check* methods, URL helpers
- Add `ShouldCheckReaction()` to Agent: returns true when webhook is set and reaction is not in the active list
- Add lightweight Check* methods to Agent: `CheckCIStatus`, `CheckRebaseNeeded`, `CheckConflicts`, `CheckNewReviews` — API-only, no agent invocation
- Add `SetSlackReporter()`, `SlackEnabled()`, `ReportToSlack()`, `RunReportOnlyChecks()` to Agent
- Wire `OOMPA_SLACK_WEBHOOK` env var in `cmd/oompa/main.go` and integrate Slack reporting into `runLoop`
- Create `specs/slack.md` documenting the Slack integration

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #175

<!-- oompa-bot v:12623b1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-poll Slack notifications: CI failures, merge conflicts, rebase-needed alerts, and new review comments; grouped by PR, deduplicated, and opt-in via environment webhook.

* **Documentation**
  * Added configuration and Slack Block Kit formatting docs, finding categories, and dedup/reset semantics.

* **Tests**
  * Added unit tests covering message formatting/grouping, deduplication behavior, HTTP post success/error, and report-only check generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/176)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->