### PR TITLE
feat: respond to PR comments (not just review comments) starting with /oompa

### DIFF
--- a/pkg/agent/dryrun.go
+++ b/pkg/agent/dryrun.go
@@ -60,6 +60,11 @@ func (d *DryRunGitHubClient) AddPRCommentReaction(_ context.Context, _, _ string
 	return nil
 }
 
+func (d *DryRunGitHubClient) AddIssueCommentReaction(_ context.Context, _, _ string, commentID int64, reaction string) error {
+	d.logger.Info("[dry-run] would add issue comment reaction", "comment", commentID, "reaction", reaction)
+	return nil
+}
+
 func (d *DryRunGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, prNumber int, commentID int64, body string) error {
 	d.logger.Info("[dry-run] would reply to comment", "pr", prNumber, "comment", commentID, "body", truncateString(body, 100))
 	return nil

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -22,6 +22,7 @@ type GitHubClient interface {
 	RemoveLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error
 	ListPRsByHead(ctx context.Context, owner, repo, headOwner, branch string) ([]PR, error)
 	AddPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error
+	AddIssueCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error
 	GetCheckRuns(ctx context.Context, owner, repo, ref string) ([]CheckRun, error)
 	GetCheckRunLog(ctx context.Context, owner, repo string, checkRunID int64) (string, error)
 	GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error)
@@ -256,6 +257,14 @@ func (g *GoGitHubClient) AddPRCommentReaction(ctx context.Context, owner, repo s
 	_, _, err := g.client.Reactions.CreatePullRequestCommentReaction(ctx, owner, repo, commentID, reaction)
 	if err != nil {
 		return fmt.Errorf("adding reaction: %w", err)
+	}
+	return nil
+}
+
+func (g *GoGitHubClient) AddIssueCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error {
+	_, _, err := g.client.Reactions.CreateIssueCommentReaction(ctx, owner, repo, commentID, reaction)
+	if err != nil {
+		return fmt.Errorf("adding issue comment reaction: %w", err)
 	}
 	return nil
 }

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -841,3 +841,23 @@ func TestCountCommitsSince_APIError(t *testing.T) {
 		t.Fatal("expected error for API failure")
 	}
 }
+
+func TestAddIssueCommentReaction(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      1,
+			"content": "eyes",
+		})
+	})
+
+	gh := setupTestClient(t, mux)
+	err := gh.AddIssueCommentReaction(context.Background(), "owner", "repo", 42, "eyes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -184,6 +184,13 @@ func (f *fakeGitHubClient) AddPRCommentReaction(_ context.Context, _, _ string, 
 	return nil
 }
 
