### PR TITLE
feat: consolidate Slack reports into one message per cycle with collapsible project sections

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -461,7 +461,8 @@ func selectCodeAgent(cfg agent.Config, logger *slog.Logger) agent.CodeAgent {
 }
 
 // buildAgentForConfig creates a fully wired Agent for a given config.
-func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool, logger *slog.Logger) *agent.Agent {
+// If sharedSlack is non-nil, it is used as the Slack reporter instead of creating a per-agent one.
+func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc func(context.Context) (string, error), useAppAuth bool, logger *slog.Logger, sharedSlack ...*agent.SlackReporter) *agent.Agent {
 	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", cfg.Owner, cfg.Repo)
 	forkURL := repoURL
 	if cfg.ForkOwner != "" {
@@ -495,8 +496,11 @@ func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, token
 		a.SetTokenFunc(tokenFunc)
 	}
 
-	if cfg.SlackWebhookURL != "" {
-		slack := agent.NewSlackReporter(cfg.SlackWebhookURL, cfg.Owner, cfg.Repo, logger)
+	if len(sharedSlack) > 0 && sharedSlack[0] != nil {
+		a.SetSlackReporter(sharedSlack[0])
+		logger.Info("Slack reporting enabled (shared reporter)")
+	} else if cfg.SlackWebhookURL != "" {
+		slack := agent.NewSlackReporter(cfg.SlackWebhookURL, logger)
 		a.SetSlackReporter(slack)
 		logger.Info("Slack reporting enabled")
 	}
@@ -605,6 +609,7 @@ func runSingleRepo(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc f
 	}
 
 	runLoop(ctx, a, logger)
+	a.FlushSlackReport(ctx)
 
 	if cfg.OneShot {
 		return
@@ -620,6 +625,7 @@ func runSingleRepo(cfg agent.Config, ghClient *agent.GoGitHubClient, tokenFunc f
 			return
 		case <-ticker.C:
 			runLoop(ctx, a, logger)
+			a.FlushSlackReport(ctx)
 			if exitOwner != "" && commitSHA != "" && shouldExitForNewVersion(ctx, ghClient, exitOwner, exitRepo, commitSHA, logger) {
 				return
 			}
@@ -671,6 +677,15 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 		"config", configPath,
 	)
 
+	// Create a shared Slack reporter for consolidated cross-project reporting.
+	// All agent goroutines collect findings into this reporter, and a separate
+	// goroutine flushes them periodically as a single consolidated message.
+	var sharedSlack *agent.SlackReporter
+	if globalCfg.SlackWebhookURL != "" {
+		sharedSlack = agent.NewSlackReporter(globalCfg.SlackWebhookURL, logger)
+		logger.Info("Slack consolidated reporting enabled")
+	}
+
 	// Two-signal graceful shutdown:
 	// First signal: cancel context → goroutines finish current cycle → clean exit
 	// Second signal: force exit immediately
@@ -689,6 +704,29 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 		os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional force exit
 	}()
 
+	// Start a Slack flush goroutine that periodically posts consolidated findings.
+	// Uses a time-based window matching the poll interval to batch findings from
+	// all project goroutines into a single Slack message per cycle.
+	// The flushDone channel signals that the goroutine has exited, preventing
+	// concurrent Flush calls between the ticker goroutine and the final flush.
+	var flushDone chan struct{}
+	if sharedSlack != nil {
+		flushDone = make(chan struct{})
+		go func() {
+			defer close(flushDone)
+			ticker := time.NewTicker(globalCfg.PollInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					sharedSlack.Flush(ctx)
+				}
+			}
+		}()
+	}
+
 	var wg sync.WaitGroup
 
 	for _, entry := range entries {
@@ -706,7 +744,7 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 				}
 			}()
 
-			a := buildAgentForConfig(entry.Config, ghClient, tokenFunc, useAppAuth, roleLogger)
+			a := buildAgentForConfig(entry.Config, ghClient, tokenFunc, useAppAuth, roleLogger, sharedSlack)
 			if emitter != nil {
 				a.SetEmitter(emitter)
 			}
@@ -726,6 +764,15 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 	}
 
 	wg.Wait()
+	// Wait for the flush goroutine to exit before doing the final flush,
+	// preventing concurrent Flush calls.
+	if flushDone != nil {
+		<-flushDone
+	}
+	// Final flush to capture any findings from the last cycle
+	if sharedSlack != nil {
+		sharedSlack.Flush(context.Background())
+	}
 	logger.Info("all role goroutines stopped, exiting")
 }
 
