### PR TITLE
fix: ensure review threads are replied to before advancing cursor

### DIFF
--- a/pkg/agent/dryrun.go
+++ b/pkg/agent/dryrun.go
@@ -147,4 +147,8 @@ func (d *DryRunGitHubClient) GetWorkflowJobLogs(ctx context.Context, owner, repo
 	return d.inner.GetWorkflowJobLogs(ctx, owner, repo, jobID)
 }
 
+func (d *DryRunGitHubClient) HasRepliesFromUser(ctx context.Context, owner, repo string, prNumber int, commentIDs []int64, username string) (map[int64]bool, error) {
+	return d.inner.HasRepliesFromUser(ctx, owner, repo, prNumber, commentIDs, username)
+}
+
 

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -42,6 +42,7 @@ type GitHubClient interface {
 	ListWorkflowRuns(ctx context.Context, owner, repo, workflowID string, status string, limit int) ([]WorkflowRun, error)
 	ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error)
 	GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error)
+	HasRepliesFromUser(ctx context.Context, owner, repo string, prNumber int, commentIDs []int64, username string) (map[int64]bool, error)
 }
 
 // GoGitHubClient implements GitHubClient using go-github.
@@ -633,6 +634,44 @@ func (g *GoGitHubClient) ListWorkflowJobs(ctx context.Context, owner, repo strin
 	}
 
 	return workflowJobs, nil
+}
+
+// HasRepliesFromUser checks which of the given PR review comment IDs have a
+// reply authored by the given username. It fetches all comments on the PR once
+// and returns a map indicating which comment IDs have replies, avoiding N+1
+// API call patterns when checking multiple comments.
+func (g *GoGitHubClient) HasRepliesFromUser(ctx context.Context, owner, repo string, prNumber int, commentIDs []int64, username string) (map[int64]bool, error) {
+	if len(commentIDs) == 0 {
+		return nil, nil
+	}
+
+	// Build a lookup set for O(1) matching
+	wanted := make(map[int64]bool, len(commentIDs))
+	for _, id := range commentIDs {
+		wanted[id] = true
+	}
+
+	result := make(map[int64]bool, len(commentIDs))
+	opts := &github.PullRequestListCommentsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		comments, resp, err := g.client.PullRequests.ListComments(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing PR comments for reply check: %w", err)
+		}
+		for _, c := range comments {
+			replyTo := c.GetInReplyTo()
+			if replyTo != 0 && wanted[replyTo] && c.GetUser().GetLogin() == username {
+				result[replyTo] = true
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return result, nil
 }
 
 // GetWorkflowJobLogs fetches the logs for a specific workflow job.

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -740,3 +740,130 @@ func TestGetCheckRuns_UsesPerPage100(t *testing.T) {
 		t.Error("expected per_page parameter to be set to 100")
 	}
 }
+
+func TestHasRepliesFromUser_FindsReply(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		comments := []*github.PullRequestComment{
+			{ID: new(int64(10)), User: &github.User{Login: new("reviewer")}, Body: new("fix this")},
+			{ID: new(int64(20)), InReplyTo: new(int64(10)), User: &github.User{Login: new("oompa-bot")}, Body: new("done")},
+		}
+		_ = json.NewEncoder(w).Encode(comments)
+	})
+
+	gh := setupTestClient(t, mux)
+	result, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10}, "oompa-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result[10] {
+		t.Error("expected comment 10 to have reply")
+	}
+}
+
+func TestHasRepliesFromUser_NoReply(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		comments := []*github.PullRequestComment{
+			{ID: new(int64(10)), User: &github.User{Login: new("reviewer")}, Body: new("fix this")},
+		}
+		_ = json.NewEncoder(w).Encode(comments)
+	})
+
+	gh := setupTestClient(t, mux)
+	result, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10}, "oompa-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[10] {
+		t.Error("expected comment 10 to have no reply")
+	}
+}
+
+func TestHasRepliesFromUser_WrongUser(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		comments := []*github.PullRequestComment{
+			{ID: new(int64(10)), User: &github.User{Login: new("reviewer")}, Body: new("fix this")},
+			{ID: new(int64(20)), InReplyTo: new(int64(10)), User: &github.User{Login: new("other-user")}, Body: new("not oompa")},
+		}
+		_ = json.NewEncoder(w).Encode(comments)
+	})
+
+	gh := setupTestClient(t, mux)
+	result, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10}, "oompa-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[10] {
+		t.Error("expected comment 10 to have no reply from oompa-bot")
+	}
+}
+
+func TestHasRepliesFromUser_Paginates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			// Page 1: original comment, no reply yet
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			comments := []*github.PullRequestComment{
+				{ID: new(int64(10)), User: &github.User{Login: new("reviewer")}, Body: new("fix this")},
+			}
+			_ = json.NewEncoder(w).Encode(comments)
+		} else {
+			// Page 2: the reply
+			comments := []*github.PullRequestComment{
+				{ID: new(int64(20)), InReplyTo: new(int64(10)), User: &github.User{Login: new("oompa-bot")}, Body: new("done")},
+			}
+			_ = json.NewEncoder(w).Encode(comments)
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	result, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10}, "oompa-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result[10] {
+		t.Error("expected comment 10 to have reply found via pagination")
+	}
+}
+
+func TestHasRepliesFromUser_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	gh := setupTestClient(t, mux)
+	_, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10}, "oompa-bot")
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+}
+
+func TestHasRepliesFromUser_MultipleComments(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/1/comments", func(w http.ResponseWriter, _ *http.Request) {
+		comments := []*github.PullRequestComment{
+			{ID: new(int64(10)), User: &github.User{Login: new("reviewer")}, Body: new("fix this")},
+			{ID: new(int64(11)), User: &github.User{Login: new("reviewer")}, Body: new("fix that")},
+			{ID: new(int64(20)), InReplyTo: new(int64(10)), User: &github.User{Login: new("oompa-bot")}, Body: new("done")},
+			// No reply to comment 11
+		}
+		_ = json.NewEncoder(w).Encode(comments)
+	})
+
+	gh := setupTestClient(t, mux)
+	result, err := gh.HasRepliesFromUser(context.Background(), "owner", "repo", 1, []int64{10, 11}, "oompa-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result[10] {
+		t.Error("expected comment 10 to have reply")
+	}
+	if result[11] {
+		t.Error("expected comment 11 to have no reply")
+	}
+}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -295,6 +295,37 @@ func (f *fakeGitHubClient) GetWorkflowJobLogs(_ context.Context, _, _ string, _ 
 	return "", nil
 }
 
