### PR TITLE
fix: reactions: [] enables all reactions instead of disabling them

### DIFF
--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -85,120 +85,28 @@ projects:
 	}
 }
 
-func TestLoadFileConfig_NoProjects(t *testing.T) {
-	yaml := `
-agent: opencode
-projects: []
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for empty projects")
+func TestLoadFileConfig_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{"no_projects", "agent: opencode\nprojects: []\n"},
+		{"invalid_repo", "projects:\n  - repo: invalid\n    prs:\n      - watch: [1]\n"},
+		{"no_roles", "projects:\n  - repo: owner/repo\n"},
+		{"prs_without_watch", "projects:\n  - repo: owner/repo\n    prs:\n      - reactions: [ci]\n"},
+		{"triage_without_jobs", "projects:\n  - repo: owner/repo\n    triage:\n      - schedule: \"09:00 Europe/Madrid\"\n"},
+		{"invalid_reaction", "projects:\n  - repo: owner/repo\n    prs:\n      - watch: [1]\n        reactions: [invalid]\n"},
+		{"invalid_agent", "agent: badagent\nprojects:\n  - repo: owner/repo\n    issues:\n      - label: test\n"},
 	}
-}
-
-func TestLoadFileConfig_InvalidRepo(t *testing.T) {
-	yaml := `
-projects:
-  - repo: invalid
-    prs:
-      - watch: [1]
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for invalid repo format")
-	}
-}
-
-func TestLoadFileConfig_NoRoles(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error when no roles defined")
-	}
-}
-
-func TestLoadFileConfig_PRsWithoutWatch(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    prs:
-      - reactions: [ci]
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for prs without watch list")
-	}
-}
-
-func TestLoadFileConfig_TriageWithoutJobs(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    triage:
-      - schedule: "09:00 Europe/Madrid"
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for triage without jobs")
-	}
-}
-
-func TestLoadFileConfig_InvalidReaction(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    prs:
-      - watch: [1]
-        reactions: [invalid]
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for invalid reaction")
-	}
-}
-
-func TestLoadFileConfig_InvalidAgent(t *testing.T) {
-	yaml := `
-agent: badagent
-projects:
-  - repo: owner/repo
-    issues:
-      - label: test
-`
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
-	if err == nil {
-		t.Fatal("expected error for invalid agent")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			os.WriteFile(path, []byte(tt.yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
+			_, err := LoadFileConfig(path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 
@@ -976,6 +884,40 @@ projects:
 	}
 	if len(cfg.Projects[0].Triage[0].SkipChecks) != 1 || cfg.Projects[0].Triage[0].SkipChecks[0] != "lint-check" {
 		t.Errorf("expected Triage skip-checks [lint-check], got %v", cfg.Projects[0].Triage[0].SkipChecks)
+	}
+}
+
+func TestReactionsNilVsEmpty(t *testing.T) {
+	// Issue #184: YAML `reactions: []` → non-nil empty; omitted → nil.
+	loadPRReactions := func(t *testing.T, y string) []string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "c.yaml")
+		os.WriteFile(p, []byte(y), 0o644) //nolint:errcheck // test helper: errors caught by LoadFileConfig
+		fc, err := LoadFileConfig(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fc.Projects[0].PRs[0].Reactions
+	}
+	if r := loadPRReactions(t, "projects:\n  - repo: o/r\n    prs:\n      - watch: [1]\n        reactions: []\n"); r == nil || len(r) != 0 {
+		t.Errorf("reactions: [] should produce non-nil empty slice, got %#v", r)
+	}
+	if r := loadPRReactions(t, "projects:\n  - repo: o/r\n    prs:\n      - watch: [1]\n"); r != nil {
+		t.Errorf("omitted reactions should be nil, got %v", r)
+	}
+	// stringsOr preserves distinction through BuildRoleEntries
+	fc := &FileConfig{Projects: []ProjectConfig{{Repo: "o/r", PRs: []PRsRoleConfig{
+		{Watch: []int{1}, Reactions: []string{}}, {Watch: []int{2}},
+	}}}}
+	e := BuildRoleEntries(fc, "/tmp/w", Config{Agent: "claudecode"})
+	if len(e) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(e))
+	}
+	if e[0].Config.Reactions == nil || len(e[0].Config.Reactions) != 0 {
+		t.Errorf("entry 0: expected non-nil empty slice, got %#v", e[0].Config.Reactions)
+	}
+	if e[1].Config.Reactions != nil {
+		t.Errorf("entry 1: expected nil, got %v", e[1].Config.Reactions)
 	}
 }
 

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -338,10 +338,11 @@ func (a *Agent) HasWatchedPRs() bool {
 }
 
 // ShouldRunReaction returns true if the given reaction type should be executed.
