### PR TITLE
feat: include build version in Slack report header

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -500,7 +500,7 @@ func buildAgentForConfig(cfg agent.Config, ghClient *agent.GoGitHubClient, token
 		a.SetSlackReporter(sharedSlack[0])
 		logger.Info("Slack reporting enabled (shared reporter)")
 	} else if cfg.SlackWebhookURL != "" {
-		slack := agent.NewSlackReporter(cfg.SlackWebhookURL, logger)
+		slack := agent.NewSlackReporter(cfg.SlackWebhookURL, cfg.Version, logger)
 		a.SetSlackReporter(slack)
 		logger.Info("Slack reporting enabled")
 	}
@@ -682,7 +682,7 @@ func runMultiProject(globalCfg agent.Config, configPath string, ghClient *agent.
 	// goroutine flushes them periodically as a single consolidated message.
 	var sharedSlack *agent.SlackReporter
 	if globalCfg.SlackWebhookURL != "" {
-		sharedSlack = agent.NewSlackReporter(globalCfg.SlackWebhookURL, logger)
+		sharedSlack = agent.NewSlackReporter(globalCfg.SlackWebhookURL, globalCfg.Version, logger)
 		logger.Info("Slack consolidated reporting enabled")
 	}
 

--- a/pkg/agent/slack.go
+++ b/pkg/agent/slack.go
@@ -52,6 +52,7 @@ type SlackFinding struct {
 // Zero external dependencies — uses only Go stdlib net/http + encoding/json.
 type SlackReporter struct {
 	webhookURL string
+	version    string          // build version (short commit SHA) included in report header
 	reported   map[string]bool // tracks DedupKeys already reported
 	logger     *slog.Logger
 	httpClient *http.Client // injectable for testing
@@ -62,13 +63,15 @@ type SlackReporter struct {
 }
 
 // NewSlackReporter creates a new reporter. If webhookURL is empty, IsEnabled() returns false.
-// A nil logger defaults to slog.Default().
-func NewSlackReporter(webhookURL string, logger *slog.Logger) *SlackReporter {
+// A nil logger defaults to slog.Default(). The version string (typically a short commit SHA)
+// is included in the Slack report header to identify which build generated the report.
+func NewSlackReporter(webhookURL, version string, logger *slog.Logger) *SlackReporter {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &SlackReporter{
 		webhookURL: webhookURL,
+		version:    version,
 		reported:   make(map[string]bool),
 		logger:     logger,
 		httpClient: &http.Client{Timeout: slackRequestTimeout},
@@ -147,7 +150,7 @@ func (r *SlackReporter) Flush(ctx context.Context) {
 		return
 	}
 
-	body := formatSlackMessage(newFindings)
+	body := formatSlackMessage(newFindings, r.version)
 	if body == nil {
 		return
 	}
@@ -201,11 +204,12 @@ func projectKey(owner, repo string) string {
 }
 
 // formatSlackMessage builds a Slack Block Kit JSON payload grouped by project and then by PR.
-// Returns nil if there are no findings.
+// Returns nil if there are no findings. The version string (short commit SHA) is included
+// in the header when non-empty.
 //
 // Format:
 //
-//	🏭 oompa report — N projects with activity
+//	🏭 oompa report (38767d1) — N project(s) with activity
 //
 //	*<repo-link|owner/repo>* (M PRs)
 //	📋 <pr-link|PR #N> — title
@@ -213,7 +217,7 @@ func projectKey(owner, repo string) string {
 //	  ⚠️ behind main
 //
 // Each project gets a header section + detail section + divider.
-func formatSlackMessage(findings []SlackFinding) []byte {
+func formatSlackMessage(findings []SlackFinding, version string) []byte {
 	if len(findings) == 0 {
 		return nil
 	}
@@ -275,7 +279,12 @@ func formatSlackMessage(findings []SlackFinding) []byte {
 	var blocks []slackBlock
 
 	// Header block
-	headerText := fmt.Sprintf("🏭 oompa report — %d project(s) with activity", len(projects))
+	var headerText string
+	if version != "" {
+		headerText = fmt.Sprintf("🏭 oompa report (%s) — %d project(s) with activity", shortSHA(version), len(projects))
+	} else {
+		headerText = fmt.Sprintf("🏭 oompa report — %d project(s) with activity", len(projects))
+	}
 	blocks = append(blocks, slackBlock{
 		Type: "header",
 		Text: &slackText{

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -20,7 +20,7 @@ func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix flaky test", PRURL: "https://github.com/org/repo/pull/100", Category: "rebase", Message: "⚠️ 15 commits behind main"},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -79,13 +79,65 @@ func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
 	}
 }
 
+func TestFormatSlackMessage_IncludesVersion(t *testing.T) {
+	findings := []SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 failed"},
+	}
+
+	body := formatSlackMessage(findings, "38767d1abc123")
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Header should include the short SHA (7 chars)
+	headerText := msg.Blocks[0].Text.Text
+	if !strings.Contains(headerText, "(38767d1)") {
+		t.Errorf("expected header to contain short SHA (38767d1), got: %s", headerText)
+	}
+
+	// Also verify the full format
+	if !strings.Contains(headerText, "oompa report (38767d1)") {
+		t.Errorf("expected header format 'oompa report (38767d1)', got: %s", headerText)
+	}
+}
+
+func TestFormatSlackMessage_EmptyVersionOmitted(t *testing.T) {
+	findings := []SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 failed"},
+	}
+
+	body := formatSlackMessage(findings, "")
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+
+	var msg slackMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Header should NOT contain parentheses when version is empty
+	headerText := msg.Blocks[0].Text.Text
+	if strings.Contains(headerText, "()") {
+		t.Errorf("expected no empty parens in header, got: %s", headerText)
+	}
+	if !strings.Contains(headerText, "oompa report —") {
+		t.Errorf("expected plain header without version, got: %s", headerText)
+	}
+}
+
 func TestFormatSlackMessage_EmptyFindings(t *testing.T) {
-	body := formatSlackMessage(nil)
+	body := formatSlackMessage(nil, "")
 	if body != nil {
 		t.Error("expected nil body for empty findings")
 	}
 
-	body = formatSlackMessage([]SlackFinding{})
+	body = formatSlackMessage([]SlackFinding{}, "")
 	if body != nil {
 		t.Error("expected nil body for empty slice")
 	}
@@ -98,7 +150,7 @@ func TestFormatSlackMessage_MultipleProjects(t *testing.T) {
 		{Owner: "org1", Repo: "repo1", PRNumber: 101, PRTitle: "Fix lint", PRURL: "https://github.com/org1/repo1/pull/101", Category: "rebase", Message: "⚠️ behind main"},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -147,7 +199,7 @@ func TestFormatSlackMessage_SingleProjectNoFindings(t *testing.T) {
 		{Owner: "org", Repo: "active", PRNumber: 1, PRTitle: "Work", PRURL: "https://github.com/org/active/pull/1", Category: "ci", Message: "🔴 failed"},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -167,7 +219,7 @@ func TestFormatSlackMessage_LinksCorrect(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 42, PRTitle: "Test PR", PRURL: "https://github.com/org/repo/pull/42", Category: "ci", Message: "🔴 <https://ci.example.com/job/1|e2e-test> failed"},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -196,7 +248,7 @@ func TestFormatSlackMessage_HasDividersBetweenProjects(t *testing.T) {
 		{Owner: "org2", Repo: "repo2", PRNumber: 2, PRTitle: "PR2", PRURL: "https://github.com/org2/repo2/pull/2", Category: "ci", Message: "🔴 failed"},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -232,7 +284,7 @@ func TestSlackReporter_Dedup(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	findings := []SlackFinding{
@@ -263,7 +315,7 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -287,7 +339,7 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 
 func TestSlackReporter_Disabled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter("", logger)
+	reporter := NewSlackReporter("", "", logger)
 
 	if reporter.IsEnabled() {
 		t.Error("expected IsEnabled() to be false with empty webhook URL")
@@ -557,7 +609,7 @@ func TestSlackReporter_EmptyDedupKey(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -599,7 +651,7 @@ func TestSlackReporter_CollectAndFlush(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -646,7 +698,7 @@ func TestSlackReporter_CollectConcurrent(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	// Simulate concurrent collection from multiple goroutines
@@ -684,7 +736,7 @@ func TestSlackReporter_FlushDedup(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -724,7 +776,7 @@ func TestFormatSlackMessage_BlockTextLimit(t *testing.T) {
 		})
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -750,7 +802,7 @@ func TestFormatSlackMessage_BlockTextLimit_SingleLongLine(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 1, PRTitle: "Long", PRURL: "https://github.com/org/repo/pull/1", Category: "ci", Message: longMsg},
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -794,7 +846,7 @@ func TestFormatSlackMessage_TruncatesAt50Blocks(t *testing.T) {
 		})
 	}
 
-	body := formatSlackMessage(findings)
+	body := formatSlackMessage(findings, "")
 	if body == nil {
 		t.Fatal("expected non-nil body")
 	}
@@ -830,7 +882,7 @@ func TestSlackReporter_FlushDedup_WithinBatch(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -881,7 +933,7 @@ func TestSlackReporter_FlushDedup_DifferentFindingsSamePR(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()
@@ -923,7 +975,7 @@ func TestSlackReporter_FlushDedup_EmptyDedupKeyNotDeduped(t *testing.T) {
 	defer ts.Close()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, logger)
+	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
 	ctx := context.Background()

--- a/specs/slack.md
+++ b/specs/slack.md
@@ -36,6 +36,7 @@ type SlackFinding struct {
 
 type SlackReporter struct {
     webhookURL string
+    version    string          // build version (short commit SHA) included in report header
     reported   map[string]bool // tracks DedupKeys already reported
     logger     *slog.Logger
     httpClient *http.Client    // injectable for testing
@@ -47,12 +48,12 @@ type SlackReporter struct {
 
 ## SlackReporter Methods
 
-- `NewSlackReporter(webhookURL string, logger *slog.Logger) *SlackReporter`
+- `NewSlackReporter(webhookURL string, version string, logger *slog.Logger) *SlackReporter`
 - `(r *SlackReporter) IsEnabled() bool` — returns true if webhookURL is non-empty
 - `(r *SlackReporter) Collect(findings []SlackFinding)` — thread-safe append to pending buffer
 - `(r *SlackReporter) Flush(ctx context.Context)` — dedup, format, POST, clear pending
 - `(r *SlackReporter) Report(ctx context.Context, findings []SlackFinding)` — convenience: Collect + Flush in one call (single-repo mode)
-- `formatSlackMessage(findings []SlackFinding) []byte` — builds Slack Block Kit JSON grouped by project then PR
+- `formatSlackMessage(findings []SlackFinding, version string) []byte` — builds Slack Block Kit JSON grouped by project then PR; includes short SHA in header when version is non-empty
 - `postToSlack(ctx context.Context, client *http.Client, webhookURL string, body []byte) error` — HTTP POST
 
 ## Collection Architecture
@@ -111,7 +112,7 @@ Each `runLoop` call collects findings and flushes immediately at the end of the 
 Slack Block Kit with header + per-project sections. One consolidated message per cycle, grouped by project then by PR:
 
 ```text
-🏭 oompa report — 3 project(s) with activity
+🏭 oompa report (38767d1) — 3 project(s) with activity
 
 *<repo-link|owner1/repo1>* (2 PRs)
 📋 <pr-link|PR #100> — Fix kubevirt test flake
@@ -129,7 +130,7 @@ Slack Block Kit with header + per-project sections. One consolidated message per
 
 ### Block structure
 
-1. `header` block — "🏭 oompa report — N project(s) with activity"
+1. `header` block — "🏭 oompa report (SHORT_SHA) — N project(s) with activity" (version omitted when empty)
 2. Per project:
    - `section` block (mrkdwn) — project name with link and PR count
    - `section` block (mrkdwn) — PR details with findings (split if >3000 chars)


### PR DESCRIPTION
Fixes #194

## Summary

Include the build version (short commit SHA) in the Slack report header so operators can confirm which oompa build generated a report, especially useful after version updates.

## Changes

- Add `version` field to `SlackReporter` struct and `NewSlackReporter` constructor
- Update `formatSlackMessage` to accept a version parameter and include it in the header when non-empty
- Pass `cfg.Version` (commit SHA) when creating `SlackReporter` in both single-repo and multi-project modes
- Add tests for version inclusion and empty-version omission in the header
- Update `specs/slack.md` to reflect the new signatures and header format

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests verify version appears in header as short SHA
- [x] New tests verify empty version produces original header format (no empty parens)

## Related Issues

Fixes #194

<!-- oompa-bot v:ea35db2 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack reports now include version information (commit SHA) in the message header, helping track which build generated each report.

* **Documentation**
  * Updated Slack reporting documentation to reflect version inclusion in messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->