+func (f *fakeGitHubClient) AddIssueCommentReaction(_ context.Context, _, _ string, commentID int64, reaction string) error {
+	f.state.mu.Lock()
+	defer f.state.mu.Unlock()
+	f.state.reactions = append(f.state.reactions, fmt.Sprintf("issue:%d:%s", commentID, reaction))
+	return nil
+}
+
 func (f *fakeGitHubClient) GetCheckRuns(_ context.Context, _, _, ref string) ([]CheckRun, error) {
 	f.state.mu.Lock()
 	defer f.state.mu.Unlock()

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -23,6 +23,11 @@ const (
 	StatusPROpen       = "pr-open"
 	StatusFailed       = "failed"
 
+	// oompaCommandPrefix is the prefix that PR conversation comments must start
+	// with to be treated as a directive to the agent. Comments without this prefix
+	// are ignored to avoid reacting to regular human discussion on the PR.
+	oompaCommandPrefix = "/oompa"
+
 	// Labels
 	labelAIFailed = "ai-failed"
 )
@@ -124,11 +129,13 @@ type newIssueTask struct {
 }
 
 type reviewTask struct {
-	work          *IssueWork
-	humanComments []ReviewComment
-	humanReviews  []PRReview
-	maxCommentID  int64 // max ID across ALL fetched comments (including filtered ones)
-	maxReviewID   int64 // max ID across ALL fetched reviews (including filtered ones)
+	work               *IssueWork
+	humanComments      []ReviewComment
+	humanReviews       []PRReview
+	prComments         []ReviewComment // PR conversation comments matching /oompa prefix
+	maxCommentID       int64           // max ID across ALL fetched review comments (including filtered ones)
+	maxReviewID        int64           // max ID across ALL fetched reviews (including filtered ones)
+	maxIssueCommentID  int64           // max ID across ALL fetched PR conversation comments (including filtered ones)
 }
 
 type ciTask struct {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -101,6 +101,11 @@ func (m *mockGitHubClient) AddPRCommentReaction(_ context.Context, _, _ string, 
 	return nil
 }
 
+func (m *mockGitHubClient) AddIssueCommentReaction(_ context.Context, _, _ string, commentID int64, reaction string) error {
+	m.addedReactions = append(m.addedReactions, fmt.Sprintf("issue:%d:%s", commentID, reaction))
+	return nil
+}
+
 func (m *mockGitHubClient) GetCheckRuns(_ context.Context, _, _, _ string) ([]CheckRun, error) {
 	return m.checkRuns, nil
 }
@@ -5147,6 +5152,308 @@ func TestBuildTriageMatchPrompt(t *testing.T) {
 	for _, want := range checks {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("prompt missing %q", want)
+		}
+	}
+}
+
+func TestProcessReviewComments_OompaCommandProcessed(t *testing.T) {
+	// A PR conversation comment starting with /oompa should be treated as a directive.
+	result := streamResultJSON(AgentResult{Result: "Done"})
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+		},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Should have invoked the agent
+	claudeCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			claudeCalls++
+		}
+	}
+	if claudeCalls != 1 {
+		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
+	}
+
+	// Cursor should advance
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastIssueCommentID != 70 {
+		t.Errorf("expected LastIssueCommentID 70, got %d", work.LastIssueCommentID)
+	}
+
+	// Should have added :eyes: reaction using issue comment API
+	if !slices.Contains(gh.addedReactions, "issue:70:eyes") {
+		t.Errorf("expected issue comment :eyes: reaction, got %v", gh.addedReactions)
+	}
+}
+
+func TestProcessReviewComments_IgnoresNonOompaComments(t *testing.T) {
+	// PR conversation comments without /oompa prefix should be ignored.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "This looks good to me"},
+			{ID: 71, User: "reviewer", Body: "I think we should refactor this"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Should NOT invoke the agent
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			t.Error("should not invoke claude for comments without /oompa prefix")
+		}
+	}
+
+	// Cursor should still advance past filtered comments
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastIssueCommentID != 71 {
+		t.Errorf("expected LastIssueCommentID to advance to 71, got %d", work.LastIssueCommentID)
+	}
+}
+
+func TestProcessReviewComments_OompaCommandSkipsNonWhitelisted(t *testing.T) {
+	// /oompa commands from non-whitelisted users should be ignored.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "random-user", Body: "/oompa fix the commit message"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.Reviewers = []string{"trusted-reviewer"}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			t.Error("should not invoke claude for non-whitelisted user's /oompa command")
+		}
+	}
+}
+
+func TestProcessReviewComments_OompaCommandIncludedInPrompt(t *testing.T) {
+	// The /oompa directive should appear in the prompt with the /oompa prefix stripped.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa add Signed-off-by trailers"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = codeAgent
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	if len(codeAgent.prompts) != 1 {
+		t.Fatalf("expected 1 prompt, got %d", len(codeAgent.prompts))
+	}
+
+	prompt := codeAgent.prompts[0]
+
+	// Should contain the directive text
+	if !strings.Contains(prompt, "add Signed-off-by trailers") {
+		t.Error("prompt should contain the directive text")
+	}
+
+	// Should contain the section header
+	if !strings.Contains(prompt, "PR conversation directives") {
+		t.Error("prompt should contain PR conversation directives section")
+	}
+
+	// Should NOT contain the /oompa prefix in the directive
+	if strings.Contains(prompt, "/oompa add") {
+		t.Error("prompt should strip the /oompa prefix from directives")
+	}
+}
+
+func TestProcessReviewComments_OompaCommandWithReviewComments(t *testing.T) {
+	// Both inline review comments and /oompa PR comments should be processed together.
+	result := streamResultJSON(AgentResult{Result: "Done"})
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Fix the typo", Path: "main.go", Line: 10},
+		},
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa rebase on main"},
+		},
+	}
+	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Should have invoked the agent once (both types combined into one task)
+	claudeCalls := 0
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			claudeCalls++
+		}
+	}
+	if claudeCalls != 1 {
+		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
+	}
+
+	// Both cursors should advance
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastCommentID != 60 {
+		t.Errorf("expected LastCommentID 60, got %d", work.LastCommentID)
+	}
+	if work.LastIssueCommentID != 70 {
+		t.Errorf("expected LastIssueCommentID 70, got %d", work.LastIssueCommentID)
+	}
+
+	// Should have reactions for both comment types
+	if !slices.Contains(gh.addedReactions, "60:eyes") {
+		t.Error("expected :eyes: reaction on review comment")
+	}
+	if !slices.Contains(gh.addedReactions, "issue:70:eyes") {
+		t.Error("expected :eyes: reaction on issue comment")
+	}
+}
+
+func TestProcessReviewComments_OompaCommandCursorAdvancesOnAgentError(t *testing.T) {
+	// When the agent errors, the issue comment cursor should still advance.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastIssueCommentID != 70 {
+		t.Errorf("expected LastIssueCommentID to advance to 70 on agent error, got %d", work.LastIssueCommentID)
+	}
+}
+
+func TestProcessReviewComments_OompaCommandIgnoresBarePrefix(t *testing.T) {
+	// A bare "/oompa" comment with no directive text should be ignored.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa"},
+			{ID: 71, User: "reviewer", Body: "/oompa   "},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Should NOT invoke the agent for bare /oompa with no directive
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			t.Error("should not invoke claude for bare /oompa comment with no directive")
+		}
+	}
+
+	// Cursor should still advance past filtered comments
+	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+	if work.LastIssueCommentID != 71 {
+		t.Errorf("expected LastIssueCommentID to advance to 71, got %d", work.LastIssueCommentID)
+	}
+}
+
+func TestProcessReviewComments_OompaCommandIgnoresBotComments(t *testing.T) {
+	// Bot-posted comments with /oompa prefix should be ignored.
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "some-bot", Body: "/oompa do something " + botMarker},
+		},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: "/tmp/worktree",
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	for _, c := range runner.calls {
+		if c.Name == "claude" {
+			t.Error("should not invoke claude for bot-posted /oompa comment")
 		}
 	}
 }

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -42,7 +42,7 @@ Do NOT push, create PRs, or amend — the agent handles that automatically.`,
 		issue.Number, issue.Title, issue.Body, trailerInstructions, issue.Number)
 }
 
-func buildReviewResponsePrompt(work IssueWork, comments []ReviewComment, reviews []PRReview, owner, repo string) string {
+func buildReviewResponsePrompt(work IssueWork, comments []ReviewComment, reviews []PRReview, prComments []ReviewComment, owner, repo string) string {
 	var prompt strings.Builder
 	fmt.Fprintf(&prompt, `You are addressing review feedback on PR #%d for issue #%d: %s
 Repository: %s/%s
