### PR TITLE
bug: triage creates duplicate issues for failures on the same PR

### DIFF
--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3469,6 +3469,196 @@ func TestProcessTriageJobs_LookbackSkipsAlreadyInvestigated(t *testing.T) {
 	}
 }
 
+func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob(t *testing.T) {
+	// When multiple failed runs of the same job are investigated in the same
+	// triage cycle, the second run should match the issue created by the first
+	// and post a run-link comment instead of creating a duplicate issue.
+	now := time.Now()
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 300, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/300"},
+			{ID: 200, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-2 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/200"},
+		},
+		searchResults:   []Issue{}, // GitHub search returns nothing (eventual consistency lag)
+		nextIssueNumber: 10,
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+	cfg := Config{
+		Owner:             "owner",
+		Repo:              "repo",
+		FlakyLabel:        "ci-flake",
+		CreateFlakyIssues: true,
+		TriageJobs:        []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
+		TriageLookback:    24 * time.Hour,
+	}
+
+	// Both runs produce the same failure signature, so titles match exactly.
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "## Summary\nCompile error in main.go"}},
+			{result: AgentResult{Result: "## Summary\nCompile error in main.go"}},
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Should create exactly 1 issue (first run) and post a run-link comment (second run)
+	if len(gh.createdIssues) != 1 {
+		t.Errorf("expected 1 issue created (dedup same job), got %d", len(gh.createdIssues))
+	}
+
+	// The run-link comment for the second run should reference the issue created by the first
+	runLinkFound := false
+	for _, comment := range gh.addedComments {
+		if strings.Contains(comment, "Same failure observed") {
+			runLinkFound = true
+		}
+	}
+	if !runLinkFound {
+		t.Error("expected a run-link comment for the deduplicated second run")
+	}
+
+	// Both runs should be marked as investigated
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+		t.Error("expected run 300 to be marked as investigated")
+	}
+	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+		t.Error("expected run 200 to be marked as investigated")
+	}
+}
+
+func TestProcessTriageJobs_DeduplicatesDifferentJobsSameRootCause(t *testing.T) {
+	// When different jobs fail for the same root cause in the same triage cycle,
+	// the second job should match the issue created by the first via LLM matching
+	// and post a run-link comment instead of creating a duplicate issue.
+	now := time.Now()
+
+	// Two different GitHub Actions workflows, each with one failed run
+	gh := &mockGitHubClient{
+		workflowRuns: []WorkflowRun{
+			{ID: 100, Status: "completed", Conclusion: "failure", CreatedAt: now.Add(-1 * time.Hour), HTMLURL: "https://github.com/owner/repo/actions/runs/100"},
+		},
+		searchResults:   []Issue{}, // GitHub search returns nothing
+		nextIssueNumber: 10,
+	}
+	runner := &mockCommandRunner{}
+	wtm := &mockWorktreeManager{}
+	state := NewState()
+	cfg := Config{
+		Owner:             "owner",
+		Repo:              "repo",
+		FlakyLabel:        "ci-flake",
+		CreateFlakyIssues: true,
+		TriageJobs: []string{
+			"https://github.com/owner/repo/actions/workflows/unit.yml",
+			"https://github.com/owner/repo/actions/workflows/e2e.yml",
+		},
+	}
+
+	// First job: analysis + no match (NONE) → creates issue
+	// Second job: analysis + LLM match → deduplicates
+	codeAgent := &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "## Summary\nDependency X broke API"}},           // first job analysis
+			{result: AgentResult{Result: "## Summary\nDependency X broke API in e2e test"}}, // second job analysis
+			{result: AgentResult{Result: "MATCH #10"}},                                      // second job matches issue #10
+		},
+	}
+
+	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a.ProcessTriageJobs(context.Background())
+
+	// Should create exactly 1 issue (first job) and post a run-link (second job)
+	if len(gh.createdIssues) != 1 {
+		t.Errorf("expected 1 issue created (dedup across jobs), got %d", len(gh.createdIssues))
+	}
+
+	// The issue created by the first job should be #10
+	if len(gh.createdIssues) > 0 && gh.createdIssues[0].Number != 10 {
+		t.Errorf("expected first issue number 10, got %d", gh.createdIssues[0].Number)
+	}
+
+	// The second job should have posted a run-link comment
+	runLinkFound := false
+	for _, comment := range gh.addedComments {
+		if strings.Contains(comment, "Same failure observed") {
+			runLinkFound = true
+		}
+	}
+	if !runLinkFound {
+		t.Error("expected a run-link comment for the deduplicated second job")
+	}
+
+	// Both runs should be investigated
+	if !state.IsRunInvestigated("owner/repo/unit.yml", "100") {
+		t.Error("expected unit.yml run to be marked as investigated")
+	}
+	if !state.IsRunInvestigated("owner/repo/e2e.yml", "100") {
+		t.Error("expected e2e.yml run to be marked as investigated")
+	}
+}
+
+func TestMergeIssues(t *testing.T) {
+	tests := []struct {
+		name    string
+		primary []Issue
+		extras  []Issue
+		want    int // expected length
+	}{
+		{
+			name:    "empty extras",
+			primary: []Issue{{Number: 1}},
+			extras:  nil,
+			want:    1,
+		},
+		{
+			name:    "no overlap",
+			primary: []Issue{{Number: 1}},
+			extras:  []Issue{{Number: 2}},
+			want:    2,
+		},
+		{
+			name:    "with overlap",
+			primary: []Issue{{Number: 1}, {Number: 2}},
+			extras:  []Issue{{Number: 2}, {Number: 3}},
+			want:    3,
+		},
+		{
+			name:    "both empty",
+			primary: nil,
+			extras:  nil,
+			want:    0,
+		},
+		{
+			name:    "empty primary with extras",
+			primary: nil,
+			extras:  []Issue{{Number: 5}},
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeIssues(tt.primary, tt.extras)
+			if len(got) != tt.want {
+				t.Errorf("mergeIssues() returned %d issues, want %d", len(got), tt.want)
+			}
+
+			// Verify no duplicates
+			seen := make(map[int]bool)
+			for _, issue := range got {
+				if seen[issue.Number] {
+					t.Errorf("duplicate issue #%d in merged result", issue.Number)
+				}
+				seen[issue.Number] = true
+			}
+		})
+	}
+}
+
 func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "RELATED Fixed CI"})
 	gh := &mockGitHubClient{

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -87,14 +87,24 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 		}
 	}
 