@@ -826,10 +873,12 @@ func runLoop(ctx context.Context, a *agent.Agent, logger *slog.Logger) {
 	a.ProcessTriageJobs(ctx)
 
 	// Slack reporting: run report-only checks for reactions NOT in the active list,
-	// then post consolidated findings to Slack.
+	// then collect findings. In single-repo mode, flush immediately to post findings.
+	// In multi-project mode with a shared reporter, each goroutine collects and the
+	// flush is called once per cycle from the orchestrator.
 	if a.SlackEnabled() {
 		findings := a.RunReportOnlyChecks(ctx)
-		a.ReportToSlack(ctx, findings)
+		a.CollectSlackFindings(findings)
 	}
 
 	a.EmitPollCycleEnd()

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -171,12 +171,22 @@ func (a *Agent) SlackEnabled() bool {
 	return a.slack != nil && a.slack.IsEnabled()
 }
 
-// ReportToSlack sends findings to Slack if the reporter is configured.
-func (a *Agent) ReportToSlack(ctx context.Context, findings []SlackFinding) {
+// CollectSlackFindings appends findings to the shared Slack reporter for later flushing.
+// Thread-safe: multiple agents can call this concurrently in multi-project mode.
+func (a *Agent) CollectSlackFindings(findings []SlackFinding) {
 	if a.slack == nil {
 		return
 	}
-	a.slack.Report(ctx, findings)
+	a.slack.Collect(findings)
+}
+
+// FlushSlackReport deduplicates and posts all collected findings as a single Slack message.
+// Call this once per poll cycle after all agents have collected their findings.
+func (a *Agent) FlushSlackReport(ctx context.Context) {
+	if a.slack == nil {
+		return
+	}
+	a.slack.Flush(ctx)
 }
 
 // RunReportOnlyChecks runs lightweight check methods for reactions NOT in the active
@@ -579,6 +589,8 @@ func (a *Agent) CheckCIStatus(ctx context.Context) []SlackFinding {
 				}
 				msg := fmt.Sprintf("🔴 <%s|%s> failed", link, r.Name)
 				findings = append(findings, SlackFinding{
+					Owner:    a.cfg.Owner,
+					Repo:     a.cfg.Repo,
 					PRNumber: work.PRNumber,
 					PRTitle:  work.IssueTitle,
 					PRURL:    prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber),
@@ -627,6 +639,8 @@ func (a *Agent) checkRebaseNeededWithStates(ctx context.Context, states map[int]
 		if needsRebase {
 			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
 			findings = append(findings, SlackFinding{
+				Owner:    a.cfg.Owner,
+				Repo:     a.cfg.Repo,
 				PRNumber: work.PRNumber,
 				PRTitle:  work.IssueTitle,
 				PRURL:    pURL,
@@ -665,6 +679,8 @@ func (a *Agent) checkConflictsWithStates(_ context.Context, states map[int]strin
 		if mergeState == "dirty" {
 			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
 			findings = append(findings, SlackFinding{
+				Owner:    a.cfg.Owner,
+				Repo:     a.cfg.Repo,
 				PRNumber: work.PRNumber,
 				PRTitle:  work.IssueTitle,
 				PRURL:    pURL,
@@ -719,6 +735,8 @@ func (a *Agent) CheckNewReviews(ctx context.Context) []SlackFinding {
 			}
 			pURL := prURL(a.cfg.Owner, a.cfg.Repo, work.PRNumber)
 			findings = append(findings, SlackFinding{
+				Owner:    a.cfg.Owner,
+				Repo:     a.cfg.Repo,
 				PRNumber: work.PRNumber,
 				PRTitle:  work.IssueTitle,
 				PRURL:    pURL,

--- a/pkg/agent/slack.go
+++ b/pkg/agent/slack.go
@@ -10,7 +10,9 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -22,11 +24,21 @@ const (
 	// When exceeded, the map is cleared to prevent unbounded growth in long-running agents.
 	// 1000 entries is generous — each entry is a small string key, so memory is negligible.
 	maxDedupEntries = 1000
+
+	// maxSlackBlockTextLen is the maximum text length for a single Slack Block Kit
+	// section block. Slack enforces a 3000-character limit per block text field.
+	maxSlackBlockTextLen = 3000
+
+	// maxSlackBlocks is the maximum number of blocks Slack accepts per message.
+	// Messages exceeding this limit are rejected by the API.
+	maxSlackBlocks = 50
 )
 
 // SlackFinding represents a single reportable finding from a poll cycle.
 // Findings should have a PR context (PRNumber, PRURL) when available.
 type SlackFinding struct {
+	Owner    string // repository owner (e.g. "ovn-kubernetes")
+	Repo     string // repository name (e.g. "ovn-kubernetes")
 	PRNumber int    // PR number this finding relates to
 	PRTitle  string // PR title for display
 	PRURL    string // clickable PR URL
@@ -35,27 +47,28 @@ type SlackFinding struct {
 	DedupKey string // unique key for dedup (e.g. "ci:sha:checkName")
 }
 
-// SlackReporter collects findings and posts them to a Slack webhook.
+// SlackReporter collects findings from multiple projects and posts a consolidated
+// Slack message. Thread-safe: multiple agent goroutines can call Collect concurrently.
 // Zero external dependencies — uses only Go stdlib net/http + encoding/json.
 type SlackReporter struct {
 	webhookURL string
-	owner      string
-	repo       string
 	reported   map[string]bool // tracks DedupKeys already reported
 	logger     *slog.Logger
 	httpClient *http.Client // injectable for testing
+
+	flushMu  sync.Mutex     // serializes Flush calls (protects reported map)
+	mu       sync.Mutex     // protects pending
+	pending  []SlackFinding // findings collected since last Flush
 }
 
 // NewSlackReporter creates a new reporter. If webhookURL is empty, IsEnabled() returns false.
 // A nil logger defaults to slog.Default().
-func NewSlackReporter(webhookURL, owner, repo string, logger *slog.Logger) *SlackReporter {
+func NewSlackReporter(webhookURL string, logger *slog.Logger) *SlackReporter {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &SlackReporter{
 		webhookURL: webhookURL,
-		owner:      owner,
-		repo:       repo,
 		reported:   make(map[string]bool),
 		logger:     logger,
 		httpClient: &http.Client{Timeout: slackRequestTimeout},
@@ -67,10 +80,37 @@ func (r *SlackReporter) IsEnabled() bool {
 	return r.webhookURL != ""
 }
 
-// Report deduplicates findings, formats a Slack message, and POSTs it to the webhook.
+// Collect appends findings to the pending buffer. Thread-safe for concurrent callers.
+// Findings accumulate until Flush is called.
+func (r *SlackReporter) Collect(findings []SlackFinding) {
+	if len(findings) == 0 {
+		return
+	}
+	r.mu.Lock()
+	r.pending = append(r.pending, findings...)
+	r.mu.Unlock()
+}
+
+// Flush deduplicates all pending findings, formats a single consolidated Slack message
+// across all projects, and POSTs it to the webhook. Clears the pending buffer afterward.
 // No-op if there are no new findings after dedup, or if the reporter is disabled.
-func (r *SlackReporter) Report(ctx context.Context, findings []SlackFinding) {
-	if !r.IsEnabled() || len(findings) == 0 {
+func (r *SlackReporter) Flush(ctx context.Context) {
+	if !r.IsEnabled() {
+		return
+	}
+
+	// Serialize Flush calls to protect the reported map from concurrent access.
+	// The pending buffer has its own mutex, but reported is only accessed in Flush.
+	r.flushMu.Lock()
+	defer r.flushMu.Unlock()
+
+	// Atomically drain the pending buffer
+	r.mu.Lock()
+	findings := r.pending
+	r.pending = nil
+	r.mu.Unlock()
+
+	if len(findings) == 0 {
 		return
 	}
 
@@ -92,7 +132,7 @@ func (r *SlackReporter) Report(ctx context.Context, findings []SlackFinding) {
 		return
 	}
 
-	body := formatSlackMessage(r.owner, r.repo, newFindings)
+	body := formatSlackMessage(newFindings)
 	if body == nil {
 		return
 	}
@@ -112,6 +152,17 @@ func (r *SlackReporter) Report(ctx context.Context, findings []SlackFinding) {
 	r.logger.Info("posted Slack report", "findings", len(newFindings))
 }
 
+// Report deduplicates findings, formats a Slack message, and POSTs it to the webhook.
+// This is the single-call path used in single-repo mode (collect + flush in one step).
+// No-op if there are no new findings after dedup, or if the reporter is disabled.
+func (r *SlackReporter) Report(ctx context.Context, findings []SlackFinding) {
+	if !r.IsEnabled() || len(findings) == 0 {
+		return
+	}
+	r.Collect(findings)
+	r.Flush(ctx)
+}
+
 // slackBlock represents a Slack Block Kit block.
 type slackBlock struct {
 	Type string     `json:"type"`
@@ -129,68 +180,179 @@ type slackMessage struct {
 	Blocks []slackBlock `json:"blocks"`
 }
 
-// formatSlackMessage builds a Slack Block Kit JSON payload grouped by PR.
+// projectKey returns the "owner/repo" string for grouping.
+func projectKey(owner, repo string) string {
+	return owner + "/" + repo
+}
+
+// formatSlackMessage builds a Slack Block Kit JSON payload grouped by project and then by PR.
 // Returns nil if there are no findings.
-func formatSlackMessage(owner, repo string, findings []SlackFinding) []byte {
+//
+// Format:
+//
+//	🏭 oompa report — N projects with activity
+//
+//	*<repo-link|owner/repo>* (M PRs)
+//	📋 <pr-link|PR #N> — title
+//	  🔴 <job-link|check-name> — failed
+//	  ⚠️ behind main
+//
+// Each project gets a header section + detail section + divider.
+func formatSlackMessage(findings []SlackFinding) []byte {
 	if len(findings) == 0 {
 		return nil
 	}
 
-	// Group findings by PR number, sorted for deterministic output.
+	// Group findings by project, then by PR number.
 	type prGroup struct {
 		prNumber int
 		prTitle  string
 		prURL    string
 		messages []string
 	}
-	groupMap := make(map[int]*prGroup)
-	var order []int
+	type projectGroup struct {
+		owner    string
+		repo     string
+		prs      map[int]*prGroup
+		prOrder  []int
+		prCount  int
+	}
+
+	projects := make(map[string]*projectGroup)
+	var projectOrder []string
 
 	for _, f := range findings {
-		g, ok := groupMap[f.PRNumber]
+		pk := projectKey(f.Owner, f.Repo)
+		pg, ok := projects[pk]
 		if !ok {
-			g = &prGroup{
+			pg = &projectGroup{
+				owner: f.Owner,
+				repo:  f.Repo,
+				prs:   make(map[int]*prGroup),
+			}
+			projects[pk] = pg
+			projectOrder = append(projectOrder, pk)
+		}
+
+		pr, ok := pg.prs[f.PRNumber]
+		if !ok {
+			pr = &prGroup{
 				prNumber: f.PRNumber,
 				prTitle:  f.PRTitle,
 				prURL:    f.PRURL,
 			}
-			groupMap[f.PRNumber] = g
-			order = append(order, f.PRNumber)
+			pg.prs[f.PRNumber] = pr
+			pg.prOrder = append(pg.prOrder, f.PRNumber)
+			pg.prCount++
 		}
-		g.messages = append(g.messages, f.Message)
+		pr.messages = append(pr.messages, f.Message)
 	}
 
-	// Sort by PR number for deterministic output
-	sort.Ints(order)
+	// Sort projects alphabetically for deterministic output
+	sort.Strings(projectOrder)
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "🏭 oompa — %s/%s\n", owner, repo)
-
-	for _, prNum := range order {
-		g := groupMap[prNum]
-		sb.WriteString("\n")
-		if g.prURL != "" {
-			fmt.Fprintf(&sb, "📋 <%s|PR #%d> — %s\n", g.prURL, g.prNumber, g.prTitle)
-		} else {
-			fmt.Fprintf(&sb, "📋 PR #%d — %s\n", g.prNumber, g.prTitle)
-		}
-		for _, msg := range g.messages {
-			fmt.Fprintf(&sb, "  %s\n", msg)
-		}
+	// Sort PRs within each project
+	for _, pg := range projects {
+		sort.Ints(pg.prOrder)
 	}
 
-	msg := slackMessage{
-		Blocks: []slackBlock{
-			{
+	// Build blocks
+	var blocks []slackBlock
+
+	// Header block
+	headerText := fmt.Sprintf("🏭 oompa report — %d project(s) with activity", len(projects))
+	blocks = append(blocks, slackBlock{
+		Type: "header",
+		Text: &slackText{
+			Type: "plain_text",
+			Text: headerText,
+		},
+	})
+
+	// Per-project blocks
+	for _, pk := range projectOrder {
+		pg := projects[pk]
+
+		// Project header section
+		repoLink := fmt.Sprintf("https://github.com/%s/%s", pg.owner, pg.repo)
+		projectHeader := fmt.Sprintf("*<%s|%s/%s>* (%d PR(s))", repoLink, pg.owner, pg.repo, pg.prCount)
+		blocks = append(blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{
+				Type: "mrkdwn",
+				Text: projectHeader,
+			},
+		})
+
+		// Project detail section — all PRs and their findings
+		var sb strings.Builder
+		for _, prNum := range pg.prOrder {
+			pr := pg.prs[prNum]
+			if pr.prURL != "" {
+				fmt.Fprintf(&sb, "📋 <%s|PR #%d> — %s\n", pr.prURL, pr.prNumber, pr.prTitle)
+			} else {
+				fmt.Fprintf(&sb, "📋 PR #%d — %s\n", pr.prNumber, pr.prTitle)
+			}
+			for _, msg := range pr.messages {
+				fmt.Fprintf(&sb, "  %s\n", msg)
+			}
+		}
+
+		detailText := sb.String()
+		// Split into multiple blocks if exceeding Slack's 3000-char limit
+		for detailText != "" {
+			chunk := detailText
+			if len(chunk) > maxSlackBlockTextLen {
+				// Find the last newline within the limit to avoid cutting mid-line
+				cutIdx := strings.LastIndex(chunk[:maxSlackBlockTextLen], "\n")
+				if cutIdx < 0 {
+					// No newline found — hard-cut at the limit on a valid UTF-8 boundary
+					cut := maxSlackBlockTextLen
+					for cut > 0 && !utf8.ValidString(detailText[:cut]) {
+						cut--
+					}
+					if cut == 0 {
+						// Malformed input — skip remaining text to avoid infinite loop
+						break
+					}
+					chunk = detailText[:cut]
+				} else {
+					chunk = detailText[:cutIdx+1]
+				}
+			}
+			blocks = append(blocks, slackBlock{
 				Type: "section",
 				Text: &slackText{
 					Type: "mrkdwn",
-					Text: sb.String(),
+					Text: chunk,
 				},
-			},
-		},
+			})
+			detailText = detailText[len(chunk):]
+		}
+
+		// Divider between projects
+		blocks = append(blocks, slackBlock{Type: "divider"})
 	}
 
+	// Remove trailing divider
+	if len(blocks) > 0 && blocks[len(blocks)-1].Type == "divider" {
+		blocks = blocks[:len(blocks)-1]
+	}
+
+	// Slack rejects messages with more than 50 blocks. Truncate and add an
+	// overflow notice so the message is still delivered.
+	if len(blocks) > maxSlackBlocks {
+		blocks = blocks[:maxSlackBlocks-1]
+		blocks = append(blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{
+				Type: "mrkdwn",
+				Text: "⚠️ _Message truncated — too many findings to fit in one Slack message._",
+			},
+		})
+	}
+
+	msg := slackMessage{Blocks: blocks}
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -3,22 +3,24 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
 func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
 	findings := []SlackFinding{
-		{PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 <https://example.com/job/1|e2e-test> failed"},
-		{PRNumber: 200, PRTitle: "Add feature", PRURL: "https://github.com/org/repo/pull/200", Category: "conflict", Message: "⚠️ Merge conflicts"},
-		{PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "rebase", Message: "⚠️ 15 commits behind main"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 <https://example.com/job/1|e2e-test> failed"},
+		{Owner: "org", Repo: "repo", PRNumber: 200, PRTitle: "Add feature", PRURL: "https://github.com/org/repo/pull/200", Category: "conflict", Message: "⚠️ Merge conflicts"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "rebase", Message: "⚠️ 15 commits behind main"},
 	}
 
-	body := formatSlackMessage("org", "repo", findings)
+	body := formatSlackMessage(findings)
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -28,48 +30,196 @@ func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
-	if len(msg.Blocks) != 1 {
-		t.Fatalf("expected 1 block, got %d", len(msg.Blocks))
+	// Should have: header + project section header + detail section + (no trailing divider)
+	if len(msg.Blocks) < 3 {
+		t.Fatalf("expected at least 3 blocks, got %d", len(msg.Blocks))
 	}
 
-	text := msg.Blocks[0].Text.Text
+	// Header block
+	if msg.Blocks[0].Type != "header" {
+		t.Errorf("expected header block, got %s", msg.Blocks[0].Type)
+	}
+	if !strings.Contains(msg.Blocks[0].Text.Text, "1 project(s)") {
+		t.Errorf("expected header to mention 1 project, got: %s", msg.Blocks[0].Text.Text)
+	}
+
+	// Project header section
+	if !strings.Contains(msg.Blocks[1].Text.Text, "org/repo") {
+		t.Error("expected project header to contain org/repo")
+	}
+
+	// Detail section — find the section with PR details
+	var fullTextBuilder strings.Builder
+	for _, b := range msg.Blocks {
+		if b.Text != nil {
+			fullTextBuilder.WriteString(b.Text.Text)
+		}
+	}
+	fullText := fullTextBuilder.String()
 
 	// PR #100 should appear before PR #200 (sorted by PR number)
-	idx100 := strings.Index(text, "PR #100")
-	idx200 := strings.Index(text, "PR #200")
+	idx100 := strings.Index(fullText, "PR #100")
+	idx200 := strings.Index(fullText, "PR #200")
 	if idx100 == -1 || idx200 == -1 {
-		t.Fatalf("expected both PRs in output, got: %s", text)
+		t.Fatalf("expected both PRs in output, got: %s", fullText)
 	}
 	if idx100 > idx200 {
 		t.Errorf("PR #100 should appear before PR #200")
 	}
 
 	// Both findings for PR #100 should be grouped together
-	if !strings.Contains(text, "e2e-test") {
+	if !strings.Contains(fullText, "e2e-test") {
 		t.Error("expected e2e-test finding")
 	}
-	if !strings.Contains(text, "15 commits behind main") {
+	if !strings.Contains(fullText, "15 commits behind main") {
 		t.Error("expected rebase finding")
 	}
-	if !strings.Contains(text, "Merge conflicts") {
+	if !strings.Contains(fullText, "Merge conflicts") {
 		t.Error("expected conflict finding")
-	}
-
-	// Header should contain owner/repo
-	if !strings.Contains(text, "org/repo") {
-		t.Error("expected owner/repo in header")
 	}
 }
 
 func TestFormatSlackMessage_EmptyFindings(t *testing.T) {
-	body := formatSlackMessage("org", "repo", nil)
+	body := formatSlackMessage(nil)
 	if body != nil {
 		t.Error("expected nil body for empty findings")
 	}
 
-	body = formatSlackMessage("org", "repo", []SlackFinding{})
+	body = formatSlackMessage([]SlackFinding{})
 	if body != nil {
 		t.Error("expected nil body for empty slice")
+	}
+}
+
+func TestFormatSlackMessage_MultipleProjects(t *testing.T) {
+	findings := []SlackFinding{
+		{Owner: "org1", Repo: "repo1", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org1/repo1/pull/100", Category: "ci", Message: "🔴 e2e failed"},
+		{Owner: "org2", Repo: "repo2", PRNumber: 200, PRTitle: "Add feature", PRURL: "https://github.com/org2/repo2/pull/200", Category: "conflict", Message: "⚠️ Merge conflicts"},
+		{Owner: "org1", Repo: "repo1", PRNumber: 101, PRTitle: "Fix lint", PRURL: "https://github.com/org1/repo1/pull/101", Category: "rebase", Message: "⚠️ behind main"},
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Header should mention 2 projects
+	if !strings.Contains(msg.Blocks[0].Text.Text, "2 project(s)") {
+		t.Errorf("expected header to mention 2 projects, got: %s", msg.Blocks[0].Text.Text)
+	}
+
+	// Check that both projects appear in the output
+	var fullTextBuilder strings.Builder
+	for _, b := range msg.Blocks {
+		if b.Text != nil {
+			fullTextBuilder.WriteString(b.Text.Text)
+		}
+	}
+	fullText := fullTextBuilder.String()
+	if !strings.Contains(fullText, "org1/repo1") {
+		t.Error("expected org1/repo1 in output")
+	}
+	if !strings.Contains(fullText, "org2/repo2") {
+		t.Error("expected org2/repo2 in output")
+	}
+
+	// org1/repo1 should appear before org2/repo2 (alphabetically sorted)
+	idx1 := strings.Index(fullText, "org1/repo1")
+	idx2 := strings.Index(fullText, "org2/repo2")
+	if idx1 > idx2 {
+		t.Errorf("org1/repo1 should appear before org2/repo2 (alphabetical sort)")
+	}
+
+	// org1/repo1 should have 2 PRs
+	if !strings.Contains(fullText, "2 PR(s)") {
+		t.Error("expected org1/repo1 to show 2 PR(s)")
+	}
+}
+
+func TestFormatSlackMessage_SingleProjectNoFindings(t *testing.T) {
+	// One project with findings, no message for projects with no findings
+	findings := []SlackFinding{
+		{Owner: "org", Repo: "active", PRNumber: 1, PRTitle: "Work", PRURL: "https://github.com/org/active/pull/1", Category: "ci", Message: "🔴 failed"},
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if !strings.Contains(msg.Blocks[0].Text.Text, "1 project(s)") {
+		t.Errorf("expected 1 project in header, got: %s", msg.Blocks[0].Text.Text)
+	}
+}
+
+func TestFormatSlackMessage_LinksCorrect(t *testing.T) {
+	findings := []SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 42, PRTitle: "Test PR", PRURL: "https://github.com/org/repo/pull/42", Category: "ci", Message: "🔴 <https://ci.example.com/job/1|e2e-test> failed"},
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	text := string(body)
+
+	// Check project link
+	if !strings.Contains(text, "https://github.com/org/repo") {
+		t.Error("expected project GitHub link")
+	}
+
+	// Check PR link
+	if !strings.Contains(text, "https://github.com/org/repo/pull/42") {
+		t.Error("expected PR link")
+	}
+
+	// Check CI job link
+	if !strings.Contains(text, "https://ci.example.com/job/1") {
+		t.Error("expected CI job link")
+	}
+}
+
+func TestFormatSlackMessage_HasDividersBetweenProjects(t *testing.T) {
+	findings := []SlackFinding{
+		{Owner: "org1", Repo: "repo1", PRNumber: 1, PRTitle: "PR1", PRURL: "https://github.com/org1/repo1/pull/1", Category: "ci", Message: "🔴 failed"},
+		{Owner: "org2", Repo: "repo2", PRNumber: 2, PRTitle: "PR2", PRURL: "https://github.com/org2/repo2/pull/2", Category: "ci", Message: "🔴 failed"},
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Should have dividers between projects but not after the last one
+	dividerCount := 0
+	for _, b := range msg.Blocks {
+		if b.Type == "divider" {
+			dividerCount++
+		}
+	}
+	if dividerCount != 1 {
+		t.Errorf("expected 1 divider between 2 projects, got %d", dividerCount)
+	}
+
+	// Last block should not be a divider
+	if msg.Blocks[len(msg.Blocks)-1].Type == "divider" {
+		t.Error("last block should not be a divider")
 	}
 }
 
@@ -82,11 +232,11 @@ func TestSlackReporter_Dedup(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter := NewSlackReporter(ts.URL, logger)
 	reporter.httpClient = ts.Client()
 
 	findings := []SlackFinding{
-		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
 	}
 
 	ctx := context.Background()
@@ -113,14 +263,14 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter := NewSlackReporter(ts.URL, logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
 
 	// First finding
 	reporter.Report(ctx, []SlackFinding{
-		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
 	})
 	if postCount != 1 {
 		t.Errorf("expected 1 POST, got %d", postCount)
@@ -128,7 +278,7 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 
 	// Different DedupKey (new SHA) should re-send
 	reporter.Report(ctx, []SlackFinding{
-		{PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:def456:e2e"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:def456:e2e"},
 	})
 	if postCount != 2 {
 		t.Errorf("expected 2 POSTs after new DedupKey, got %d", postCount)
@@ -137,7 +287,7 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 
 func TestSlackReporter_Disabled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter("", "org", "repo", logger)
+	reporter := NewSlackReporter("", logger)
 
 	if reporter.IsEnabled() {
 		t.Error("expected IsEnabled() to be false with empty webhook URL")
@@ -145,7 +295,7 @@ func TestSlackReporter_Disabled(t *testing.T) {
 
 	// Should not panic or error when disabled
 	reporter.Report(context.Background(), []SlackFinding{
-		{PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "test"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "test"},
 	})
 }
 
@@ -220,6 +370,9 @@ func TestCheckCIStatus_ReportsFailures(t *testing.T) {
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
 	}
+	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
+		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
+	}
 	if findings[0].Category != "ci" {
 		t.Errorf("expected category ci, got %s", findings[0].Category)
 	}
@@ -256,6 +409,9 @@ func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
 	}
+	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
+		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
+	}
 	if findings[0].Category != "rebase" {
 		t.Errorf("expected category rebase, got %s", findings[0].Category)
 	}
@@ -287,6 +443,9 @@ func TestCheckConflicts_ReportsDirty(t *testing.T) {
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
+		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
 	}
 	if findings[0].Category != "conflict" {
 		t.Errorf("expected category conflict, got %s", findings[0].Category)
@@ -322,6 +481,9 @@ func TestCheckNewReviews_ReportsComments(t *testing.T) {
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
+		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
 	}
 	if findings[0].Category != "review" {
 		t.Errorf("expected category review, got %s", findings[0].Category)
@@ -395,14 +557,14 @@ func TestSlackReporter_EmptyDedupKey(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "org", "repo", logger)
+	reporter := NewSlackReporter(ts.URL, logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
 
 	// Findings with empty DedupKey should always be sent
 	findings := []SlackFinding{
-		{PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: ""},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: ""},
 	}
 
 	reporter.Report(ctx, findings)
@@ -425,5 +587,230 @@ func TestURLHelpers(t *testing.T) {
 	}
 	if got := issueURL("org", "repo", 7); got != "https://github.com/org/repo/issues/7" {
 		t.Errorf("issueURL: %s", got)
+	}
+}
+
+func TestSlackReporter_CollectAndFlush(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// Collect findings from multiple projects
+	reporter.Collect([]SlackFinding{
+		{Owner: "org1", Repo: "repo1", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org1/repo1/pull/100", Category: "ci", Message: "🔴 failed", DedupKey: "ci:abc:e2e"},
+	})
+	reporter.Collect([]SlackFinding{
+		{Owner: "org2", Repo: "repo2", PRNumber: 200, PRTitle: "Add feature", PRURL: "https://github.com/org2/repo2/pull/200", Category: "conflict", Message: "⚠️ conflicts", DedupKey: "conflict:200"},
+	})
+
+	// No POST until Flush
+	if postCount != 0 {
+		t.Errorf("expected 0 POSTs before Flush, got %d", postCount)
+	}
+
+	// Flush should send a single consolidated message
+	reporter.Flush(ctx)
+	if postCount != 1 {
+		t.Errorf("expected 1 POST after Flush, got %d", postCount)
+	}
+
+	// Pending should be drained
+	reporter.mu.Lock()
+	if len(reporter.pending) != 0 {
+		t.Errorf("expected pending to be empty after Flush, got %d", len(reporter.pending))
+	}
+	reporter.mu.Unlock()
+
+	// Flushing again with no new findings should not POST
+	reporter.Flush(ctx)
+	if postCount != 1 {
+		t.Errorf("expected still 1 POST after empty Flush, got %d", postCount)
+	}
+}
+
+func TestSlackReporter_CollectConcurrent(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	// Simulate concurrent collection from multiple goroutines
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Go(func() {
+			reporter.Collect([]SlackFinding{
+				{Owner: "org", Repo: "repo", PRNumber: i, PRTitle: "Test", Message: "test", DedupKey: ""},
+			})
+		})
+	}
+	wg.Wait()
+
+	// All 10 findings should be pending
+	reporter.mu.Lock()
+	pendingCount := len(reporter.pending)
+	reporter.mu.Unlock()
+	if pendingCount != 10 {
+		t.Errorf("expected 10 pending findings, got %d", pendingCount)
+	}
+
+	// Flush should send all as one message
+	reporter.Flush(context.Background())
+	if postCount != 1 {
+		t.Errorf("expected 1 POST after Flush, got %d", postCount)
+	}
+}
+
+func TestSlackReporter_FlushDedup(t *testing.T) {
+	var postCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		postCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// First collect+flush
+	reporter.Collect([]SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "ci:abc:e2e"},
+	})
+	reporter.Flush(ctx)
+	if postCount != 1 {
+		t.Errorf("expected 1 POST, got %d", postCount)
+	}
+
+	// Second collect+flush with same DedupKey — should be suppressed
+	reporter.Collect([]SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "ci:abc:e2e"},
+	})
+	reporter.Flush(ctx)
+	if postCount != 1 {
+		t.Errorf("expected still 1 POST after dedup, got %d", postCount)
+	}
+}
+
+func TestFormatSlackMessage_BlockTextLimit(t *testing.T) {
+	// Create a finding with a very long message to test block splitting
+	var findings []SlackFinding
+	longMsg := strings.Repeat("x", 200) // Each finding line will be ~200 chars
+	for i := range 20 {
+		findings = append(findings, SlackFinding{
+			Owner:    "org",
+			Repo:     "repo",
+			PRNumber: i + 1,
+			PRTitle:  "Test PR " + longMsg[:50],
+			PRURL:    "https://github.com/org/repo/pull/" + strings.Repeat("1", 3),
+			Category: "ci",
+			Message:  "🔴 " + longMsg,
+		})
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Verify no block text exceeds the limit
+	for i, b := range msg.Blocks {
+		if b.Text != nil && len(b.Text.Text) > maxSlackBlockTextLen {
+			t.Errorf("block %d text exceeds limit: %d > %d", i, len(b.Text.Text), maxSlackBlockTextLen)
+		}
+	}
+}
+
+func TestFormatSlackMessage_BlockTextLimit_SingleLongLine(t *testing.T) {
+	// A single finding with a message that exceeds 3000 chars and contains no
+	// newlines, exercising the no-newline fallback in the block splitter.
+	longMsg := strings.Repeat("A", maxSlackBlockTextLen+500)
+	findings := []SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 1, PRTitle: "Long", PRURL: "https://github.com/org/repo/pull/1", Category: "ci", Message: longMsg},
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Verify no block text exceeds the limit
+	for i, b := range msg.Blocks {
+		if b.Text != nil && len(b.Text.Text) > maxSlackBlockTextLen {
+			t.Errorf("block %d text exceeds limit: %d > %d", i, len(b.Text.Text), maxSlackBlockTextLen)
+		}
+	}
+
+	// Should have produced at least 2 detail blocks (split)
+	detailBlocks := 0
+	for _, b := range msg.Blocks {
+		if b.Type == "section" && b.Text != nil && strings.Contains(b.Text.Text, "A") {
+			detailBlocks++
+		}
+	}
+	if detailBlocks < 2 {
+		t.Errorf("expected at least 2 detail blocks after splitting, got %d", detailBlocks)
+	}
+}
+
+func TestFormatSlackMessage_TruncatesAt50Blocks(t *testing.T) {
+	// Create enough findings across many projects to exceed 50 blocks
+	var findings []SlackFinding
+	for i := range 30 {
+		findings = append(findings, SlackFinding{
+			Owner:    fmt.Sprintf("org%d", i),
+			Repo:     fmt.Sprintf("repo%d", i),
+			PRNumber: i + 1,
+			PRTitle:  fmt.Sprintf("PR %d", i+1),
+			PRURL:    fmt.Sprintf("https://github.com/org%d/repo%d/pull/%d", i, i, i+1),
+			Category: "ci",
+			Message:  "🔴 test failed",
+		})
+	}
+
+	body := formatSlackMessage(findings)
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(msg.Blocks) > maxSlackBlocks {
+		t.Errorf("expected at most %d blocks, got %d", maxSlackBlocks, len(msg.Blocks))
+	}
+
+	// Last block should be the overflow notice
+	lastBlock := msg.Blocks[len(msg.Blocks)-1]
+	if lastBlock.Text == nil || !strings.Contains(lastBlock.Text.Text, "truncated") {
+		t.Error("expected last block to be the truncation notice")
 	}
 }

--- a/specs/slack.md
+++ b/specs/slack.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Automatic Slack reporting at the end of each poll cycle. When `OOMPA_SLACK_WEBHOOK` is set, oompa posts a consolidated Slack message with concrete findings and clickable GitHub links. Silent cycles produce no Slack message.
+Automatic Slack reporting at the end of each poll cycle. When `OOMPA_SLACK_WEBHOOK` is set, oompa posts a **single consolidated Slack message** across all projects with concrete findings and clickable GitHub links. Silent cycles produce no Slack message.
+
+In multi-project mode, findings from all project goroutines are collected into a shared reporter and flushed periodically as one message. Projects with no findings are omitted.
 
 ## Trigger
 
@@ -12,16 +14,18 @@ Automatic Slack reporting at the end of each poll cycle. When `OOMPA_SLACK_WEBHO
 
 | File | Purpose |
 |------|---------|
-| `pkg/agent/slack.go` | SlackFinding, SlackReporter, postToSlack, message formatter, dedup tracker |
-| `pkg/agent/slack_test.go` | Tests for formatting, dedup, empty findings, link construction |
-| `pkg/agent/loop.go` | Agent loop integration: Check* methods, ShouldCheckReaction, RunReportOnlyChecks, cycle-end reporting |
+| `pkg/agent/slack.go` | SlackFinding, SlackReporter (thread-safe: `mu` protects pending buffer, `flushMu` serializes Flush), postToSlack, message formatter, dedup tracker |
+| `pkg/agent/slack_test.go` | Tests for formatting, dedup, empty findings, link construction, collect/flush, concurrency, block splitting |
+| `pkg/agent/loop.go` | Agent loop integration: Check* methods, ShouldCheckReaction, RunReportOnlyChecks, CollectSlackFindings, FlushSlackReport |
 | `pkg/agent/config.go` | `SlackWebhookURL` field on Config |
-| `cmd/oompa/main.go` | Read `OOMPA_SLACK_WEBHOOK` env var |
+| `cmd/oompa/main.go` | Read `OOMPA_SLACK_WEBHOOK` env var, create shared reporter in multi-project mode, flush goroutine |
 
 ## Data Types
 
 ```go
 type SlackFinding struct {
+    Owner     string   // repository owner (e.g. "ovn-kubernetes")
+    Repo      string   // repository name (e.g. "ovn-kubernetes")
     PRNumber  int
     PRTitle   string
     PRURL     string
@@ -32,21 +36,36 @@ type SlackFinding struct {
 
 type SlackReporter struct {
     webhookURL string
-    owner      string
-    repo       string
     reported   map[string]bool // tracks DedupKeys already reported
     logger     *slog.Logger
     httpClient *http.Client    // injectable for testing
+    flushMu    sync.Mutex      // serializes Flush calls (protects reported map)
+    mu         sync.Mutex      // protects pending
+    pending    []SlackFinding  // findings collected since last Flush
 }
 ```
 
 ## SlackReporter Methods
 
-- `NewSlackReporter(webhookURL, owner, repo string, logger *slog.Logger) *SlackReporter`
-- `(r *SlackReporter) Report(ctx context.Context, findings []SlackFinding)` — dedup, format, POST
+- `NewSlackReporter(webhookURL string, logger *slog.Logger) *SlackReporter`
 - `(r *SlackReporter) IsEnabled() bool` — returns true if webhookURL is non-empty
-- `formatSlackMessage(owner, repo string, findings []SlackFinding) []byte` — builds Slack Block Kit JSON
+- `(r *SlackReporter) Collect(findings []SlackFinding)` — thread-safe append to pending buffer
+- `(r *SlackReporter) Flush(ctx context.Context)` — dedup, format, POST, clear pending
+- `(r *SlackReporter) Report(ctx context.Context, findings []SlackFinding)` — convenience: Collect + Flush in one call (single-repo mode)
+- `formatSlackMessage(findings []SlackFinding) []byte` — builds Slack Block Kit JSON grouped by project then PR
 - `postToSlack(ctx context.Context, client *http.Client, webhookURL string, body []byte) error` — HTTP POST
+
+## Collection Architecture
+
+### Single-repo mode
+Each `runLoop` call collects findings and flushes immediately at the end of the cycle (one agent, one reporter).
+
+### Multi-project mode
+1. A shared `SlackReporter` is created once and passed to all agent goroutines
+2. Each goroutine calls `CollectSlackFindings()` at the end of its poll cycle
+3. A separate flush goroutine runs on a timer matching the poll interval, calling `Flush()` periodically
+4. This produces one consolidated Slack message per flush window across all projects
+5. A final `Flush()` runs on shutdown to capture remaining findings
 
 ## What Gets Reported
 
@@ -69,6 +88,7 @@ type SlackReporter struct {
 - Poll cycle start/end
 - Routine checks that found nothing
 - Any idle/no-op cycle
+- Projects with no findings (omitted from message entirely)
 
 ## Reactions Behavior with Slack
 
@@ -88,19 +108,39 @@ type SlackReporter struct {
 
 ## Slack Message Format
 
-Slack Block Kit with mrkdwn. One message per cycle, grouped by PR:
+Slack Block Kit with header + per-project sections. One consolidated message per cycle, grouped by project then by PR:
 
 ```text
-🏭 oompa — owner/repo
+🏭 oompa report — 3 project(s) with activity
 
-📋 <pr-link|PR #N> — title
-  🔴 <job-link|check-name> — failed
-  ⚠️ 15 commits behind main
+*<repo-link|owner1/repo1>* (2 PRs)
+📋 <pr-link|PR #100> — Fix kubevirt test flake
+  🔴 <job-link|e2e-test> failed
+  ⚠️ behind main
+📋 <pr-link|PR #101> — kubevirt vm hostname
+  💬 3 new review comment(s)
 
-📋 <pr-link|PR #N> — title
-  💬 3 new reviews
-  ⚠️ Merge conflicts
+---
+
+*<repo-link|owner2/repo2>* (1 PR)
+📋 <pr-link|PR #200> — KubeVirt nmstate
+  🔴 <job-link|e2e-kubevirt> failed
 ```
+
+### Block structure
+
+1. `header` block — "🏭 oompa report — N project(s) with activity"
+2. Per project:
+   - `section` block (mrkdwn) — project name with link and PR count
+   - `section` block (mrkdwn) — PR details with findings (split if >3000 chars)
+   - `divider` block (between projects, not after last)
+
+### Links
+
+Every item links to the relevant GitHub resource:
+- Project name → `github.com/owner/repo`
+- PR number → `github.com/owner/repo/pull/N`
+- CI check name → `CheckRun.HTMLURL`
 
 ## Dedup
 
@@ -113,14 +153,25 @@ Don't re-report the same finding every poll cycle. Each finding has a DedupKey. 
 
 ## Tests
 
-- `TestFormatSlackMessage_GroupsByPR` — findings grouped by PR number
+- `TestFormatSlackMessage_GroupsByPR` — findings grouped by PR number within a project
 - `TestFormatSlackMessage_EmptyFindings` — returns nil
+- `TestFormatSlackMessage_MultipleProjects` — findings from multiple projects in one message
+- `TestFormatSlackMessage_SingleProjectNoFindings` — only projects with findings appear
+- `TestFormatSlackMessage_LinksCorrect` — project, PR, and CI links correct
+- `TestFormatSlackMessage_HasDividersBetweenProjects` — dividers between projects, not after last
+- `TestFormatSlackMessage_BlockTextLimit` — blocks split when text exceeds 3000 chars
+- `TestFormatSlackMessage_BlockTextLimit_SingleLongLine` — single line exceeding 3000 chars splits correctly
+- `TestFormatSlackMessage_TruncatesAt50Blocks` — messages with >50 blocks are truncated
 - `TestSlackReporter_Dedup` — same DedupKey suppressed on second call
 - `TestSlackReporter_DedupReset` — different DedupKey re-sends
 - `TestSlackReporter_Disabled` — no webhook → IsEnabled() false
+- `TestSlackReporter_EmptyDedupKey` — empty DedupKey always sent
+- `TestSlackReporter_CollectAndFlush` — collect from multiple projects, flush as one POST
+- `TestSlackReporter_CollectConcurrent` — concurrent Collect calls are thread-safe
+- `TestSlackReporter_FlushDedup` — dedup works across collect/flush cycles
 - `TestPostToSlack_Success` — HTTP POST with correct body
 - `TestPostToSlack_HTTPError` — non-200 status returns error
-- `TestCheckCIStatus_ReportsFailures` — report-only check produces findings
-- `TestCheckRebaseNeeded_ReportsBehind` — report-only check produces findings
-- `TestCheckConflicts_ReportsDirty` — report-only check produces findings
-- `TestCheckNewReviews_ReportsComments` — report-only check produces findings
+- `TestCheckCIStatus_ReportsFailures` — report-only check produces findings with Owner/Repo
+- `TestCheckRebaseNeeded_ReportsBehind` — report-only check produces findings with Owner/Repo
+- `TestCheckConflicts_ReportsDirty` — report-only check produces findings with Owner/Repo
+- `TestCheckNewReviews_ReportsComments` — report-only check produces findings with Owner/Repo


### PR DESCRIPTION
Fixes #179

## Summary

Consolidates Slack reports into a single message per poll cycle across all projects, replacing the previous per-project-per-cycle approach that could produce N separate Slack messages (one per project goroutine).

## Changes

- Refactored `SlackReporter` to be project-agnostic with thread-safe `Collect()` and `Flush()` methods instead of per-project `Report()` calls
- Added `Owner`/`Repo` fields to `SlackFinding` so each finding carries its project identity
- Rewrote `formatSlackMessage` to group findings by project first, then by PR, using Slack Block Kit with header, per-project section headers with repo links, detail sections, and dividers
- Added block text splitting to stay within Slack's 3000-character limit per block
- In multi-project mode: created a shared `SlackReporter` passed to all agent goroutines, with a separate flush goroutine that batches findings on a timer matching the poll interval
- In single-repo mode: findings are collected and flushed at the end of each poll cycle
- Updated the Slack spec to document the new consolidated architecture
- Added new tests: multi-project formatting, concurrent collection, collect/flush lifecycle, block splitting, divider placement, link correctness

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #179

<!-- oompa-bot v:a86b478 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated per-poll-cycle Slack reports across projects with per-project sections, clickable GitHub links, overflow splitting and truncation; shared, thread-safe reporter with periodic/background flush; single-repo convenience path retained.
* **Bug Fixes**
  * Deduplication across cycles to avoid duplicate notifications; silent/idle cycles produce no message; final flush on shutdown; thread-safe collection to prevent concurrent flush races.
* **Documentation**
  * Updated Slack integration spec covering Block Kit format, dedup, collect/flush and truncation behavior.
* **Tests**
  * Expanded tests for formatting, splitting/truncation, dedup, concurrency, disabled mode, and collect+flush pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/180)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->