+func (f *fakeGitHubClient) HasRepliesFromUser(_ context.Context, _, _ string, prNumber int, commentIDs []int64, username string) (map[int64]bool, error) {
+	f.state.mu.Lock()
+	defer f.state.mu.Unlock()
+
+	wanted := make(map[int64]bool, len(commentIDs))
+	for _, id := range commentIDs {
+		wanted[id] = true
+	}
+
+	result := make(map[int64]bool)
+
+	// Check structured PR comments
+	for _, c := range f.state.prComments[prNumber] {
+		if c.InReplyToID != 0 && wanted[c.InReplyToID] && c.User == username {
+			result[c.InReplyToID] = true
+		}
+	}
+
+	// Also check replies recorded by ReplyToPRComment in posted comments
+	for _, p := range f.state.postedComments {
+		for _, id := range commentIDs {
+			prefix := fmt.Sprintf("reply:%d:", id)
+			if strings.HasPrefix(p, prefix) {
+				result[id] = true
+			}
+		}
+	}
+
+	return result, nil
+}
+
 // initBareRepo creates a bare repo and a working clone for the agent to use.
 // Returns (cloneDir, cleanup).
 func initBareRepo(t *testing.T) string {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -40,6 +40,11 @@ type mockGitHubClient struct {
 	listIssuesCalled bool // tracks whether ListLabeledIssues was called
 	listIssuesErr    error
 	replyErr         error // error to return from ReplyToPRComment
+
+	// repliedCommentIDs simulates comments that already have a reply from the
+	// agent user (used by HasReplyFromUser).
+	repliedCommentIDs map[int64]bool
+	hasReplyErr       error // error to return from HasReplyFromUser
 }
 
 func (m *mockGitHubClient) ListLabeledIssues(_ context.Context, _, _, _ string) ([]Issue, error) {
@@ -136,6 +141,19 @@ func (m *mockGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, _ in
 	}
 	m.addedComments = append(m.addedComments, fmt.Sprintf("reply:%d:%s", commentID, body))
 	return nil
+}
+
+func (m *mockGitHubClient) HasRepliesFromUser(_ context.Context, _, _ string, _ int, commentIDs []int64, _ string) (map[int64]bool, error) {
+	if m.hasReplyErr != nil {
+		return nil, m.hasReplyErr
+	}
+	result := make(map[int64]bool)
+	for _, id := range commentIDs {
+		if m.repliedCommentIDs != nil && m.repliedCommentIDs[id] {
+			result[id] = true
+		}
+	}
+	return result, nil
 }
 
 func (m *mockGitHubClient) GetPRMergeable(_ context.Context, _, _ string, _ int) (string, error) {
@@ -255,7 +273,7 @@ func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt *mockWorktreeMa
 		runner:    runner,
 		worktrees: wt,
 		state:     NewState(),
-		cfg:       Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", FlakyLabel: "flaky-test"},
+		cfg:       Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", FlakyLabel: "flaky-test", GitHubUser: "test-bot"},
 		logger:    slog.Default(),
 		codeAgent: &ClaudeCodeAgent{},
 	}
@@ -542,11 +560,15 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 		t.Errorf("expected lastCommentID 60, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID)
 	}
 
-	// Oompa no longer posts hardcoded replies — the skill handles per-comment replies.
+	// Fallback reply should be posted for unreplied threads before cursor advances.
+	foundReply := false
 	for _, comment := range gh.addedComments {
-		if strings.HasPrefix(comment, "reply:") {
-			t.Errorf("expected no hardcoded replies from oompa, got: %s", comment)
+		if strings.HasPrefix(comment, "reply:60:") {
+			foundReply = true
 		}
+	}
+	if !foundReply {
+		t.Error("expected fallback reply to be posted for unreplied comment 60")
 	}
 }
 
@@ -606,11 +628,231 @@ func TestProcessReviewComments_CursorAdvancesUnconditionally(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	// Cursor should always advance after a successful agent run —
-	// oompa no longer posts replies (the skill handles them).
+	// Cursor should always advance after a successful agent run.
+	// Fallback replies are posted for any unreplied threads before advancing.
 	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
 	if work.LastCommentID != 60 {
 		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
+	}
+}
+
+func TestProcessReviewComments_FallbackRepliesForUnrepliedThreads(t *testing.T) {
+	// When the agent finds no changes needed and the skill doesn't post replies,
+	// oompa should post fallback replies so threads aren't left unresolved.
+	result := streamResultJSON(AgentResult{Result: "No changes needed"})
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+			{ID: 61, User: "reviewer", Body: "Also fix that", Path: "util.go", Line: 5},
+		},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Both comments should get fallback replies
+	reply60 := false
+	reply61 := false
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:60:") {
+			reply60 = true
+		}
+		if strings.HasPrefix(comment, "reply:61:") {
+			reply61 = true
+		}
+	}
+	if !reply60 {
+		t.Error("expected fallback reply for comment 60")
+	}
+	if !reply61 {
+		t.Error("expected fallback reply for comment 61")
+	}
+
+	// Cursor should advance after replies are posted
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 61 {
+		t.Errorf("expected LastCommentID to advance to 61, got %d", work.LastCommentID)
+	}
+}
+
+func TestProcessReviewComments_NoDuplicateFallbackReplies(t *testing.T) {
+	// When the skill already posted replies, no duplicate fallback replies should be posted.
+	result := streamResultJSON(AgentResult{Result: "Addressed the feedback"})
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+			{ID: 61, User: "reviewer", Body: "Also fix that", Path: "util.go", Line: 5},
+		},
+		// Simulate that both comments already have replies from the agent
+		repliedCommentIDs: map[int64]bool{60: true, 61: true},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// No fallback replies should be posted (skill already handled them)
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:") {
+			t.Errorf("expected no fallback replies (skill already replied), got: %s", comment)
+		}
+	}
+
+	// Cursor should still advance
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 61 {
+		t.Errorf("expected LastCommentID to advance to 61, got %d", work.LastCommentID)
+	}
+}
+
+func TestProcessReviewComments_MixedRepliesOnlyFallbackForUnreplied(t *testing.T) {
+	// When the skill replied to some threads but not others,
+	// only unreplied threads get fallback replies.
+	result := streamResultJSON(AgentResult{Result: "Partially addressed"})
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+			{ID: 61, User: "reviewer", Body: "Also fix that", Path: "util.go", Line: 5},
+		},
+		// Simulate that only comment 60 has a reply
+		repliedCommentIDs: map[int64]bool{60: true},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Only comment 61 should get a fallback reply
+	reply60 := false
+	reply61 := false
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:60:") {
+			reply60 = true
+		}
+		if strings.HasPrefix(comment, "reply:61:") {
+			reply61 = true
+		}
+	}
+	if reply60 {
+		t.Error("expected no fallback reply for comment 60 (already replied)")
+	}
+	if !reply61 {
+		t.Error("expected fallback reply for unreplied comment 61")
+	}
+}
+
+func TestProcessReviewComments_AgentErrorPostsFallbackReplies(t *testing.T) {
+	// When the agent errors out, fallback replies should still be posted
+	// before cursor advances.
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Fallback reply should be posted even when agent fails
+	foundReply := false
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:60:") {
+			foundReply = true
+		}
+	}
+	if !foundReply {
+		t.Error("expected fallback reply to be posted for unreplied comment 60 even on agent error")
+	}
+
+	// Cursor should still advance (to avoid infinite retry loops)
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 60 {
+		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
+	}
+}
+
+func TestProcessReviewComments_PushFailureSkipsFallbackReplies(t *testing.T) {
+	// When changes were detected but push failed, fallback replies should NOT
+	// be posted (the comments will be retried on the next poll cycle).
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	runner := &mockCommandRunner{stdout: []byte("dirty"), err: fmt.Errorf("git failed")}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// No fallback replies when push fails (will retry on next cycle)
+	for _, comment := range gh.addedComments {
+		if strings.HasPrefix(comment, "reply:") {
+			t.Errorf("expected no fallback replies when push failed, got: %s", comment)
+		}
+	}
+
+	// Cursor should NOT advance
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 50 {
+		t.Errorf("expected LastCommentID to stay at 50, got %d", work.LastCommentID)
 	}
 }
 

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -6,6 +6,41 @@ import (
 	"time"
 )
 
