### PR TITLE
feat: configurable rebase-interval per project to control rebase frequency

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	MaxReviewNoOps    int      // consecutive no-op review cycles before pausing review processing (default: 3)
 	MaxPRSessionCost  float64  // max cumulative agent cost per PR per session before pausing (default: 0 = unlimited)
 	SlackWebhookURL   string   // Slack Incoming Webhook URL for per-cycle reporting (empty = disabled)
+	RebaseInterval    time.Duration // minimum time between rebases (default: 4h)
 
 	// GitHub App authentication (alternative to GITHUB_TOKEN)
 	GitHubAppID             int64

--- a/pkg/agent/conflicts.go
+++ b/pkg/agent/conflicts.go
@@ -120,11 +120,15 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 // Returns (true, "") if rebase should proceed, or (false, reason) if deferred.
 func (a *Agent) shouldRebaseNow(ctx context.Context, work *IssueWork) (allowed bool, reason string) {
 	// Guard: minimum interval between rebases for the same PR
-	if !work.LastRebaseTime.IsZero() && time.Since(work.LastRebaseTime) < rebaseMinInterval {
+	minInterval := a.cfg.RebaseInterval
+	if minInterval <= 0 {
+		minInterval = rebaseMinInterval // fallback default (4h)
+	}
+	if !work.LastRebaseTime.IsZero() && time.Since(work.LastRebaseTime) < minInterval {
 		a.logger.Debug("skipping rebase (minimum interval not reached)",
 			"pr", work.PRNumber,
 			"lastRebase", work.LastRebaseTime,
-			"minInterval", rebaseMinInterval)
+			"minInterval", minInterval)
 		return false, "minimum interval not reached"
 	}
 

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -37,7 +37,8 @@ type ProjectConfig struct {
 	Reactions         []string `yaml:"reactions"`
 	Label             string   `yaml:"label"`
 	OnlyAssigned      *bool    `yaml:"only-assigned"`
-	Reviewers         []string `yaml:"reviewers"` // whitelist of users/bots whose reviews to address
+	Reviewers         []string `yaml:"reviewers"`         // whitelist of users/bots whose reviews to address
+	RebaseInterval    string   `yaml:"rebase-interval"`   // e.g. "24h", "12h" — minimum time between rebases
 
 	// Role arrays
 	PRs    []PRsRoleConfig    `yaml:"prs"`
@@ -54,7 +55,8 @@ type PRsRoleConfig struct {
 	SkipFix           *bool    `yaml:"skip-fix"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
 	FlakyLabel        string   `yaml:"flaky-label"`
-	Reviewers         []string `yaml:"reviewers"` // overrides project-level reviewers
+	Reviewers         []string `yaml:"reviewers"`       // overrides project-level reviewers
+	RebaseInterval    string   `yaml:"rebase-interval"` // overrides project-level rebase-interval
 }
 
 // IssuesRoleConfig represents a single Issues role entry.
@@ -132,6 +134,19 @@ func validateFileConfig(cfg *FileConfig) error {
 		}
 	}
 
+	// Validate project-level rebase-interval
+	for i, p := range cfg.Projects {
+		if p.RebaseInterval != "" {
+			d, err := time.ParseDuration(p.RebaseInterval)
+			if err != nil {
+				return fmt.Errorf("project %d (%s): invalid rebase-interval %q: %w", i, p.Repo, p.RebaseInterval, err)
+			}
+			if d <= 0 {
+				return fmt.Errorf("project %d (%s): rebase-interval must be positive, got %q", i, p.Repo, p.RebaseInterval)
+			}
+		}
+	}
+
 	validReactions := map[string]bool{"reviews": true, "ci": true, "conflicts": true, "rebase": true}
 	validComments := map[string]bool{
 		"ci-unrelated": true, "ci-infrastructure": true, "ci-related": true,
@@ -184,6 +199,15 @@ func validateFileConfig(cfg *FileConfig) error {
 			for _, c := range pr.SkipComment {
 				if !validComments[c] {
 					return fmt.Errorf("project %d (%s): prs[%d]: invalid skip-comment %q", i, p.Repo, j, c)
+				}
+			}
+			if pr.RebaseInterval != "" {
+				d, err := time.ParseDuration(pr.RebaseInterval)
+				if err != nil {
+					return fmt.Errorf("project %d (%s): prs[%d]: invalid rebase-interval %q: %w", i, p.Repo, j, pr.RebaseInterval, err)
+				}
+				if d <= 0 {
+					return fmt.Errorf("project %d (%s): prs[%d]: rebase-interval must be positive, got %q", i, p.Repo, j, pr.RebaseInterval)
 				}
 			}
 		}
@@ -255,6 +279,19 @@ func stringsOr(s, fallback []string) []string {
 	return fallback
 }
 
+// parseDurationOr parses s as a time.Duration. If s is empty or invalid,
+// it returns the fallback value.
+func parseDurationOr(s string, fallback time.Duration) time.Duration {
+	if s == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
 // RoleEntry describes a single role goroutine to run. Built from FileConfig by
 // expanding projects and roles with two-tier inheritance applied.
 type RoleEntry struct {
@@ -304,6 +341,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		projLabel := stringOr(p.Label, "good-for-ai")
 		projOnlyAssigned := boolOr(p.OnlyAssigned, false)
 		projReviewers := stringsOr(p.Reviewers, globalCfg.Reviewers)
+		projRebaseInterval := parseDurationOr(p.RebaseInterval, 4*time.Hour)
 
 		// Base config for this project (shared fields)
 		baseCfg := Config{
@@ -353,6 +391,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg.CreateFlakyIssues = boolOr(pr.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(pr.FlakyLabel, projFlakyLabel)
 			cfg.Reviewers = stringsOr(pr.Reviewers, projReviewers)
+			cfg.RebaseInterval = parseDurationOr(pr.RebaseInterval, projRebaseInterval)
 			entries = append(entries, RoleEntry{Config: cfg, Role: "prs"})
 		}
 

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -939,3 +939,194 @@ projects:
 		t.Fatal("expected error for unknown YAML key")
 	}
 }
+
+func TestLoadFileConfig_RebaseIntervalValid(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    rebase-interval: 24h
+    prs:
+      - watch: [1]
+        rebase-interval: 8h
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fc.Projects[0].RebaseInterval != "24h" {
+		t.Errorf("expected project rebase-interval '24h', got %q", fc.Projects[0].RebaseInterval)
+	}
+	if fc.Projects[0].PRs[0].RebaseInterval != "8h" {
+		t.Errorf("expected PR rebase-interval '8h', got %q", fc.Projects[0].PRs[0].RebaseInterval)
+	}
+}
+
+func TestLoadFileConfig_RebaseIntervalInvalidProject(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    rebase-interval: not-a-duration
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid project rebase-interval")
+	}
+}
+
+func TestLoadFileConfig_RebaseIntervalNegativeProject(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    rebase-interval: "-1h"
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for negative project rebase-interval")
+	}
+}
+
+func TestLoadFileConfig_RebaseIntervalZeroProject(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    rebase-interval: "0s"
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for zero project rebase-interval")
+	}
+}
+
+func TestLoadFileConfig_RebaseIntervalNegativePR(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    prs:
+      - watch: [1]
+        rebase-interval: "-2h"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for negative PR rebase-interval")
+	}
+}
+
+func TestLoadFileConfig_RebaseIntervalInvalidPR(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    prs:
+      - watch: [1]
+        rebase-interval: bad
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid PR rebase-interval")
+	}
+}
+
+func TestBuildRoleEntries_RebaseIntervalTwoTierInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo:           "owner/repo",
+				RebaseInterval: "24h",
+				PRs: []PRsRoleConfig{
+					{
+						Watch: []int{100},
+						// Inherits project-level rebase-interval (24h)
+					},
+					{
+						Watch:          []int{200},
+						RebaseInterval: "8h", // Override project level
+					},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	// First entry: inherits project-level 24h
+	if entries[0].Config.RebaseInterval != 24*time.Hour {
+		t.Errorf("expected RebaseInterval 24h, got %v", entries[0].Config.RebaseInterval)
+	}
+	// Second entry: overrides with 8h
+	if entries[1].Config.RebaseInterval != 8*time.Hour {
+		t.Errorf("expected RebaseInterval 8h, got %v", entries[1].Config.RebaseInterval)
+	}
+}
+
+func TestBuildRoleEntries_RebaseIntervalDefault(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo: "owner/repo",
+				// No rebase-interval set
+				PRs: []PRsRoleConfig{
+					{Watch: []int{100}},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	// Default should be 4h
+	if entries[0].Config.RebaseInterval != 4*time.Hour {
+		t.Errorf("expected RebaseInterval 4h (default), got %v", entries[0].Config.RebaseInterval)
+	}
+}
+
+func TestParseDurationOr(t *testing.T) {
+	tests := []struct {
+		input    string
+		fallback time.Duration
+		want     time.Duration
+	}{
+		{"24h", 4 * time.Hour, 24 * time.Hour},
+		{"8h", 4 * time.Hour, 8 * time.Hour},
+		{"", 4 * time.Hour, 4 * time.Hour},
+		{"invalid", 4 * time.Hour, 4 * time.Hour},
+	}
+	for _, tt := range tests {
+		got := parseDurationOr(tt.input, tt.fallback)
+		if got != tt.want {
+			t.Errorf("parseDurationOr(%q, %v) = %v, want %v", tt.input, tt.fallback, got, tt.want)
+		}
+	}
+}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -4742,3 +4742,157 @@ func TestProcessRebase_ExactThresholdAllowsRebase(t *testing.T) {
 		t.Error("expected git rebase when commit count equals threshold (only >threshold defers)")
 	}
 }
+
+func TestShouldRebaseNow_ConfigurableInterval24h(t *testing.T) {
+	// RebaseInterval = 24h, last rebase 20h ago → skip (minimum interval not reached)
+	gh := &mockGitHubClient{
+		recentCommits: 0, // quiet main
+	}
+	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.RebaseInterval = 24 * time.Hour
+
+	work := &IssueWork{
+		PRNumber:       100,
+		LastRebaseTime: time.Now().Add(-20 * time.Hour), // 20h ago
+	}
+
+	allowed, reason := agent.shouldRebaseNow(context.Background(), work)
+	if allowed {
+		t.Error("expected rebase to be deferred (20h < 24h interval)")
+	}
+	if reason != "minimum interval not reached" {
+		t.Errorf("expected reason 'minimum interval not reached', got %q", reason)
+	}
+}
+
+func TestShouldRebaseNow_ConfigurableInterval24hExpired(t *testing.T) {
+	// RebaseInterval = 24h, last rebase 25h ago → allow
+	gh := &mockGitHubClient{
+		recentCommits: 0, // quiet main
+	}
+	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.RebaseInterval = 24 * time.Hour
+
+	work := &IssueWork{
+		PRNumber:       100,
+		LastRebaseTime: time.Now().Add(-25 * time.Hour), // 25h ago
+	}
+
+	allowed, _ := agent.shouldRebaseNow(context.Background(), work)
+	if !allowed {
+		t.Error("expected rebase to be allowed (25h > 24h interval)")
+	}
+}
+
+func TestShouldRebaseNow_ZeroIntervalUsesDefault(t *testing.T) {
+	// RebaseInterval = 0 (not set) → use 4h default
+	gh := &mockGitHubClient{
+		recentCommits: 0,
+	}
+	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
+	// agent.cfg.RebaseInterval is zero (default)
+
+	work := &IssueWork{
+		PRNumber:       100,
+		LastRebaseTime: time.Now().Add(-3 * time.Hour), // 3h ago, less than 4h default
+	}
+
+	allowed, reason := agent.shouldRebaseNow(context.Background(), work)
+	if allowed {
+		t.Error("expected rebase to be deferred (3h < 4h default interval)")
+	}
+	if reason != "minimum interval not reached" {
+		t.Errorf("expected reason 'minimum interval not reached', got %q", reason)
+	}
+}
+
+func TestBuildStateFromGitHub_RecoverLastRebaseTime(t *testing.T) {
+	// On restart, LastRebaseTime should be recovered from the PR head commit date.
+	headDate := time.Now().Add(-2 * time.Hour) // head commit was 2h ago
+	gh := &mockGitHubClient{
+		prs: []PR{
+			{Number: 123, Title: "Fix login", State: "open", Head: "fix-login"},
+		},
+		headCommitDate: headDate,
+	}
+
+	cfg := Config{
+		Owner:           "owner",
+		Repo:            "repo",
+		WatchPRs:        []int{123},
+		GitHubHeadOwner: "owner",
+	}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/work", slog.Default())
+
+	work := state.ActiveIssues[IssueKey("owner", "repo", 123)]
+	if work == nil {
+		t.Fatal("expected PR 123 to be tracked")
+	}
+	if work.LastRebaseTime.IsZero() {
+		t.Error("expected LastRebaseTime to be recovered from head commit date")
+	}
+	if !work.LastRebaseTime.Equal(headDate) {
+		t.Errorf("expected LastRebaseTime %v, got %v", headDate, work.LastRebaseTime)
+	}
+}
+
+func TestBuildStateFromGitHub_RecoverLastRebaseTimeIssueDiscovered(t *testing.T) {
+	// Issue-discovered PR path: LastRebaseTime should be recovered from head commit date.
+	headDate := time.Now().Add(-2 * time.Hour)
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Fix bug", Labels: []string{"good-for-ai"}}},
+		prs:    []PR{{Number: 100, State: "open", Head: "ai/issue-42"}},
+		headCommitDate: headDate,
+	}
+
+	cfg := Config{
+		Owner:           "owner",
+		Repo:            "repo",
+		Label:           "good-for-ai",
+		GitHubHeadOwner: "owner",
+	}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/work", slog.Default())
+
+	work := state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work == nil {
+		t.Fatal("expected issue 42 to be tracked")
+	}
+	if work.PRNumber != 100 {
+		t.Errorf("expected PR 100, got %d", work.PRNumber)
+	}
+	if work.LastRebaseTime.IsZero() {
+		t.Error("expected LastRebaseTime to be recovered from head commit date")
+	}
+	if !work.LastRebaseTime.Equal(headDate) {
+		t.Errorf("expected LastRebaseTime %v, got %v", headDate, work.LastRebaseTime)
+	}
+}
+
+func TestBuildStateFromGitHub_NoHeadCommitDate(t *testing.T) {
+	// On restart with no head commit date available → LastRebaseTime = zero → rebase allowed (fail-open)
+	gh := &mockGitHubClient{
+		prs: []PR{
+			{Number: 123, Title: "Fix login", State: "open", Head: "fix-login"},
+		},
+		// headCommitDate is zero value
+	}
+
+	cfg := Config{
+		Owner:           "owner",
+		Repo:            "repo",
+		WatchPRs:        []int{123},
+		GitHubHeadOwner: "owner",
+	}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/work", slog.Default())
+
+	work := state.ActiveIssues[IssueKey("owner", "repo", 123)]
+	if work == nil {
+		t.Fatal("expected PR 123 to be tracked")
+	}
+	if !work.LastRebaseTime.IsZero() {
+		t.Errorf("expected LastRebaseTime to be zero when no head commit date, got %v", work.LastRebaseTime)
+	}
+}

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -41,6 +41,23 @@ func (s *State) IsRunInvestigated(jobName, runID string) bool {
 	return s.InvestigatedRuns[key]
 }
 
+// recoverLastRebaseTime recovers LastRebaseTime from the PR head commit date as
+// an approximation. This prevents an unnecessary rebase immediately after restart.
+// Future timestamps are clamped to now to avoid deferring rebases longer than configured.
+func recoverLastRebaseTime(ctx context.Context, gh GitHubClient, cfg Config, work *IssueWork, prNumber int, logger *slog.Logger) {
+	headCommitDate, err := gh.GetPRHeadCommitDate(ctx, cfg.Owner, cfg.Repo, prNumber)
+	if err != nil {
+		logger.Warn("failed to get PR head commit date for rebase time recovery", "pr", prNumber, "error", err)
+		return
+	}
+	if !headCommitDate.IsZero() {
+		if headCommitDate.After(time.Now()) {
+			headCommitDate = time.Now()
+		}
+		work.LastRebaseTime = headCommitDate
+	}
+}
+
 // BuildStateFromGitHub reconstructs state by scanning labeled issues and their PRs.
 func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, cloneDir string, logger *slog.Logger) *State {
 	state := NewState()
@@ -82,6 +99,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 					work.PRNumber = openPR.Number
 					work.Status = StatusPROpen
 					// lastCommentID stays 0 — ProcessReviewComments uses :eyes: reaction to skip already-handled comments
+					recoverLastRebaseTime(ctx, gh, cfg, work, openPR.Number, logger)
 					logger.Info("recovered state from GitHub", "issue", issue.Number, "pr", work.PRNumber)
 				case hasMerged:
 					// PR was merged — skip to avoid reprocessing a completed issue
@@ -139,6 +157,8 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 			Status:       StatusPROpen,
 			CreatedAt:    time.Now(),
 		}
+
+		recoverLastRebaseTime(ctx, gh, cfg, work, prNumber, logger)
 
 		state.ActiveIssues[IssueKey(cfg.Owner, cfg.Repo, prNumber)] = work
 		logger.Info("recovered watched PR state", "pr", prNumber, "branch", pr.Head)

--- a/specs/config.md
+++ b/specs/config.md
@@ -21,6 +21,7 @@ type Config struct {
     CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
     SkipComments      []string // comment categories to suppress (empty = none suppressed)
     SkipChecks        []string // CI check names to ignore entirely (filtered before investigation)
+    RebaseInterval    time.Duration // minimum time between rebases (default: 4h)
 }
 ```
 
@@ -46,6 +47,32 @@ type Config struct {
 | `OOMPA_CREATE_FLAKY_ISSUES` | `--create-flaky-issues` | `false` | When true, create issues for unrelated CI failures (opt-in) |
 
 Config from env vars (`OOMPA_*`) with flag overrides, read in `main()`.
+
+## YAML File Config: `rebase-interval`
+
+The `rebase-interval` field controls the minimum time between rebases for a PR.
+It is configured via the YAML file config (not via env vars or flags).
+
+**Syntax**: Any positive Go duration string (e.g., `4h`, `24h`, `168h`).
+
+**Levels** (two-tier inheritance):
+- **Project level**: Sets the default for all PR watch groups in the project.
+- **PR role level**: Overrides the project-level default for a specific watch group.
+
+**Default**: `4h` (when not specified at either level).
+
+```yaml
+projects:
+  - repo: RedHatQE/openshift-virtualization-tests
+    rebase-interval: 24h    # project default: at most once per day
+    prs:
+      - watch: [4770]
+        reactions: [ci, conflicts, rebase]
+      - watch: [5000]
+        rebase-interval: 12h  # override: twice per day for this group
+```
+
+**Validation**: Non-positive values (zero or negative) are rejected at config load time.
 
 ## Required External Setup
 


### PR DESCRIPTION
Fixes #188

## Summary

Add configurable `rebase-interval` field to the YAML config that controls the minimum time between rebases per project and per PR watch group. Also recover `LastRebaseTime` from the PR head commit date on restart to prevent an unnecessary extra rebase after each oompa restart.

## Changes

- Add `RebaseInterval time.Duration` to `Config` struct (`pkg/agent/config.go`)
- Add `RebaseInterval string` (yaml: `rebase-interval`) to `ProjectConfig` and `PRsRoleConfig` (`pkg/agent/fileconfig.go`)
- Add `parseDurationOr` helper for parsing duration strings with fallback
- Implement two-tier inheritance in `BuildRoleEntries`: PR-level overrides project-level, project-level defaults to 4h
- Add validation for `rebase-interval` at both project and PR role levels in `validateFileConfig`
- Replace hardcoded `rebaseMinInterval` constant usage in `shouldRebaseNow` with configurable `a.cfg.RebaseInterval` (`pkg/agent/conflicts.go`)
- Recover `LastRebaseTime` from PR head commit date in `BuildStateFromGitHub` for both issue-discovered and watched PRs (`pkg/agent/state.go`)
- Update `specs/config.md` to document the new field

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

New tests added:
- `TestLoadFileConfig_RebaseIntervalValid` - valid parsing at project and PR level
- `TestLoadFileConfig_RebaseIntervalInvalidProject` - invalid duration at project level errors
- `TestLoadFileConfig_RebaseIntervalInvalidPR` - invalid duration at PR level errors
- `TestBuildRoleEntries_RebaseIntervalTwoTierInheritance` - PR-level overrides project-level
- `TestBuildRoleEntries_RebaseIntervalDefault` - defaults to 4h when unset
- `TestParseDurationOr` - helper function edge cases
- `TestShouldRebaseNow_ConfigurableInterval24h` - 24h interval, last rebase 20h ago, skips
- `TestShouldRebaseNow_ConfigurableInterval24hExpired` - 24h interval, last rebase 25h ago, allows
- `TestShouldRebaseNow_ZeroIntervalUsesDefault` - zero interval falls back to 4h default
- `TestBuildStateFromGitHub_RecoverLastRebaseTime` - recovery from head commit date on restart
- `TestBuildStateFromGitHub_NoHeadCommitDate` - fail-open when no head commit date available

## Related Issues

Fixes #188

<!-- oompa-bot v:24557b5 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable rebase interval: Set minimum time between rebases at project or per-PR role level in configuration (defaults to 4 hours).

* **Improvements**
  * Rebase timing now recovers the last rebase time from PR history on restart, enabling more accurate scheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->