-	// Investigate collected failed runs in parallel
+	// Track issues created during this triage cycle so that subsequent
+	// investigations can find them without relying on GitHub search
+	// indexing (which is eventually consistent). This prevents duplicate
+	// issues when multiple runs of the same job or different jobs fail
+	// for the same root cause within the same triage cycle.
+	var cycleIssues []Issue
+
+	// Investigate collected failed runs sequentially
 	runSequential(ctx, tasks, func(ctx context.Context, task triageRunTask) {
-		a.investigateTriageRun(ctx, task.ciSource, task.run)
+		a.investigateTriageRun(ctx, task.ciSource, task.run, &cycleIssues)
 	})
 }
 
 // investigateTriageRun handles the investigation of a single failed CI run.
-func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, run JobRun) {
+// cycleIssues accumulates issues created during the current triage cycle so
+// that subsequent investigations can match against them without relying on
+// GitHub's eventually-consistent search index.
+func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, run JobRun, cycleIssues *[]Issue) {
 	// Fetch build log
 	buildLog, err := ciSource.FetchLog(ctx, run.ID)
 	if err != nil {
@@ -158,12 +168,24 @@ func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, 
 			title = fmt.Sprintf("CI Failure: %s", ciSource.JobName())
 		}
 
-		// Search for existing issues about this job to avoid duplicates
-		searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open in:title %q", a.cfg.Owner, a.cfg.Repo, ciSource.JobName())
+		// Search for existing triage issues to avoid duplicates.
+		// Search broadly (not scoped to this job's name) so that issues
+		// created for other jobs in the same triage cycle can be found
+		// when the root cause is shared (e.g. all jobs failing on the
+		// same PR). Constrained by the flaky label and a 30-day window
+		// to keep result sets small and limit LLM token costs.
+		cutoffDate := time.Now().AddDate(0, 0, -30).Format("2006-01-02")
+		searchQuery := fmt.Sprintf("repo:%s/%s is:issue is:open label:%q in:title \"CI Failure:\" created:>%s",
+			a.cfg.Owner, a.cfg.Repo, a.cfg.FlakyLabel, cutoffDate)
 		existingIssues, err := a.gh.SearchIssues(ctx, searchQuery)
 		if err != nil {
 			a.logger.Warn("failed to search for existing issues", "error", err)
 		}
+
+		// Merge in issues created during this triage cycle that may not
+		// yet be indexed by GitHub's search API. Deduplicate by number
+		// to avoid presenting the same issue twice to the LLM matcher.
+		existingIssues = mergeIssues(existingIssues, *cycleIssues)
 
 		matchedIssue := a.matchExistingTriageIssue(ctx, ciSource.JobName(), title, analysis, existingIssues, worktreePath)
 
@@ -187,6 +209,13 @@ func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, 
 				a.logger.Error("failed to create issue", "error", err)
 			} else {
 				a.logger.Info("created issue for CI failure", "job", ciSource.JobName(), "issue", issueNumber)
+				// Track newly created issue for same-cycle dedup
+				*cycleIssues = append(*cycleIssues, Issue{
+					Number: issueNumber,
+					Title:  title,
+					Body:   body,
+					Labels: []string{a.cfg.FlakyLabel},
+				})
 			}
 		}
 	}