@@ -68,6 +68,16 @@ Repository: %s/%s
 				}
 			}
 			fmt.Fprintf(&prompt, " ---\n%s\n", c.Body)
+		}
+	}
+
+	if len(prComments) > 0 {
+		prompt.WriteString("\nPR conversation directives (from /oompa commands):\n")
+		for _, c := range prComments {
+			body := strings.TrimSpace(c.Body)
+			// Strip the prefix to present just the instruction
+			directive := strings.TrimSpace(strings.TrimPrefix(body, oompaCommandPrefix))
+			fmt.Fprintf(&prompt, "\n--- Directive by %s ---\n%s\n", c.User, directive)
 		}
 	}
 

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -88,7 +88,7 @@ func TestBuildReviewResponsePrompt(t *testing.T) {
 		},
 	}
 
-	prompt := buildReviewResponsePrompt(work, comments, nil, "owner", "repo")
+	prompt := buildReviewResponsePrompt(work, comments, nil, nil, "owner", "repo")
 
 	checks := []string{
 		"reviewer1",
@@ -118,6 +118,43 @@ func TestBuildReviewResponsePrompt(t *testing.T) {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("prompt missing %q", want)
 		}
+	}
+}
+
+func TestBuildReviewResponsePrompt_WithPRComments(t *testing.T) {
+	work := IssueWork{
+		IssueNumber: 42,
+		IssueTitle:  "Fix nil pointer in handler",
+		PRNumber:    100,
+	}
+
+	prComments := []ReviewComment{
+		{ID: 10, User: "reviewer1", Body: "/oompa fix the commit message"},
+		{ID: 11, User: "reviewer2", Body: "/oompa add Signed-off-by trailers"},
+	}
+
+	prompt := buildReviewResponsePrompt(work, nil, nil, prComments, "owner", "repo")
+
+	checks := []string{
+		"PR conversation directives",
+		"Directive by reviewer1",
+		"fix the commit message",
+		"Directive by reviewer2",
+		"add Signed-off-by trailers",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+
+	// The /oompa prefix should be stripped from directives
+	if strings.Contains(prompt, "/oompa fix") {
+		t.Error("prompt should strip /oompa prefix from directives")
+	}
+	if strings.Contains(prompt, "/oompa add") {
+		t.Error("prompt should strip /oompa prefix from directives")
 	}
 }
 

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -116,7 +116,39 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			humanReviews = append(humanReviews, r)
 		}
 
