### PR TITLE
fix: TUI shows 'Scanning for new issues' while agent is actively working on an issue

### DIFF
--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -144,6 +144,48 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 
 	// Sequential phase: run Claude, push, create PR
 	runSequential(ctx, tasks, func(ctx context.Context, task newIssueTask) {
+		var success bool
+		defer func() {
+			if !success {
+				a.emit(Event{
+					Type:     EventAgentCompleted,
+					Category: CategoryAgent,
+					Worker:   a.workerName(),
+					State:    "idle",
+					Action:   fmt.Sprintf("Agent failed implementing issue #%d", task.issue.Number),
+				})
+				a.emit(Event{
+					Type:     EventActionCompleted,
+					Category: CategoryIssue,
+					Worker:   a.workerName(),
+					State:    "idle",
+					Action:   fmt.Sprintf("Failed to process issue #%d", task.issue.Number),
+				})
+			} else {
+				a.emit(Event{
+					Type:     EventAgentCompleted,
+					Category: CategoryAgent,
+					Worker:   a.workerName(),
+					State:    "idle",
+					Action:   fmt.Sprintf("Agent finished implementing issue #%d", task.issue.Number),
+				})
+			}
+		}()
+
+		a.emit(Event{
+			Type:     EventActionStarted,
+			Category: CategoryIssue,
+			Worker:   a.workerName(),
+			State:    "working",
+			Action:   fmt.Sprintf("Working on issue #%d: %s", task.issue.Number, task.issue.Title),
+		})
+		a.emit(Event{
+			Type:     EventAgentInvocation,
+			Category: CategoryAgent,
+			Worker:   a.workerName(),
+			State:    "working",
+			Action:   fmt.Sprintf("Agent implementing issue #%d", task.issue.Number),
+		})
 		prompt := buildImplementationPrompt(task.issue, a.cfg.SignedOffBy)
 		_, err := a.codeAgent.Run(ctx, a.runner, task.worktreePath, prompt, a.logger, false)
 		if err != nil {
@@ -193,6 +235,15 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		task.work.PRNumber = prNumber
 		task.work.Status = StatusPROpen
 		a.logger.Info("created PR", "issue", task.issue.Number, "pr", prNumber)
+		a.emit(Event{
+			Type:      EventActionCompleted,
+			Category:  CategoryIssue,
+			Worker:    a.workerName(),
+			State:     "idle",
+			Action:    fmt.Sprintf("Created PR #%d for issue #%d", prNumber, task.issue.Number),
+			PRNumbers: []int{prNumber},
+		})
+		success = true
 
 		_ = a.gh.UnassignIssue(ctx, a.cfg.Owner, a.cfg.Repo, task.issue.Number, a.cfg.GitHubUser)
 	})

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -510,6 +510,53 @@ func (r *recordingEmitter) Emit(event Event) {
 	r.events = append(r.events, event)
 }
 
+func TestProcessNewIssues_EmitsIssueAndAgentEvents(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	emitter := &recordingEmitter{}
+	agent.SetEmitter(emitter)
+
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify issue-category event emitted when processing starts
+	var foundIssueWorking, foundAgentInvocation, foundPRCreated, foundAgentCompleted bool
+	for _, e := range emitter.events {
+		if e.Category == CategoryIssue && e.State == "working" && strings.Contains(e.Action, "Working on issue #42") {
+			foundIssueWorking = true
+		}
+		if e.Category == CategoryAgent && e.State == "working" && strings.Contains(e.Action, "Agent implementing issue #42") {
+			foundAgentInvocation = true
+		}
+		if e.Category == CategoryIssue && e.State == "idle" && strings.Contains(e.Action, "Created PR #100 for issue #42") {
+			foundPRCreated = true
+			if len(e.PRNumbers) != 1 || e.PRNumbers[0] != 100 {
+				t.Errorf("expected PRNumbers [100], got %v", e.PRNumbers)
+			}
+		}
+		if e.Category == CategoryAgent && e.State == "idle" && strings.Contains(e.Action, "Agent finished implementing issue #42") {
+			foundAgentCompleted = true
+		}
+	}
+	if !foundIssueWorking {
+		t.Error("expected CategoryIssue event with state 'working' when issue processing starts")
+	}
+	if !foundAgentInvocation {
+		t.Error("expected CategoryAgent event with state 'working' when agent starts running")
+	}
+	if !foundPRCreated {
+		t.Error("expected CategoryIssue event with state 'idle' when PR is created")
+	}
+	if !foundAgentCompleted {
+		t.Error("expected CategoryAgent event with state 'idle' when agent finishes implementing")
+	}
+}
+
 func TestProcessReviewComments_NoNewComments(t *testing.T) {
 	gh := &mockGitHubClient{}
 	runner := &mockCommandRunner{}


### PR DESCRIPTION
Fixes #198

## Summary

Emit issue/agent category events during `ProcessNewIssues()` so the TUI shows meaningful state instead of staying stuck on "Scanning for new issues" while the agent is actively working.

## Changes

- Emit `CategoryIssue` event with state `working` when an issue is found and processing starts (e.g. "Working on issue #42: Fix bug")
- Emit `CategoryAgent` event with state `working` when the code agent begins implementing (e.g. "Agent implementing issue #42")
- Emit `CategoryIssue` event with state `idle` when a PR is created (e.g. "Created PR #100 for issue #42")
- Add `TestProcessNewIssues_EmitsIssueAndAgentEvents` verifying all three events are emitted during the happy path

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #198

<!-- oompa-bot v:ea35db2 -->