@@ -250,6 +279,27 @@ func (a *Agent) addTriageRunLinkComment(ctx context.Context, jobName string, run
 	if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, issueNum, comment); err != nil {
 		a.logger.Error("failed to post run link comment on triage issue", "issue", issueNum, "error", err)
 	}
+}
+
+// mergeIssues combines two issue slices, deduplicating by issue number.
+// Issues from the primary slice take precedence over extras.
+func mergeIssues(primary, extras []Issue) []Issue {
+	if len(extras) == 0 {
+		return primary
+	}
+	seen := make(map[int]bool, len(primary))
+	for _, issue := range primary {
+		seen[issue.Number] = true
+	}
+	merged := make([]Issue, 0, len(primary)+len(extras))
+	merged = append(merged, primary...)
+	for _, issue := range extras {
+		if !seen[issue.Number] {
+			merged = append(merged, issue)
+			seen[issue.Number] = true
+		}
+	}
+	return merged
 }
 
 // extractFailureSignature extracts a short failure identifier from the agent's


### PR DESCRIPTION
Fixes #216

## Summary

Fix duplicate issue creation during triage when multiple CI runs of the same job or different jobs fail for the same root cause within a single triage cycle.

## Changes

- Track issues created during each triage cycle in an in-memory `cycleIssues` slice, passed through `investigateTriageRun` calls
- Merge cycle-created issues with GitHub search results before dedup matching, bypassing GitHub Search API eventual consistency lag
- Broaden the search query from job-specific (`in:title "job-name"`) to all triage issues (`in:title "CI Failure:"`) so cross-job dedup can find matches
- Add `mergeIssues` helper to deduplicate issue slices by number
- Add tests for same-job multi-run dedup, cross-job dedup via LLM matching, and `mergeIssues` unit tests

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests: `TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob`, `TestProcessTriageJobs_DeduplicatesDifferentJobsSameRootCause`, `TestMergeIssues`

## Related Issues

Fixes #216

<!-- oompa-bot v:b366a0d -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced CI failure issue deduplication. Multiple failed CI runs related to the same underlying issue are now consolidated into a single issue, with additional run information linked as comments rather than creating duplicate issues.

* **Tests**
  * Added comprehensive test coverage for deduplication behavior across multiple failed runs and issue merging logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->