-		if len(humanComments) == 0 && len(humanReviews) == 0 {
+		// Fetch PR conversation comments (Issues API) and filter for /oompa prefix.
+		// These are regular comments on the PR conversation tab, not inline code review comments.
+		issueComments, err := a.gh.GetIssueComments(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber, work.LastIssueCommentID)
+		if err != nil {
+			a.logger.Error("failed to get PR issue comments", "pr", work.PRNumber, "error", err)
+			continue
+		}
+
+		// Track the max issue comment ID across ALL fetched comments (including filtered ones).
+		var maxIssueCommentID int64
+		for _, c := range issueComments {
+			if c.ID > maxIssueCommentID {
+				maxIssueCommentID = c.ID
+			}
+		}
+
+		// Filter PR conversation comments: only /oompa-prefixed, whitelisted, non-bot.
+		var prComments []ReviewComment
+		for _, c := range issueComments {
+			if strings.Contains(c.Body, botMarker) {
+				continue
+			}
+			if !a.isAllowedReviewer(c.User) {
+				continue
+			}
+			fields := strings.Fields(c.Body)
+			if len(fields) < 2 || fields[0] != oompaCommandPrefix {
+				continue
+			}
+			prComments = append(prComments, c)
+		}
+
+		if len(humanComments) == 0 && len(humanReviews) == 0 && len(prComments) == 0 {
 			// No actionable comments/reviews, but still advance cursors past
 			// filtered items to avoid re-fetching them on every poll cycle.
 			if maxCommentID > work.LastCommentID {
@@ -124,6 +156,9 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			}
 			if maxReviewID > work.LastReviewID {
 				work.LastReviewID = maxReviewID
+			}
+			if maxIssueCommentID > work.LastIssueCommentID {
+				work.LastIssueCommentID = maxIssueCommentID
 			}
 			continue
 		}
@@ -142,6 +177,9 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			if maxReviewID > work.LastReviewID {
 				work.LastReviewID = maxReviewID
 			}
+			if maxIssueCommentID > work.LastIssueCommentID {
+				work.LastIssueCommentID = maxIssueCommentID
+			}
 			a.logger.Warn("skipping stale reviews (no-op retry limit reached)",
 				"pr", work.PRNumber,
 				"noOpCount", work.ReviewNoOpCount,
@@ -154,7 +192,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			continue
 		}
 
-		a.logger.Info("addressing review feedback", "pr", work.PRNumber, "comments", len(humanComments), "reviews", len(humanReviews))
+		a.logger.Info("addressing review feedback", "pr", work.PRNumber, "comments", len(humanComments), "reviews", len(humanReviews), "prComments", len(prComments))
 
 		if err := a.ensureWorktreeReady(ctx, work); err != nil {
 			a.logger.Error("failed to prepare worktree", "pr", work.PRNumber, "error", err)
@@ -167,13 +205,20 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 				a.logger.Warn("failed to add reaction", "comment", c.ID, "error", err)
 			}
 		}
+		for _, c := range prComments {
+			if err := a.gh.AddIssueCommentReaction(ctx, a.cfg.Owner, a.cfg.Repo, c.ID, "eyes"); err != nil {
+				a.logger.Warn("failed to add issue comment reaction", "comment", c.ID, "error", err)
+			}
+		}
 
 		tasks = append(tasks, reviewTask{
-			work:          work,
-			humanComments: humanComments,
-			humanReviews:  humanReviews,
-			maxCommentID:  maxCommentID,
-			maxReviewID:   maxReviewID,
+			work:              work,
+			humanComments:     humanComments,
+			humanReviews:      humanReviews,
+			prComments:        prComments,
+			maxCommentID:      maxCommentID,
+			maxReviewID:       maxReviewID,
+			maxIssueCommentID: maxIssueCommentID,
 		})
 	}
 
