### PR TITLE
fix: CI dedup relies solely on comment markers, re-investigates when comments are deleted

### DIFF
--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -333,9 +333,13 @@ func (a *Agent) classifyCIInfrastructure(_ context.Context, task ciTask, cleaned
 	idx := strings.Index(cleaned, "INFRASTRUCTURE")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "INFRASTRUCTURE"), " :—–-"))
 
+	// Always mark as checked in memory to prevent re-investigation on next poll.
+	// Comment markers serve as a secondary dedup mechanism but can be lost
+	// (e.g. if comments are deleted), so in-memory state is the primary guard.
+	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
+
 	if a.ShouldSkipComment("ci-infrastructure") {
 		a.logger.Info("skipping CI infrastructure comment (--skip-comment)", "pr", task.work.PRNumber)
-		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 	}
 
 	task.work.LastCIStatus = "infrastructure-failure"
@@ -371,9 +375,13 @@ func (a *Agent) classifyCIUnrelated(ctx context.Context, task ciTask, cleaned st
 	idx := strings.Index(cleaned, "UNRELATED")
 	explanation := strings.TrimSpace(strings.TrimLeft(strings.TrimPrefix(cleaned[idx:], "UNRELATED"), " :—–-"))
 
+	// Always mark as checked in memory to prevent re-investigation on next poll.
+	// Comment markers serve as a secondary dedup mechanism but can be lost
+	// (e.g. if comments are deleted), so in-memory state is the primary guard.
+	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
+
 	if a.ShouldSkipComment("ci-unrelated") {
 		a.logger.Info("skipping CI unrelated comment (--skip-comment)", "pr", task.work.PRNumber)
-		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 	}
 
 	task.work.LastCIStatus = "unrelated-failure"
@@ -669,9 +677,10 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 	if a.cfg.SkipFix {
 		// Skip-fix mode: just record the analysis, don't try to fix or push
 		a.logger.Info("CI failure is related (skip-fix mode, not pushing)", "pr", task.work.PRNumber)
+		// Always mark as checked in memory to prevent re-investigation on next poll.
+		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 		if a.ShouldSkipComment("ci-related") {
 			a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
-			a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 		}
 		task.work.LastCIStatus = "related-skip-fix"
 		task.work.LastCheckedCISHA = task.headSHA
@@ -742,9 +751,13 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 		a.logger.Warn("Claude said RELATED but no changes to push", "pr", task.work.PRNumber)
 	}
 
+	// Always mark as checked in memory to prevent re-investigation on next poll.
+	// Comment markers serve as a secondary dedup mechanism but can be lost
+	// (e.g. if comments are deleted), so in-memory state is the primary guard.
+	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
+
 	if a.ShouldSkipComment("ci-related") {
 		a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
-		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 	}
 
 	task.work.CIFixAttempts++

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -786,6 +786,14 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 		{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "test failed: expected 1 got 2"},
 	})
 
+	// Simulate push updating the PR's head SHA on each Claude invocation.
+	// In production, each fix push changes the HEAD SHA, so the in-memory
+	// dedup (keyed by SHA+check) allows re-investigation on the new SHA.
+	prNum := work.PRNumber
+	runner.onClaudeRun = func() {
+		gh.simulatePush(prNum)
+	}
+
 	// First fix attempt
 	agent.ProcessCIFailures(ctx)
 	if agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts != 1 {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -1821,6 +1821,87 @@ func TestProcessCIFailures_SkipCommentCIInfrastructure(t *testing.T) {
 	}
 }
 
