### PR TITLE
fix: Slack report shows duplicate findings per PR in multi-project mode

### DIFF
--- a/pkg/agent/slack.go
+++ b/pkg/agent/slack.go
@@ -114,6 +114,21 @@ func (r *SlackReporter) Flush(ctx context.Context) {
 		return
 	}
 
+	// Deduplicate within the pending batch (multiple poll cycles may have
+	// collected the same finding before this Flush ran).
+	seen := make(map[string]bool)
+	deduped := make([]SlackFinding, 0, len(findings))
+	for _, f := range findings {
+		if f.DedupKey != "" {
+			if seen[f.DedupKey] {
+				continue
+			}
+			seen[f.DedupKey] = true
+		}
+		deduped = append(deduped, f)
+	}
+	findings = deduped
+
 	// Prune dedup map if it has grown too large to prevent unbounded memory growth.
 	if len(r.reported) > maxDedupEntries {
 		r.logger.Info("pruning Slack dedup map", "entries", len(r.reported))

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -814,3 +814,136 @@ func TestFormatSlackMessage_TruncatesAt50Blocks(t *testing.T) {
 		t.Error("expected last block to be the truncation notice")
 	}
 }
+
+func TestSlackReporter_FlushDedup_WithinBatch(t *testing.T) {
+	var mu sync.Mutex
+	var postCount int
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		postCount++
+		receivedBody = string(body)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// Simulate multiple poll cycles collecting the same findings before Flush fires.
+	// This is the exact scenario from the bug: unsynchronized timers cause 2-3 poll
+	// cycles to append identical findings to pending before the flush goroutine runs.
+	for range 3 {
+		reporter.Collect([]SlackFinding{
+			{Owner: "org", Repo: "repo", PRNumber: 8365, PRTitle: "Generate KubeVirt nmstate", PRURL: "https://github.com/org/repo/pull/8365", Category: "rebase", Message: "⚠️ PR #8365 is behind main", DedupKey: "rebase:8365"},
+			{Owner: "org", Repo: "repo", PRNumber: 8365, PRTitle: "Generate KubeVirt nmstate", PRURL: "https://github.com/org/repo/pull/8365", Category: "review", Message: "💬 PR #8365 has 1 new review comment(s)", DedupKey: "review:8365:10"},
+		})
+	}
+
+	// A single flush should produce exactly one message with each finding once
+	reporter.Flush(ctx)
+
+	mu.Lock()
+	count := postCount
+	body := receivedBody
+	mu.Unlock()
+
+	if count != 1 {
+		t.Fatalf("expected 1 POST, got %d", count)
+	}
+
+	// Verify the message contains each finding exactly once
+	rebaseCount := strings.Count(body, "behind main")
+	if rebaseCount != 1 {
+		t.Errorf("expected 1 'behind main' in message, got %d", rebaseCount)
+	}
+	reviewCount := strings.Count(body, "new review comment")
+	if reviewCount != 1 {
+		t.Errorf("expected 1 'new review comment' in message, got %d", reviewCount)
+	}
+}
+
+func TestSlackReporter_FlushDedup_DifferentFindingsSamePR(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedBody = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// Collect different findings for the same PR — all should appear (no over-dedup)
+	reporter.Collect([]SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 e2e failed", DedupKey: "ci:abc:e2e"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "rebase", Message: "⚠️ behind main", DedupKey: "rebase:100"},
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "review", Message: "💬 2 new review comments", DedupKey: "review:100:5"},
+	})
+
+	reporter.Flush(ctx)
+
+	mu.Lock()
+	body := receivedBody
+	mu.Unlock()
+
+	if !strings.Contains(body, "e2e failed") {
+		t.Error("expected 'e2e failed' in message")
+	}
+	if !strings.Contains(body, "behind main") {
+		t.Error("expected 'behind main' in message")
+	}
+	if !strings.Contains(body, "new review comments") {
+		t.Error("expected 'new review comments' in message")
+	}
+}
+
+func TestSlackReporter_FlushDedup_EmptyDedupKeyNotDeduped(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedBody = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := NewSlackReporter(ts.URL, logger)
+	reporter.httpClient = ts.Client()
+
+	ctx := context.Background()
+
+	// Findings without a DedupKey should always be included, even if identical
+	for range 3 {
+		reporter.Collect([]SlackFinding{
+			{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", PRURL: "https://github.com/org/repo/pull/100", Category: "error", Message: "⚠️ transient error", DedupKey: ""},
+		})
+	}
+
+	reporter.Flush(ctx)
+
+	mu.Lock()
+	body := receivedBody
+	mu.Unlock()
+
+	// All 3 should appear (empty DedupKey is never deduplicated)
+	errorCount := strings.Count(body, "transient error")
+	if errorCount != 3 {
+		t.Errorf("expected 3 'transient error' in message (empty DedupKey), got %d", errorCount)
+	}
+}

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -281,12 +281,12 @@ func extractFailureSignature(analysis string) string {
 
 // extractSection extracts the first paragraph of content under a markdown heading.
 func extractSection(text, heading string) string {
-	idx := strings.Index(text, heading)
-	if idx < 0 {
+	_, after, ok := strings.Cut(text, heading)
+	if !ok {
 		return ""
 	}
 	// Skip the heading line itself
-	rest := text[idx+len(heading):]
+	rest := after
 	if newline := strings.IndexByte(rest, '\n'); newline >= 0 {
 		rest = rest[newline+1:]
 	} else {


### PR DESCRIPTION
Fixes #195

## Summary

Fix duplicate findings in Slack reports when running in multi-project mode. Multiple poll cycles could append identical findings to the pending buffer before Flush ran, causing the same finding to appear 2-3 times per PR in the Slack message.

## Changes

- Add within-batch deduplication in `SlackReporter.Flush()` after draining `pending` and before the existing `r.reported` cross-flush dedup check. Findings with the same `DedupKey` within a single batch are collapsed to one entry; findings with empty `DedupKey` are never deduplicated.
- Add three new tests covering the within-batch dedup scenarios: duplicate findings from multiple poll cycles, different findings for the same PR (no over-dedup), and empty `DedupKey` findings always included.

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #195

<!-- oompa-bot v:280de76 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication of findings in Slack reports to prevent duplicate notifications when identical findings are collected within a single batch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->