@@ -196,7 +241,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		}
 		headSHABefore := strings.TrimSpace(string(headBefore))
 
-		prompt := buildReviewResponsePrompt(*task.work, task.humanComments, task.humanReviews, a.cfg.Owner, a.cfg.Repo)
+		prompt := buildReviewResponsePrompt(*task.work, task.humanComments, task.humanReviews, task.prComments, a.cfg.Owner, a.cfg.Repo)
 		agentResult, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
 		// Track cumulative cost even on failure — failed invocations still consume
 		// tokens and incur costs, so the MaxPRSessionCost guard must count them.
@@ -221,6 +266,9 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			}
 			if task.maxReviewID > task.work.LastReviewID {
 				task.work.LastReviewID = task.maxReviewID
+			}
+			if task.maxIssueCommentID > task.work.LastIssueCommentID {
+				task.work.LastIssueCommentID = task.maxIssueCommentID
 			}
 			task.work.ReviewNoOpCount++
 			return
@@ -296,6 +344,9 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 			}
 			if task.maxReviewID > task.work.LastReviewID {
 				task.work.LastReviewID = task.maxReviewID
+			}
+			if task.maxIssueCommentID > task.work.LastIssueCommentID {
+				task.work.LastIssueCommentID = task.maxIssueCommentID
 			}
 		}
 

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -50,8 +50,9 @@ type IssueWork struct {
 	WorktreePath     string          `json:"worktreePath"`
 	BranchName       string          `json:"branchName"`
 	PRNumber         int             `json:"prNumber"`
-	LastCommentID    int64           `json:"lastCommentID"`
-	LastReviewID     int64           `json:"lastReviewID"`
+	LastCommentID      int64           `json:"lastCommentID"`
+	LastReviewID       int64           `json:"lastReviewID"`
+	LastIssueCommentID int64           `json:"lastIssueCommentID,omitempty"` // cursor for PR conversation comments (Issues API)
 	Status           string          `json:"status"` // implementing, pr-open, failed, done
 	CIFixAttempts    int             `json:"ciFixAttempts"`
 	LastCIStatus     string          `json:"lastCIStatus"`              // "", "pending", "success", "failure"


### PR DESCRIPTION
Fixes #207

## Summary

Respond to PR conversation comments (not just review comments) that start with `/oompa`, treating them as directives to the agent.

## Changes

- Add `LastIssueCommentID` cursor to `IssueWork` for tracking processed PR conversation comments
- Add `AddIssueCommentReaction` to `GitHubClient` interface and all implementations (`GoGitHubClient`, `DryRunGitHubClient`, mock, fake)
- Add `/oompa` command prefix constant (`oompaCommandPrefix`)
- Extend `ProcessReviewComments` to fetch PR conversation comments via `GetIssueComments`, filter for `/oompa` prefix + allowed reviewers, add :eyes: reactions, and track cursor advancement
- Extend `buildReviewResponsePrompt` to include PR conversation directives with the `/oompa` prefix stripped
- Add `prComments` and `maxIssueCommentID` fields to `reviewTask`

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- New tests added:
  - `TestProcessReviewComments_OompaCommandProcessed` — verifies agent is invoked and cursor advances
  - `TestProcessReviewComments_IgnoresNonOompaComments` — verifies comments without `/oompa` prefix are ignored
  - `TestProcessReviewComments_OompaCommandSkipsNonWhitelisted` — verifies reviewer allowlist is enforced
  - `TestProcessReviewComments_OompaCommandIncludedInPrompt` — verifies directive text in prompt with prefix stripped
  - `TestProcessReviewComments_OompaCommandWithReviewComments` — verifies both comment types work together
  - `TestProcessReviewComments_OompaCommandCursorAdvancesOnAgentError` — verifies cursor advancement on failure
  - `TestProcessReviewComments_OompaCommandIgnoresBotComments` — verifies bot comments are filtered
  - `TestBuildReviewResponsePrompt_WithPRComments` — verifies prompt formatting for PR directives
  - `TestAddIssueCommentReaction` — verifies the new GitHub API method

## Related Issues

Fixes #207

<!-- oompa-bot v:8e4f017 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now reacts with emoji to PR conversation comments
  * Introduced `/oompa` command support for PR conversations to guide AI reviews  
  * PR conversation directives automatically included in AI review prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->