+const fallbackReplyBody = "Reviewed — no code changes needed."
+
+// postFallbackReplies checks each review thread for a reply from the agent user
+// and posts a fallback reply for any threads that were left unreplied. This
+// ensures review threads are never left unresolved when the cursor advances.
+// Returns true if all replies were verified/posted successfully, false if any
+// GitHub API call failed (callers should not advance cursors on failure).
+func (a *Agent) postFallbackReplies(ctx context.Context, task reviewTask) bool {
+	if len(task.humanComments) == 0 {
+		return true
+	}
+
+	commentIDs := make([]int64, 0, len(task.humanComments))
+	for _, c := range task.humanComments {
+		commentIDs = append(commentIDs, c.ID)
+	}
+
+	repliedMap, err := a.gh.HasRepliesFromUser(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, commentIDs, a.cfg.GitHubUser)
+	if err != nil {
+		a.logger.Warn("failed to check for replies", "pr", task.work.PRNumber, "error", err)
+		return false
+	}
+
+	ok := true
+	for _, c := range task.humanComments {
+		if !repliedMap[c.ID] {
+			if err := a.gh.ReplyToPRComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber, c.ID, fallbackReplyBody); err != nil {
+				a.logger.Warn("failed to post fallback reply", "comment", c.ID, "error", err)
+				ok = false
+			}
+		}
+	}
+	return ok
+}
+
 // ProcessReviewComments checks for new review comments and review bodies, then runs Claude to address them.
 func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	a.emit(Event{
@@ -213,14 +248,22 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 				Duration:  time.Since(agentStart).Seconds(),
 				Error:     err.Error(),
 			})
