### PR TITLE
fix: Slack reports stale findings every cycle (e.g. 'new review comment' that isn't new)

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -128,6 +128,7 @@ func (g *GoGitHubClient) GetPRReviewComments(ctx context.Context, owner, repo st
 				Body:        c.GetBody(),
 				Path:        c.GetPath(),
 				Line:        c.GetLine(),
+				CreatedAt:   c.GetCreatedAt().Time,
 			})
 		}
 		if resp.NextPage == 0 {
@@ -278,13 +279,18 @@ func (g *GoGitHubClient) GetCheckRuns(ctx context.Context, owner, repo, ref stri
 				output = r.Output.GetSummary()
 			}
 		}
+		var completedAt time.Time
+		if t := r.GetCompletedAt(); !t.IsZero() {
+			completedAt = t.Time
+		}
 		runs = append(runs, CheckRun{
-			ID:         r.GetID(),
-			Name:       r.GetName(),
-			Status:     r.GetStatus(),
-			Conclusion: r.GetConclusion(),
-			Output:     output,
-			HTMLURL:    r.GetHTMLURL(),
+			ID:          r.GetID(),
+			Name:        r.GetName(),
+			Status:      r.GetStatus(),
+			Conclusion:  r.GetConclusion(),
+			Output:      output,
+			HTMLURL:     r.GetHTMLURL(),
+			CompletedAt: completedAt,
 		})
 	}
 	return runs, nil

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -191,11 +191,19 @@ func (a *Agent) FlushSlackReport(ctx context.Context) {
 
 // RunReportOnlyChecks runs lightweight check methods for reactions NOT in the active
 // reactions list and returns findings. Only called when Slack reporting is enabled.
+// Uses LastReportedAt from the SlackReporter to filter out stale findings that
+// were already reported in a previous cycle.
 func (a *Agent) RunReportOnlyChecks(ctx context.Context) []SlackFinding {
 	var findings []SlackFinding
 
+	// Get the last reported timestamp to filter stale findings.
+	var lastReportedAt time.Time
+	if a.slack != nil {
+		lastReportedAt = a.slack.LastReportedAt()
+	}
+
 	if a.ShouldCheckReaction("ci") {
-		findings = append(findings, a.CheckCIStatus(ctx)...)
+		findings = append(findings, a.CheckCIStatus(ctx, lastReportedAt)...)
 	}
 
 	// Prefetch mergeable states once when both conflict and rebase checks are needed,
@@ -213,7 +221,7 @@ func (a *Agent) RunReportOnlyChecks(ctx context.Context) []SlackFinding {
 	}
 
 	if a.ShouldCheckReaction("reviews") {
-		findings = append(findings, a.CheckNewReviews(ctx)...)
+		findings = append(findings, a.CheckNewReviews(ctx, lastReportedAt)...)
 	}
 
 	return findings
@@ -559,7 +567,8 @@ func isUnstagedChangesError(stderr string) bool {
 
 // CheckCIStatus is a lightweight report-only check that fetches CI check runs
 // and returns findings for any failures. No agent invocation, no fixes.
-func (a *Agent) CheckCIStatus(ctx context.Context) []SlackFinding {
+// Only reports failures that completed after lastReportedAt to avoid stale reports.
+func (a *Agent) CheckCIStatus(ctx context.Context, lastReportedAt time.Time) []SlackFinding {
 	var findings []SlackFinding
 
 	for _, work := range a.state.ActiveIssues {
@@ -584,6 +593,10 @@ func (a *Agent) CheckCIStatus(ctx context.Context) []SlackFinding {
 				continue
 			}
 			if r.Status == "completed" && r.Conclusion == "failure" {
+				// Skip failures that completed before the last report to avoid stale reports
+				if !lastReportedAt.IsZero() && !r.CompletedAt.IsZero() && !r.CompletedAt.After(lastReportedAt) {
+					continue
+				}
 				link := r.HTMLURL
 				if link == "" {
 					link = fmt.Sprintf("https://github.com/%s/%s/commit/%s/checks", a.cfg.Owner, a.cfg.Repo, headSHA)
@@ -705,7 +718,8 @@ func (a *Agent) checkConflictsWithStates(_ context.Context, states map[int]strin
 
 // CheckNewReviews is a lightweight report-only check that counts new review comments
 // and returns findings when new comments exist.
-func (a *Agent) CheckNewReviews(ctx context.Context) []SlackFinding {
+// Only reports comments created after lastReportedAt to avoid stale reports.
+func (a *Agent) CheckNewReviews(ctx context.Context, lastReportedAt time.Time) []SlackFinding {
 	var findings []SlackFinding
 
 	for _, work := range a.state.ActiveIssues {
@@ -719,8 +733,8 @@ func (a *Agent) CheckNewReviews(ctx context.Context) []SlackFinding {
 			continue
 		}
 
-		// Filter out bot comments, replies, and non-whitelisted reviewers
-		// (same filtering as ProcessReviewComments to avoid noise)
+		// Filter out bot comments, replies, non-whitelisted reviewers, and
+		// comments created before the last report to avoid stale reports.
 		var humanComments []ReviewComment
 		for _, c := range comments {
 			if c.InReplyToID != 0 {
@@ -730,6 +744,10 @@ func (a *Agent) CheckNewReviews(ctx context.Context) []SlackFinding {
 				continue
 			}
 			if !a.isAllowedReviewer(c.User) {
+				continue
+			}
+			// Skip comments created before the last report
+			if !lastReportedAt.IsZero() && !c.CreatedAt.IsZero() && !c.CreatedAt.After(lastReportedAt) {
 				continue
 			}
 			humanComments = append(humanComments, c)

--- a/pkg/agent/slack.go
+++ b/pkg/agent/slack.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -32,6 +35,12 @@ const (
 	// maxSlackBlocks is the maximum number of blocks Slack accepts per message.
 	// Messages exceeding this limit are rejected by the API.
 	maxSlackBlocks = 50
+
+	// lastReportAtFile is the filename (under stateDir) where the last successful
+	// Slack report timestamp is persisted. Follows XDG Base Directory spec for
+	// state data: ~/.local/state/oompa/last-report-at
+	lastReportAtFile = "last-report-at"
+	defaultStateDir  = ".local/state/oompa"
 )
 
 // SlackFinding represents a single reportable finding from a poll cycle.
@@ -51,11 +60,13 @@ type SlackFinding struct {
 // Slack message. Thread-safe: multiple agent goroutines can call Collect concurrently.
 // Zero external dependencies — uses only Go stdlib net/http + encoding/json.
 type SlackReporter struct {
-	webhookURL string
-	version    string          // build version (short commit SHA) included in report header
-	reported   map[string]bool // tracks DedupKeys already reported
-	logger     *slog.Logger
-	httpClient *http.Client // injectable for testing
+	webhookURL     string
+	version        string          // build version (short commit SHA) included in report header
+	reported       map[string]bool // tracks DedupKeys already reported
+	logger         *slog.Logger
+	httpClient     *http.Client // injectable for testing
+	lastReportedAt time.Time    // when findings were last successfully flushed to Slack
+	stateFilePath  string       // path to the persisted last-report-at file
 
 	flushMu  sync.Mutex     // serializes Flush calls (protects reported map)
 	mu       sync.Mutex     // protects pending
@@ -65,16 +76,108 @@ type SlackReporter struct {
 // NewSlackReporter creates a new reporter. If webhookURL is empty, IsEnabled() returns false.
 // A nil logger defaults to slog.Default(). The version string (typically a short commit SHA)
 // is included in the Slack report header to identify which build generated the report.
+//
+// On construction, reads ~/.local/state/oompa/last-report-at to restore LastReportedAt
+// across restarts. If the file is missing or unparseable, falls back to time.Now()
+// (first cycle is silent baseline, subsequent cycles report changes).
 func NewSlackReporter(webhookURL, version string, logger *slog.Logger) *SlackReporter {
 	if logger == nil {
 		logger = slog.Default()
 	}
+
+	stateFilePath := defaultLastReportAtPath(webhookURL)
+	lastReportedAt := loadLastReportedAt(stateFilePath, logger)
+
 	return &SlackReporter{
-		webhookURL: webhookURL,
-		version:    version,
-		reported:   make(map[string]bool),
-		logger:     logger,
-		httpClient: &http.Client{Timeout: slackRequestTimeout},
+		webhookURL:     webhookURL,
+		version:        version,
+		reported:       make(map[string]bool),
+		logger:         logger,
+		httpClient:     &http.Client{Timeout: slackRequestTimeout},
+		lastReportedAt: lastReportedAt,
+		stateFilePath:  stateFilePath,
+	}
+}
+
+// LastReportedAt returns the timestamp of the last successful Slack report flush.
+// Report-only check methods use this to filter out stale findings.
+// Thread-safe: protects against concurrent reads while Flush() updates the field.
+func (r *SlackReporter) LastReportedAt() time.Time {
+	r.flushMu.Lock()
+	defer r.flushMu.Unlock()
+	return r.lastReportedAt
+}
+
+// defaultLastReportAtPath returns the default path for the last-report-at state file,
+// following XDG Base Directory spec for state data.
+// Uses $XDG_STATE_HOME/oompa/ if set, otherwise ~/.local/state/oompa/.
+// It hashes the webhookURL to ensure different Slack destinations do not interfere
+// when multiple oompa instances run on the same machine.
+func defaultLastReportAtPath(webhookURL string) string {
+	filename := lastReportAtFile
+	if webhookURL != "" {
+		h := fnv.New32a()
+		h.Write([]byte(webhookURL))
+		filename = fmt.Sprintf("%s-%x", lastReportAtFile, h.Sum32())
+	}
+
+	// Honor XDG_STATE_HOME per the XDG Base Directory spec.
+	if xdgState := os.Getenv("XDG_STATE_HOME"); xdgState != "" {
+		return filepath.Join(xdgState, "oompa", filename)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback: write directly to tmpdir with prefix to avoid shared-directory
+		// permission conflicts on multi-user systems.
+		return filepath.Join(os.TempDir(), "oompa-"+filename)
+	}
+	return filepath.Join(home, defaultStateDir, filename)
+}
+
+// loadLastReportedAt reads and parses the persisted timestamp from the state file.
+// Returns time.Now() if the file is missing, empty, or unparseable.
+func loadLastReportedAt(path string, logger *slog.Logger) time.Time {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// File missing (first run) or unreadable — use time.Now() as baseline
+		return time.Now()
+	}
+
+	ts := strings.TrimSpace(string(data))
+	if ts == "" {
+		return time.Now()
+	}
+
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		logger.Warn("unparseable last-report-at file, using time.Now() as baseline", "path", path, "content", ts, "error", err)
+		return time.Now()
+	}
+
+	return t
+}
+
+// persistLastReportedAt writes the timestamp to the state file in RFC 3339 format.
+// Creates the directory if it doesn't exist. Uses atomic write (temp file + rename)
+// to prevent corruption if the process is killed mid-write.
+func persistLastReportedAt(path string, t time.Time, logger *slog.Logger) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logger.Error("failed to create state directory", "dir", dir, "error", err)
+		return
+	}
+
+	data := []byte(t.UTC().Format(time.RFC3339) + "\n")
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		logger.Error("failed to write temporary last-report-at file", "path", tmpPath, "error", err)
+		return
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		logger.Error("failed to rename last-report-at file", "from", tmpPath, "to", path, "error", err)
+		_ = os.Remove(tmpPath)
 	}
 }
 
@@ -166,6 +269,14 @@ func (r *SlackReporter) Flush(ctx context.Context) {
 			r.reported[f.DedupKey] = true
 		}
 	}
+
+	// Persist the report timestamp so it survives restarts.
+	// Future report-only checks use this to filter out stale findings.
+	// Subtract a 2-minute safety margin to avoid missing findings created
+	// between when the GitHub API was queried and when Flush runs. The
+	// in-memory DedupKey map filters out duplicates within the overlap window.
+	r.lastReportedAt = time.Now().Add(-2 * time.Minute)
+	persistLastReportedAt(r.stateFilePath, r.lastReportedAt, r.logger)
 
 	r.logger.Info("posted Slack report", "findings", len(newFindings))
 }

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -8,9 +8,12 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
@@ -417,7 +420,7 @@ func TestCheckCIStatus_ReportsFailures(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckCIStatus(context.Background())
+	findings := a.CheckCIStatus(context.Background(), time.Time{})
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -529,7 +532,7 @@ func TestCheckNewReviews_ReportsComments(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckNewReviews(context.Background())
+	findings := a.CheckNewReviews(context.Background(), time.Time{})
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -567,7 +570,7 @@ func TestCheckCIStatus_NoFailures(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckCIStatus(context.Background())
+	findings := a.CheckCIStatus(context.Background(), time.Time{})
 
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for passing CI, got %d", len(findings))
@@ -997,5 +1000,386 @@ func TestSlackReporter_FlushDedup_EmptyDedupKeyNotDeduped(t *testing.T) {
 	errorCount := strings.Count(body, "transient error")
 	if errorCount != 3 {
 		t.Errorf("expected 3 'transient error' in message (empty DedupKey), got %d", errorCount)
+	}
+}
+
+// --- LastReportedAt persistence tests ---
+
+func TestLoadLastReportedAt_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "last-report-at")
+	expected := time.Date(2026, 5, 29, 8, 38, 23, 0, time.UTC)
+	if err := os.WriteFile(path, []byte("2026-05-29T08:38:23Z\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	got := loadLastReportedAt(path, logger)
+
+	if !got.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestLoadLastReportedAt_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	before := time.Now()
+	got := loadLastReportedAt(path, logger)
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("expected time.Now() fallback, got %v (before=%v, after=%v)", got, before, after)
+	}
+}
+
+func TestLoadLastReportedAt_FileCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "last-report-at")
+	if err := os.WriteFile(path, []byte("not-a-timestamp"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	before := time.Now()
+	got := loadLastReportedAt(path, logger)
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("expected time.Now() fallback for corrupt file, got %v", got)
+	}
+}
+
+func TestLoadLastReportedAt_FileEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "last-report-at")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	before := time.Now()
+	got := loadLastReportedAt(path, logger)
+	after := time.Now()
+
+	if got.Before(before) || got.After(after) {
+		t.Errorf("expected time.Now() fallback for empty file, got %v", got)
+	}
+}
+
+func TestPersistLastReportedAt_WritesAndReads(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "last-report-at")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ts := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+	persistLastReportedAt(path, ts, logger)
+
+	got := loadLastReportedAt(path, logger)
+	if !got.Equal(ts) {
+		t.Errorf("expected %v after persist+load, got %v", ts, got)
+	}
+}
+
+func TestPersistLastReportedAt_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "last-report-at")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ts := time.Now()
+	persistLastReportedAt(path, ts, logger)
+
+	// Verify directory was created
+	if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+		t.Error("expected directory to be created")
+	}
+	// Verify file exists and is readable
+	got := loadLastReportedAt(path, logger)
+	if got.IsZero() {
+		t.Error("expected non-zero timestamp after persist")
+	}
+}
+
+func TestDefaultLastReportAtPath_UniquePerWebhook(t *testing.T) {
+	path1 := defaultLastReportAtPath("https://hooks.slack.com/services/T000/B000/xxx")
+	path2 := defaultLastReportAtPath("https://hooks.slack.com/services/T111/B111/yyy")
+	pathEmpty := defaultLastReportAtPath("")
+
+	if path1 == path2 {
+		t.Errorf("expected different paths for different webhook URLs, both got: %s", path1)
+	}
+	if path1 == pathEmpty {
+		t.Errorf("expected different path for non-empty vs empty webhook URL")
+	}
+	// Empty webhook should use the base filename without hash
+	if !strings.HasSuffix(pathEmpty, lastReportAtFile) {
+		t.Errorf("expected empty webhook path to end with %q, got: %s", lastReportAtFile, pathEmpty)
+	}
+	// Non-empty webhook should have a hash suffix
+	if strings.HasSuffix(path1, lastReportAtFile) {
+		t.Errorf("expected non-empty webhook path to have hash suffix, got: %s", path1)
+	}
+}
+
+func TestSlackReporter_FlushPersistsLastReportedAt(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "last-report-at")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reporter := &SlackReporter{
+		webhookURL:     ts.URL,
+		reported:       make(map[string]bool),
+		logger:         logger,
+		httpClient:     ts.Client(),
+		lastReportedAt: time.Now().Add(-1 * time.Hour),
+		stateFilePath:  stateFile,
+	}
+
+	before := time.Now()
+	reporter.Collect([]SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 1, PRTitle: "Test", Message: "test", DedupKey: "test:1"},
+	})
+	reporter.Flush(context.Background())
+	after := time.Now()
+
+	// Verify lastReportedAt was updated.
+	// Flush subtracts a 2-minute safety margin, so lastReportedAt should be ~2min before now.
+	safetyMargin := 2 * time.Minute
+	if reporter.LastReportedAt().Before(before.Add(-safetyMargin-1*time.Second)) || reporter.LastReportedAt().After(after.Add(-safetyMargin+1*time.Second)) {
+		t.Errorf("expected LastReportedAt to be ~now minus 2min safety margin, got %v", reporter.LastReportedAt())
+	}
+
+	// Verify the file was written.
+	// RFC 3339 truncates to seconds, so the loaded timestamp may be up to 1s off.
+	got := loadLastReportedAt(stateFile, logger)
+	if got.Before(before.Add(-safetyMargin-1*time.Second)) || got.After(after.Add(-safetyMargin+1*time.Second)) {
+		t.Errorf("expected persisted timestamp to be ~now minus 2min, got %v (before=%v, after=%v)", got, before, after)
+	}
+}
+
+func TestSlackReporter_LastReportedAtSurvivesRestart(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "last-report-at")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// First reporter: flush to persist timestamp
+	reporter1 := &SlackReporter{
+		webhookURL:     ts.URL,
+		reported:       make(map[string]bool),
+		logger:         logger,
+		httpClient:     ts.Client(),
+		lastReportedAt: time.Now().Add(-1 * time.Hour),
+		stateFilePath:  stateFile,
+	}
+
+	reporter1.Collect([]SlackFinding{
+		{Owner: "org", Repo: "repo", PRNumber: 1, PRTitle: "Test", Message: "test", DedupKey: "test:1"},
+	})
+	reporter1.Flush(context.Background())
+	firstReportTime := reporter1.LastReportedAt()
+
+	// Second reporter: simulate restart by loading from the same file
+	reporter2 := &SlackReporter{
+		webhookURL:     ts.URL,
+		reported:       make(map[string]bool),
+		logger:         logger,
+		httpClient:     ts.Client(),
+		lastReportedAt: loadLastReportedAt(stateFile, logger),
+		stateFilePath:  stateFile,
+	}
+
+	// The second reporter should have the same lastReportedAt as the first.
+	// RFC 3339 truncates to seconds, so compare at second precision.
+	firstTrunc := firstReportTime.UTC().Truncate(time.Second)
+	secondTrunc := reporter2.LastReportedAt().UTC().Truncate(time.Second)
+	if !secondTrunc.Equal(firstTrunc) {
+		t.Errorf("expected LastReportedAt to survive restart: first=%v, second=%v",
+			firstTrunc, secondTrunc)
+	}
+}
+
+// --- Timestamp-based filtering tests ---
+
+func TestCheckCIStatus_FiltersStaleFailures(t *testing.T) {
+	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "stale-test", Status: "completed", Conclusion: "failure",
+				CompletedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC), // Before lastReportedAt
+				HTMLURL:     "https://github.com/org/repo/actions/runs/1/job/1"},
+			{ID: 2, Name: "new-test", Status: "completed", Conclusion: "failure",
+				CompletedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC), // After lastReportedAt
+				HTMLURL:     "https://github.com/org/repo/actions/runs/2/job/2"},
+		},
+		prHeadSHAs: []string{"abc123"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (only new failure), got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Message, "new-test") {
+		t.Errorf("expected finding for new-test, got: %s", findings[0].Message)
+	}
+}
+
+func TestCheckCIStatus_IncludesFailuresWithZeroCompletedAt(t *testing.T) {
+	// Failures with zero CompletedAt (e.g. commit statuses) should not be filtered
+	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+
+	gh := &mockGitHubClient{
+		checkRuns: []CheckRun{
+			{ID: 1, Name: "no-timestamp", Status: "completed", Conclusion: "failure",
+				HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
+		},
+		prHeadSHAs: []string{"abc123"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (zero CompletedAt not filtered), got %d", len(findings))
+	}
+}
+
+func TestCheckNewReviews_FiltersStaleComments(t *testing.T) {
+	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 10, User: "reviewer1", Body: "Old comment",
+				CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)}, // Before lastReportedAt
+			{ID: 11, User: "reviewer2", Body: "New comment",
+				CreatedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC)}, // After lastReportedAt
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (only new comment), got %d", len(findings))
+	}
+	if !strings.Contains(findings[0].Message, "1 new review comment") {
+		t.Errorf("expected message about 1 new review comment, got: %s", findings[0].Message)
+	}
+}
+
+func TestCheckNewReviews_IncludesCommentsWithZeroCreatedAt(t *testing.T) {
+	// Comments with zero CreatedAt should not be filtered
+	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 10, User: "reviewer1", Body: "No timestamp comment"},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
+
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (zero CreatedAt not filtered), got %d", len(findings))
+	}
+}
+
+func TestCheckNewReviews_AllStaleNoFindings(t *testing.T) {
+	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 10, User: "reviewer1", Body: "Old comment",
+				CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)},
+			{ID: 11, User: "reviewer2", Body: "Also old",
+				CreatedAt: time.Date(2026, 5, 29, 8, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := &Agent{
+		gh:     gh,
+		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:  NewState(),
+		logger: logger,
+	}
+
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+
+	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
+
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings when all comments are stale, got %d", len(findings))
 	}
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -19,6 +19,7 @@ type ReviewComment struct {
 	Body        string
 	Path        string
 	Line        int
+	CreatedAt   time.Time
 }
 
 // PR represents a GitHub pull request.
@@ -76,12 +77,13 @@ type PRReview struct {
 // For commit statuses (e.g. Prow): ID is 0, Output contains the target_url.
 // Callers must check ID != 0 before calling GetCheckRunLog.
 type CheckRun struct {
-	ID         int64
-	Name       string
-	Status     string // queued, in_progress, completed
-	Conclusion string // success, failure, neutral, cancelled, skipped, timed_out, action_required
-	Output     string // summary/text from the check run, or target_url for commit statuses
-	HTMLURL    string // direct link to the check run page on GitHub
+	ID          int64
+	Name        string
+	Status      string    // queued, in_progress, completed
+	Conclusion  string    // success, failure, neutral, cancelled, skipped, timed_out, action_required
+	Output      string    // summary/text from the check run, or target_url for commit statuses
+	HTMLURL     string    // direct link to the check run page on GitHub
+	CompletedAt time.Time // when the check run completed (zero if not completed or unknown)
 }
 
 // JobRun represents a CI job run (periodic or triggered).


### PR DESCRIPTION
Fixes #202

## Summary

Persist `LastReportedAt` timestamp in the Slack reporter so report-only checks can filter out stale findings that were already reported. Previously, the in-memory dedup map was lost on restart, causing repeated stale Slack reports (e.g. "1 new review comment" for an old comment, "PR is behind main" every cycle).

## Changes

- Add `LastReportedAt` field to `SlackReporter` with file persistence at `~/.local/state/oompa/last-report-at` (XDG state dir)
- Add `CreatedAt` to `ReviewComment` and `CompletedAt` to `CheckRun` types
- Populate new timestamp fields from GitHub API responses in `github.go`
- Filter CI failures by `CompletedAt > LastReportedAt` in `CheckCIStatus`
- Filter review comments by `CreatedAt > LastReportedAt` in `CheckNewReviews`
- Pass `LastReportedAt` from `SlackReporter` through `RunReportOnlyChecks` to individual check methods
- Persist timestamp after each successful `Flush()`, load on construction with `time.Now()` fallback

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests for persistence: write/read/fallback (missing file, corrupt file, empty file)
- [x] New tests for timestamp filtering: stale CI failures filtered, stale review comments filtered, zero-timestamp items not filtered

## Related Issues

Fixes #202

<!-- oompa-bot v:0e0cace -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevents duplicate CI failure and review comment findings by tracking the last successful report timestamp across restarts. The agent now filters to report only findings from events occurring after the previous report cycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qinqon/oompa/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->