+// TestProcessCIFailures_CheckedCIChecksPopulatedWhenCommentsPosted verifies that
+// the in-memory CheckedCIChecks map is populated even when comments are posted
+// (the default, non-skip path). This is the primary dedup mechanism; comment
+// markers are a secondary fallback that can be lost if comments are deleted.
+func TestProcessCIFailures_CheckedCIChecksPopulatedWhenCommentsPosted(t *testing.T) {
+	// Test all three classification categories
+	tests := []struct {
+		name           string
+		claudeResponse string
+		checkName      string
+		wantCIStatus   string
+	}{
+		{
+			name:           "infrastructure",
+			claudeResponse: "INFRASTRUCTURE Fedora koji server returned HTTP 502 Bad Gateway",
+			checkName:      "Build-PR",
+			wantCIStatus:   "infrastructure-failure",
+		},
+		{
+			name:           "unrelated",
+			claudeResponse: "UNRELATED The test database connection times out intermittently",
+			checkName:      "integration-tests",
+			wantCIStatus:   "unrelated-failure",
+		},
+		{
+			name:           "related-skip-fix",
+			claudeResponse: "RELATED The unit test fails because the new function returns nil",
+			checkName:      "unit-tests",
+			wantCIStatus:   "related-skip-fix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claudeResult := streamResultJSON(AgentResult{Result: tt.claudeResponse})
+			gh := &mockGitHubClient{
+				checkRuns: []CheckRun{
+					{ID: 1, Name: tt.checkName, Status: "completed", Conclusion: "failure", Output: "Error details here for analysis context padding to reach the 50 char minimum threshold"},
+				},
+				checkRunLogs: map[int64]string{
+					1: "Build log output with enough content for analysis context padding to reach minimum",
+				},
+			}
+			runner := &mockCommandRunner{stdout: claudeResult}
+			wt := &mockWorktreeManager{}
+
+			agent := newTestAgent(gh, runner, wt)
+			agent.cfg.SkipFix = true // Prevent push attempts for RELATED
+			// SkipComments is empty — comments will be posted (default behavior)
+			agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+				IssueNumber:  42,
+				IssueTitle:   "Fix bug",
+				PRNumber:     100,
+				BranchName:   "ai/issue-42",
+				Status:       "pr-open",
+				WorktreePath: "/tmp/worktree",
+			}
+
+			agent.ProcessCIFailures(context.Background())
+
+			work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+
+			// Verify in-memory dedup map is populated even though comments are posted
+			dedupKey := "abc123:" + tt.checkName
+			if !work.CheckedCIChecks[dedupKey] {
+				t.Errorf("expected CheckedCIChecks[%q] to be true when comments are posted (not skipped), but it was false", dedupKey)
+			}
+
+			// Verify status was set correctly
+			if work.LastCIStatus != tt.wantCIStatus {
+				t.Errorf("expected LastCIStatus %q, got %q", tt.wantCIStatus, work.LastCIStatus)
+			}
+
+			// Verify a comment was actually posted (confirming we're testing the non-skip path)
+			if len(gh.addedComments) == 0 {
+				t.Error("expected at least 1 comment to be posted (testing non-skip path), got 0")
+			}
+		})
+	}
+}
+
 func TestProcessCIFailures_SkipCommentFlaky(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "UNRELATED The test database connection times out intermittently"})
 	gh := &mockGitHubClient{


### PR DESCRIPTION
Fixes #200

## Summary

Fix CI dedup to always populate the in-memory `CheckedCIChecks` map, making it the primary dedup mechanism instead of relying solely on comment markers that can be lost if comments are deleted.

## Changes

- Move `markCIChecked()` calls outside `ShouldSkipComment` conditionals in `classifyCIInfrastructure`, `classifyCIUnrelated`, and `classifyCIRelated` (both skip-fix and normal paths) so the in-memory dedup map is always populated regardless of whether comments are posted
- Update integration test `TestIntegration_CIFailureFixAndRetryLimit` to simulate SHA changes on push (matching production behavior where each fix push changes the HEAD SHA)
- Add `TestProcessCIFailures_CheckedCIChecksPopulatedWhenCommentsPosted` covering all three classification categories (infrastructure, unrelated, related) to verify in-memory dedup works when comments are posted

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #200

<!-- oompa-bot v:ea35db2 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure CI checks are always recorded for deduplication across infrastructure, unrelated, and related classifications, regardless of whether comment posting is skipped.

* **Tests**
  * Simulate evolving PR head SHAs during CI retry flows for more realistic retries.
  * Added table-driven tests verifying deduplication tracking and status updates across CI classification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->