+			// Post fallback replies before advancing cursors so threads don't
+			// appear ignored on GitHub.
+			fallbackOK := a.postFallbackReplies(ctx, task)
+
 			// Advance cursors even on agent failure — the reviews were evaluated.
 			// Not advancing causes an infinite retry loop where the same reviews
 			// are re-fetched and re-processed every poll cycle ($0.50-1.00 each time).
-			if task.maxCommentID > task.work.LastCommentID {
-				task.work.LastCommentID = task.maxCommentID
-			}
-			if task.maxReviewID > task.work.LastReviewID {
-				task.work.LastReviewID = task.maxReviewID
+			// However, skip advancement if fallback replies failed — a transient
+			// GitHub failure should not permanently skip unreplied threads.
+			if fallbackOK {
+				if task.maxCommentID > task.work.LastCommentID {
+					task.work.LastCommentID = task.maxCommentID
+				}
+				if task.maxReviewID > task.work.LastReviewID {
+					task.work.LastReviewID = task.maxReviewID
+				}
 			}
 			task.work.ReviewNoOpCount++
 			return
@@ -285,12 +328,23 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			}
 		}
 
+		// Post fallback replies for any review threads the agent didn't
+		// reply to, so threads are never left unresolved on GitHub.
+		// Skip when changes were detected but push failed — the comments
+		// will be retried on the next poll cycle.
+		fallbackOK := true
+		if !changeDetected || pushed {
+			fallbackOK = a.postFallbackReplies(ctx, task)
+		}
+
 		// Advance cursors based on ALL fetched comment/review IDs (not just
 		// the human-filtered subset) to avoid re-fetching and re-filtering
 		// bot-posted or already-replied comments on every poll cycle.
 		// When changes were detected but push failed, skip cursor advancement
 		// so the comments are retried on the next poll cycle.