-// If cfg.Reactions is empty, all reactions are enabled.
+// If cfg.Reactions is nil (not configured), all reactions are enabled (backward compatible).
+// If cfg.Reactions is an empty non-nil slice (explicitly set to []), no reactions are enabled.
 // Valid reaction names: "reviews", "ci", "conflicts", "rebase".
 func (a *Agent) ShouldRunReaction(reaction string) bool {
-	if len(a.cfg.Reactions) == 0 {
+	if a.cfg.Reactions == nil {
 		return true
 	}
 	return slices.Contains(a.cfg.Reactions, reaction)
@@ -349,13 +350,13 @@ func (a *Agent) ShouldRunReaction(reaction string) bool {
 
 // ShouldCheckReaction returns true if a report-only check should run for the given reaction.
 // This is true when the Slack webhook is set AND the reaction is NOT in the active reactions list.
-// When Reactions is empty (all enabled), no report-only checks run because all reactions
-// are already being processed by their full Process* methods.
+// When Reactions is nil (not configured, all enabled), no report-only checks run because all
+// reactions are already being processed by their full Process* methods.
 func (a *Agent) ShouldCheckReaction(reaction string) bool {
 	if a.cfg.SlackWebhookURL == "" {
 		return false
 	}
-	if len(a.cfg.Reactions) == 0 {
+	if a.cfg.Reactions == nil {
 		// All reactions enabled → nothing is report-only
 		return false
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -2506,28 +2506,168 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 	}
 }
 
-func TestShouldRunReaction_EmptyAllowsAll(t *testing.T) {
+func TestShouldRunReaction_NilAllowsAll(t *testing.T) {
 	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
-	// No reactions configured — all should be allowed
-	for _, reaction := range []string{"reviews", "ci", "conflicts"} {
+	// Reactions == nil (not configured) — all should be allowed
+	for _, reaction := range []string{"reviews", "ci", "conflicts", "rebase"} {
 		if !agent.ShouldRunReaction(reaction) {
-			t.Errorf("expected %q to be allowed with empty Reactions", reaction)
+			t.Errorf("expected %q to be allowed with nil Reactions", reaction)
+		}
+	}
+}
+
+func TestShouldRunReaction_EmptySliceDisablesAll(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.Reactions = []string{} // explicitly set to empty list
+	for _, reaction := range []string{"reviews", "ci", "conflicts", "rebase"} {
+		if agent.ShouldRunReaction(reaction) {
+			t.Errorf("expected %q to be disabled with empty (non-nil) Reactions", reaction)
 		}
 	}
 }
 
 func TestShouldRunReaction_Filtered(t *testing.T) {
 	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
-	agent.cfg.Reactions = []string{"ci", "conflicts"}
+	agent.cfg.Reactions = []string{"ci", "rebase"}
 
 	if !agent.ShouldRunReaction("ci") {
 		t.Error("expected 'ci' to be allowed")
 	}
-	if !agent.ShouldRunReaction("conflicts") {
-		t.Error("expected 'conflicts' to be allowed")
+	if !agent.ShouldRunReaction("rebase") {
+		t.Error("expected 'rebase' to be allowed")
 	}
 	if agent.ShouldRunReaction("reviews") {
 		t.Error("expected 'reviews' to be filtered out")
+	}
+	if agent.ShouldRunReaction("conflicts") {
+		t.Error("expected 'conflicts' to be filtered out")
+	}
+}
+
+func TestShouldCheckReaction_NoWebhook(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SlackWebhookURL = ""
+	// No webhook — always returns false regardless of reactions config
+	agent.cfg.Reactions = nil
+	if agent.ShouldCheckReaction("ci") {
+		t.Error("expected false with no webhook and nil Reactions")
+	}
+	agent.cfg.Reactions = []string{}
+	if agent.ShouldCheckReaction("ci") {
+		t.Error("expected false with no webhook and empty Reactions")
+	}
+	agent.cfg.Reactions = []string{"rebase"}
+	if agent.ShouldCheckReaction("ci") {
+		t.Error("expected false with no webhook and specific Reactions")
+	}
+}
+
+func TestShouldCheckReaction_WebhookNilReactions(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SlackWebhookURL = "https://hooks.slack.com/test"
+	agent.cfg.Reactions = nil // all reactions enabled
+	// All reactions active → nothing is report-only
+	for _, reaction := range []string{"reviews", "ci", "conflicts", "rebase"} {
+		if agent.ShouldCheckReaction(reaction) {
+			t.Errorf("expected %q to NOT be report-only when all reactions enabled", reaction)
+		}
+	}
+}
+
+func TestShouldCheckReaction_WebhookEmptyReactions(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SlackWebhookURL = "https://hooks.slack.com/test"
+	agent.cfg.Reactions = []string{} // no reactions enabled → everything is report-only
+	for _, reaction := range []string{"reviews", "ci", "conflicts", "rebase"} {
+		if !agent.ShouldCheckReaction(reaction) {
+			t.Errorf("expected %q to be report-only when no reactions enabled", reaction)
+		}
+	}
+}
+
+func TestShouldCheckReaction_WebhookPartialReactions(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SlackWebhookURL = "https://hooks.slack.com/test"
+	agent.cfg.Reactions = []string{"rebase"}
+	// "rebase" is active — NOT report-only
+	if agent.ShouldCheckReaction("rebase") {
+		t.Error("expected 'rebase' to NOT be report-only (it's active)")
+	}
+	// All others are report-only
+	for _, reaction := range []string{"ci", "reviews", "conflicts"} {
+		if !agent.ShouldCheckReaction(reaction) {
+			t.Errorf("expected %q to be report-only (not in active reactions)", reaction)
+		}
+	}
+}
+
+func TestReportOnlyMode_EmptyReactionsGatesAndChecks(t *testing.T) {
+	// Verifies that with Reactions == []string{} + webhook set:
+	// - ShouldRunReaction returns false for all reactions (gating mechanism)
+	// - ShouldCheckReaction returns true for all reactions (report-only)
+	// - RunReportOnlyChecks produces findings from the mock state
+	// - No agent/runner invocations occur
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
+		},
+		mergeableState: "dirty",
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.Reactions = []string{}                            // report-only mode
+	agent.cfg.SlackWebhookURL = "https://hooks.slack.com/test" // enable Slack
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	// All reactions should be skipped
+	if agent.ShouldRunReaction("reviews") {
+		t.Error("ProcessReviewComments should be skipped in report-only mode")
+	}
+	if agent.ShouldRunReaction("ci") {
+		t.Error("ProcessCIFailures should be skipped in report-only mode")
+	}
+	if agent.ShouldRunReaction("rebase") {
+		t.Error("ProcessRebase should be skipped in report-only mode")
+	}
+	if agent.ShouldRunReaction("conflicts") {
+		t.Error("ProcessConflicts should be skipped in report-only mode")
+	}
+
+	// Report-only checks SHOULD run
+	if !agent.ShouldCheckReaction("ci") {
+		t.Error("CI report-only check should run in report-only mode")
+	}
+	if !agent.ShouldCheckReaction("reviews") {
+		t.Error("Reviews report-only check should run in report-only mode")
+	}
+	if !agent.ShouldCheckReaction("conflicts") {
+		t.Error("Conflicts report-only check should run in report-only mode")
+	}
+	if !agent.ShouldCheckReaction("rebase") {
+		t.Error("Rebase report-only check should run in report-only mode")
+	}
+
+	// RunReportOnlyChecks should produce findings
+	findings := agent.RunReportOnlyChecks(context.Background())
+	if len(findings) == 0 {
+		t.Error("expected at least one finding from report-only checks")
+	}
+
+	// No agent invocations should have happened
+	if len(runner.calls) != 0 {
+		t.Errorf("expected 0 runner calls in report-only mode, got %d", len(runner.calls))
 	}
 }
 

--- a/specs/loop.md
+++ b/specs/loop.md
@@ -20,7 +20,8 @@ type Agent struct {
 - `(a *Agent) ProcessReviewComments(ctx)` -- check for new review comments, run Claude to address them
 - `(a *Agent) isAllowedReviewer(user string) bool` -- checks if user is in reviewers whitelist (empty = allow all)
 - `(a *Agent) HasWatchedPRs() bool` -- returns true if `cfg.WatchPRs` is non-empty
-- `(a *Agent) ShouldRunReaction(reaction string) bool` -- returns true if `cfg.Reactions` is empty (all enabled) or contains the given reaction name
+- `(a *Agent) ShouldRunReaction(reaction string) bool` -- returns true if `cfg.Reactions` is nil (not configured, all enabled) or contains the given reaction name. An empty non-nil slice (`reactions: []`) disables all reactions.
+- `(a *Agent) ShouldCheckReaction(reaction string) bool` -- returns true if Slack webhook is set AND the reaction is NOT in the active reactions list. Returns false when Reactions is nil (all active, nothing report-only).
 - `(a *Agent) BootstrapWatchedPRs(ctx)` -- creates IssueWork entries for directly-specified PR numbers (calls `GetPR` to fetch details, skips merged/closed/already-tracked)
 
 Main loop lives in `cmd/oompa/main.go`, calls these methods sequentially. CleanupDone runs first so that closed/merged PRs are removed from state before ProcessNewIssues checks for new work.
@@ -61,8 +62,14 @@ All interfaces mocked:
 - `TestCleanupDone_MergedPR` -- removes worktree, deletes from state
 - `TestCleanupDone_ClosedPR` -- removes worktree, deletes from state
 - `TestCleanupDone_OpenPR` -- no action
-- `TestShouldRunReaction_EmptyAllowsAll` -- empty Reactions allows all reaction types
+- `TestShouldRunReaction_NilAllowsAll` -- nil Reactions (not configured) allows all reaction types
+- `TestShouldRunReaction_EmptySliceDisablesAll` -- empty non-nil Reactions (`reactions: []`) disables all reaction types
 - `TestShouldRunReaction_Filtered` -- only configured reactions are allowed
+- `TestShouldCheckReaction_NoWebhook` -- no webhook always returns false
+- `TestShouldCheckReaction_WebhookNilReactions` -- webhook + nil reactions returns false (all active)
+- `TestShouldCheckReaction_WebhookEmptyReactions` -- webhook + empty reactions returns true for all (everything report-only)
+- `TestShouldCheckReaction_WebhookPartialReactions` -- webhook + partial reactions returns correct values
+- `TestReportOnlyMode_EmptyReactionsGatesAndChecks` -- empty reactions: ShouldRunReaction returns false, ShouldCheckReaction returns true, RunReportOnlyChecks produces findings, no runner invocations
 - `TestBootstrapWatchedPRs_HappyPath` -- creates IssueWork entries for open watched PRs
 - `TestBootstrapWatchedPRs_SkipsClosedPR` -- does not track merged/closed PRs
 - `TestBootstrapWatchedPRs_SkipsAlreadyTracked` -- does not duplicate existing entries


### PR DESCRIPTION
Fixes #184

## Summary

`reactions: []` in YAML config was treated the same as "not configured" (nil), enabling all reactions instead of disabling them. This broke report-only mode — projects configured with an empty reactions list still got full autonomous behavior.

## Changes

- Changed `ShouldRunReaction` in `pkg/agent/loop.go` to check `a.cfg.Reactions == nil` instead of `len(a.cfg.Reactions) == 0`, so only truly unconfigured (nil) reactions default to "all enabled"
- Changed `ShouldCheckReaction` in `pkg/agent/loop.go` with the same nil check, so empty reactions correctly makes all reaction types report-only
- Added unit tests for `ShouldRunReaction`: nil allows all, empty slice disables all, specific list filters correctly
- Added unit tests for `ShouldCheckReaction`: no webhook always false, webhook + nil returns false (all active), webhook + empty returns true for all (everything report-only), webhook + partial list returns correct values
- Added integration test verifying report-only mode end-to-end: empty reactions skips all Process* methods while report-only checks produce findings
- Added config parsing tests in `fileconfig_test.go`: `reactions: []` produces non-nil empty slice, omitted `reactions` produces nil, `stringsOr` preserves the distinction through two-tier inheritance

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #184

<!-- oompa-bot v:3356a2b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated multiple config validation cases into a single table-driven suite.
  * Added tests for nil vs explicitly empty reaction lists and expanded gating/report-only coverage (webhook/no-webhook, nil/empty/partial lists), including an integration-style report-only scenario verifying skipped runs and produced findings.

* **Documentation**
  * Clarified agent reaction-handling semantics: nil = allow all, empty list = disable all, and webhook-driven report-only behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/185)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->