-		if !changeDetected || pushed {
+		// Also skip if fallback replies failed — a transient GitHub failure
+		// should not permanently skip unreplied threads.
+		if (!changeDetected || pushed) && fallbackOK {
 			if task.maxCommentID > task.work.LastCommentID {
 				task.work.LastCommentID = task.maxCommentID
 			}


### PR DESCRIPTION
Fixes #181

## Summary

Ensure review threads are replied to before advancing the LastReviewID/LastCommentID cursors. When the agent evaluates review comments and determines "no changes needed", oompa now verifies each thread has a reply and posts a fallback reply for any unreplied threads before advancing cursors.

## Changes

- Add `HasReplyFromUser` method to `GitHubClient` interface and implement it on `GoGitHubClient`, `DryRunGitHubClient`, and test mocks
- Add `postFallbackReplies` to `review.go` that checks each human comment for an existing reply from the agent user and posts a fallback reply ("Reviewed — no code changes needed.") for unreplied threads
- Call `postFallbackReplies` in both the success path (before cursor advancement) and the agent failure path (before cursor advancement)
- Skip fallback replies when changes were detected but push failed (the comments will be retried on the next poll cycle)

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- Manual testing (if applicable)

New tests added:
- `TestProcessReviewComments_FallbackRepliesForUnrepliedThreads` — agent finds no changes needed → fallback replies posted to all threads → cursor advances
- `TestProcessReviewComments_NoDuplicateFallbackReplies` — agent posts its own replies via skill → no duplicate fallback replies → cursor advances
- `TestProcessReviewComments_MixedRepliesOnlyFallbackForUnreplied` — some threads replied by skill, some not → fallback only for unreplied ones
- `TestProcessReviewComments_AgentErrorPostsFallbackReplies` — agent errors out → fallback replies still posted → cursor advances
- `TestProcessReviewComments_PushFailureSkipsFallbackReplies` — push fails → no replies, no cursor advance (retry next cycle)
- `TestHasReplyFromUser_FindsReply` / `TestHasReplyFromUser_NoReply` / `TestHasReplyFromUser_WrongUser` — unit tests for the new GitHub API method

## Related Issues

Fixes #181

<!-- oompa-bot v:a86b478 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback replies for unreplied PR review threads and gated cursor advancement on successful fallback posting.

* **Bug Fixes**
  * Added reliable detection of whether a thread already has a reply from the agent to avoid duplicate replies and handle transient API failures correctly.

* **Tests**
  * Expanded unit and integration tests for reply detection, pagination, API error propagation, and fallback-reply behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/182)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->