### PR TITLE
feat: e2e test framework with stateful GitHub mock server

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -52,11 +54,20 @@ type GoGitHubClient struct {
 }
 
 // NewGoGitHubClient creates a new client authenticated with the given token.
+// If OOMPA_GITHUB_API_URL is set, the client uses it as the GitHub Enterprise
+// base URL (for testing with a fake GitHub server).
 func NewGoGitHubClient(token string) *GoGitHubClient {
 	httpClient := &http.Client{Transport: NewCachingTransport(http.DefaultTransport)}
-	return &GoGitHubClient{
-		client: github.NewClient(httpClient).WithAuthToken(token),
+	client := github.NewClient(httpClient).WithAuthToken(token)
+	if base := os.Getenv("OOMPA_GITHUB_API_URL"); base != "" {
+		enterpriseClient, err := client.WithEnterpriseURLs(base, base)
+		if err != nil {
+			slog.Warn("invalid OOMPA_GITHUB_API_URL, falling back to api.github.com", "url", base, "error", err)
+		} else {
+			client = enterpriseClient
+		}
 	}
+	return &GoGitHubClient{client: client}
 }
 
 // NewGoGitHubClientFromHTTPClient creates a new client using a custom HTTP client

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -842,6 +842,32 @@ func TestCountCommitsSince_APIError(t *testing.T) {
 	}
 }
 
+func TestNewGoGitHubClient_EnvOverridesBaseURL(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		issues := []*github.Issue{
+			{Number: new(1), Title: new("test")},
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Setenv("OOMPA_GITHUB_API_URL", server.URL+"/")
+	gh := NewGoGitHubClient("test-token")
+
+	issues, err := gh.ListLabeledIssues(context.Background(), "owner", "repo", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Number != 1 {
+		t.Errorf("expected issue 1, got %d", issues[0].Number)
+	}
+}
+
 func TestAddIssueCommentReaction(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v3/repos/owner/repo/issues/comments/42/reactions", func(w http.ResponseWriter, r *http.Request) {

--- a/test/e2e/fakegithub.go
+++ b/test/e2e/fakegithub.go
@@ -1,0 +1,426 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// FakeIssue represents an issue in the fake GitHub server.
+type FakeIssue struct {
+	Number    int              `json:"number"`
+	Title     string           `json:"title"`
+	Body      string           `json:"body"`
+	State     string           `json:"state"`
+	Labels    []map[string]any `json:"labels"`
+	Assignees []map[string]any `json:"assignees"`
+}
+
+// FakeComment represents an issue comment in the fake GitHub server.
+type FakeComment struct {
+	ID   int64          `json:"id"`
+	Body string         `json:"body"`
+	User map[string]any `json:"user"`
+}
+
+// FakePR represents a pull request in the fake GitHub server.
+type FakePR struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	State  string `json:"state"`
+	Head   string `json:"head"` // head ref name for matching
+	Base   string `json:"base"` // base ref name
+}
+
+// fakePRJSON is the JSON representation returned by the API.
+type fakePRJSON struct {
+	Number int            `json:"number"`
+	Title  string         `json:"title"`
+	Body   string         `json:"body"`
+	State  string         `json:"state"`
+	Merged bool           `json:"merged"`
+	Head   map[string]any `json:"head"`
+	Base   map[string]any `json:"base"`
+}
+
+// CreatePRCall records the arguments of a CreatePR API call.
+type CreatePRCall struct {
+	Title string
+	Body  string
+	Head  string
+	Base  string
+}
+
+// AssignCall records the arguments of an assign/unassign API call.
+type AssignCall struct {
+	IssueNumber int
+	Assignees   []string
+}
+
+// FakeGitHub is a stateful in-memory GitHub API mock backed by httptest.
+type FakeGitHub struct {
+	mu     sync.Mutex
+	t      *testing.T
+	server *httptest.Server
+
+	// State
+	issues        map[int]*FakeIssue     // issue number -> issue
+	comments      map[int][]*FakeComment // issue number -> comments
+	prs           map[int]*FakePR        // PR number -> PR
+	nextCommentID int64
+	nextPRNumber  int
+
+	// Recorders for assertions
+	CreatePRCalls []CreatePRCall
+	AssignCalls   []AssignCall
+	UnassignCalls []AssignCall
+	CommentCalls  []FakeComment // all comments posted via API
+}
+
+// NewFakeGitHub creates a new stateful fake GitHub server.
+func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
+	fg := &FakeGitHub{
+		t:             t,
+		issues:        make(map[int]*FakeIssue),
+		comments:      make(map[int][]*FakeComment),
+		prs:           make(map[int]*FakePR),
+		nextCommentID: 1,
+		nextPRNumber:  100,
+	}
+
+	prefix := fmt.Sprintf("/api/v3/repos/%s/%s", owner, repo)
+	mux := http.NewServeMux()
+
+	// GET /repos/{o}/{r}/issues - list issues with label filtering
+	mux.HandleFunc(prefix+"/issues", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			// Create issue (not needed for smoke test, but handle gracefully)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 999})
+			return
+		}
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+
+		labelFilter := r.URL.Query().Get("labels")
+		var result []*FakeIssue
+		for _, issue := range fg.issues {
+			if issue.State != "open" {
+				continue
+			}
+			if labelFilter != "" {
+				hasLabel := false
+				for _, l := range issue.Labels {
+					if name, ok := l["name"].(string); ok && name == labelFilter {
+						hasLabel = true
+						break
+					}
+				}
+				if !hasLabel {
+					continue
+				}
+			}
+			result = append(result, issue)
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	})
+
+	// GET/POST /repos/{o}/{r}/issues/{n}/comments - list/create issue comments
+	mux.HandleFunc(prefix+"/issues/", func(w http.ResponseWriter, r *http.Request) {
+		// Parse the path to extract issue number and sub-resource
+		path := strings.TrimPrefix(r.URL.Path, prefix+"/issues/")
+		parts := strings.SplitN(path, "/", 2)
+		issueNum, err := strconv.Atoi(parts[0])
+		if err != nil {
+			http.Error(w, "bad issue number", http.StatusBadRequest)
+			return
+		}
+
+		if len(parts) < 2 {
+			// GET /repos/{o}/{r}/issues/{n} - get single issue (not needed but safe)
+			fg.mu.Lock()
+			defer fg.mu.Unlock()
+			if issue, ok := fg.issues[issueNum]; ok {
+				_ = json.NewEncoder(w).Encode(issue)
+			} else {
+				http.NotFound(w, r)
+			}
+			return
+		}
+
+		subResource := parts[1]
+
+		switch subResource {
+		case "comments":
+			fg.handleIssueComments(w, r, issueNum)
+		case "assignees":
+			fg.handleAssignees(w, r, issueNum)
+		case "timeline":
+			fg.handleTimeline(w, r)
+		case "labels":
+			fg.handleLabels(w, r, issueNum)
+		default:
+			// Check for labels/{name} pattern
+			if strings.HasPrefix(subResource, "labels/") {
+				fg.handleLabels(w, r, issueNum)
+			} else {
+				log.Printf("[FakeGitHub] unhandled sub-resource: %s %s", r.Method, r.URL.Path)
+				http.NotFound(w, r)
+			}
+		}
+	})
+
+	// GET/POST /repos/{o}/{r}/pulls - list/create PRs
+	mux.HandleFunc(prefix+"/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			fg.handleCreatePR(w, r)
+			return
+		}
+		fg.handleListPRs(w, r)
+	})
+
+	// Handle /repos/{o}/{r}/pulls/{n} for individual PR operations
+	mux.HandleFunc(prefix+"/pulls/", func(w http.ResponseWriter, r *http.Request) {
+		// GET /repos/{o}/{r}/pulls/{n} - get single PR
+		path := strings.TrimPrefix(r.URL.Path, prefix+"/pulls/")
+		parts := strings.SplitN(path, "/", 2)
+		prNum, err := strconv.Atoi(parts[0])
+		if err != nil {
+			http.Error(w, "bad PR number", http.StatusBadRequest)
+			return
+		}
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+		if pr, ok := fg.prs[prNum]; ok {
+			_ = json.NewEncoder(w).Encode(fg.prToJSON(pr))
+		} else {
+			http.NotFound(w, r)
+		}
+	})
+
+	// Default 404 handler for unmatched routes under /api/v3/
+	mux.HandleFunc("/api/v3/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("[FakeGitHub] UNHANDLED: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	})
+
+	// Catch-all for non-API routes
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("[FakeGitHub] UNHANDLED (root): %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	})
+
+	fg.server = httptest.NewServer(mux)
+	t.Cleanup(fg.server.Close)
+
+	return fg
+}
+
+// URL returns the base URL of the fake server (with trailing slash for go-github).
+func (fg *FakeGitHub) URL() string {
+	return fg.server.URL + "/"
+}
+
+// SeedIssue adds an issue to the fake server's state.
+func (fg *FakeGitHub) SeedIssue(issue FakeIssue) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	issue.State = "open"
+	fg.issues[issue.Number] = &issue
+}
+
+func (fg *FakeGitHub) handleIssueComments(w http.ResponseWriter, r *http.Request, issueNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	// Return 404 if the issue doesn't exist, matching real GitHub API behavior.
+	if _, ok := fg.issues[issueNum]; !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		comments := fg.comments[issueNum]
+		if comments == nil {
+			comments = []*FakeComment{}
+		}
+		_ = json.NewEncoder(w).Encode(comments)
+	case "POST":
+		var body struct {
+			Body string `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		comment := &FakeComment{
+			ID:   fg.nextCommentID,
+			Body: body.Body,
+			User: map[string]any{"login": "oompa-bot"},
+		}
+		fg.nextCommentID++
+		fg.comments[issueNum] = append(fg.comments[issueNum], comment)
+		fg.CommentCalls = append(fg.CommentCalls, *comment)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(comment)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (fg *FakeGitHub) handleAssignees(w http.ResponseWriter, r *http.Request, issueNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	var body struct {
+		Assignees []string `json:"assignees"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+
+	issue, ok := fg.issues[issueNum]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case "POST":
+		// Add assignees
+		for _, a := range body.Assignees {
+			issue.Assignees = append(issue.Assignees, map[string]any{"login": a})
+		}
+		fg.AssignCalls = append(fg.AssignCalls, AssignCall{
+			IssueNumber: issueNum,
+			Assignees:   body.Assignees,
+		})
+		_ = json.NewEncoder(w).Encode(issue)
+	case "DELETE":
+		// Remove assignees
+		var remaining []map[string]any
+		for _, a := range issue.Assignees {
+			login, _ := a["login"].(string)
+			shouldRemove := slices.Contains(body.Assignees, login)
+			if !shouldRemove {
+				remaining = append(remaining, a)
+			}
+		}
+		issue.Assignees = remaining
+		fg.UnassignCalls = append(fg.UnassignCalls, AssignCall{
+			IssueNumber: issueNum,
+			Assignees:   body.Assignees,
+		})
+		_ = json.NewEncoder(w).Encode(issue)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (fg *FakeGitHub) handleTimeline(w http.ResponseWriter, _ *http.Request) {
+	// Return empty timeline events (no linked PRs)
+	_ = json.NewEncoder(w).Encode([]map[string]any{})
+}
+
+func (fg *FakeGitHub) handleLabels(w http.ResponseWriter, r *http.Request, issueNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	// Return an empty JSON array for all label operations to satisfy go-github's
+	// response handling consistently across methods.
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode([]map[string]any{})
+	_ = issueNum // Suppress unused warning — labels are acknowledged but not stored yet
+}
+
+func (fg *FakeGitHub) handleListPRs(w http.ResponseWriter, r *http.Request) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	headFilter := r.URL.Query().Get("head")
+	var result []fakePRJSON
+	for _, pr := range fg.prs {
+		if headFilter != "" {
+			// headFilter can be "owner:branch" or just "branch"
+			branchName := headFilter
+			if _, after, ok := strings.Cut(headFilter, ":"); ok {
+				branchName = after
+			}
+			if pr.Head != branchName {
+				continue
+			}
+		}
+		result = append(result, fg.prToJSON(pr))
+	}
+	if result == nil {
+		result = []fakePRJSON{}
+	}
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+func (fg *FakeGitHub) handleCreatePR(w http.ResponseWriter, r *http.Request) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	var body struct {
+		Title string `json:"title"`
+		Body  string `json:"body"`
+		Head  string `json:"head"`
+		Base  string `json:"base"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+
+	prNumber := fg.nextPRNumber
+	fg.nextPRNumber++
+
+	pr := &FakePR{
+		Number: prNumber,
+		Title:  body.Title,
+		Body:   body.Body,
+		State:  "open",
+		Head:   body.Head,
+		Base:   body.Base,
+	}
+	fg.prs[prNumber] = pr
+
+	fg.CreatePRCalls = append(fg.CreatePRCalls, CreatePRCall{
+		Title: body.Title,
+		Body:  body.Body,
+		Head:  body.Head,
+		Base:  body.Base,
+	})
+
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(fg.prToJSON(pr))
+}
+
+// prToJSON converts a FakePR to the JSON structure go-github expects.
+func (fg *FakeGitHub) prToJSON(pr *FakePR) fakePRJSON {
+	return fakePRJSON{
+		Number: pr.Number,
+		Title:  pr.Title,
+		Body:   pr.Body,
+		State:  pr.State,
+		Merged: false,
+		Head: map[string]any{
+			"ref": pr.Head,
+			"sha": "fake-sha-" + strconv.Itoa(pr.Number),
+		},
+		Base: map[string]any{
+			"ref": pr.Base,
+		},
+	}
+}

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -1,0 +1,233 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// oompaBinary is the path to the compiled oompa binary, built once in TestMain.
+var oompaBinary string
+
+// BuildOompa compiles the oompa binary into a temporary directory.
+// Call this from TestMain. The binary is shared across all tests in the package.
+func BuildOompa(m *testing.M) int {
+	// Find the module root (two levels up from test/e2e/)
+	_, thisFile, _, _ := runtime.Caller(0)
+	moduleRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	tmpDir, err := os.MkdirTemp("", "oompa-e2e-bin-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir for binary: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oompaBinary = filepath.Join(tmpDir, "oompa")
+	cmd := exec.Command("go", "build", "-o", oompaBinary, "./cmd/oompa")
+	cmd.Dir = moduleRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build oompa: %v\n", err)
+		return 1
+	}
+
+	return m.Run()
+}
+
+// Harness holds all per-test temporary state for running oompa end-to-end.
+type Harness struct {
+	t        *testing.T
+	tmpDir   string // root temp dir for this test
+	bareRepo string // path to bare git repo (acts as "origin")
+	homeDir  string // isolated HOME
+	binDir   string // holds fake-claude
+	cloneDir string // passed to oompa --clone-dir
+	owner    string
+	repo     string
+	label    string
+}
+
+// NewHarness creates an isolated test environment with:
+// - a bare git repo seeded with one commit on main
+// - a fake claude script on PATH
+// - an isolated HOME with a gitconfig using insteadOf to redirect GitHub URLs
+func NewHarness(t *testing.T, owner, repo, label string) *Harness {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	h := &Harness{
+		t:        t,
+		tmpDir:   tmpDir,
+		bareRepo: filepath.Join(tmpDir, "bare.git"),
+		homeDir:  filepath.Join(tmpDir, "home"),
+		binDir:   filepath.Join(tmpDir, "bin"),
+		cloneDir: filepath.Join(tmpDir, "clones"),
+		owner:    owner,
+		repo:     repo,
+		label:    label,
+	}
+
+	// Create directories
+	for _, dir := range []string{h.homeDir, h.binDir, h.cloneDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	h.seedBareRepo()
+	h.installFakeClaude()
+	h.writeGitConfig()
+
+	return h
+}
+
+// seedBareRepo creates a bare git repo with one commit on main.
+func (h *Harness) seedBareRepo() {
+	h.t.Helper()
+
+	// Create bare repo with main as the default branch
+	h.run("", "git", "init", "--bare", "--initial-branch=main", h.bareRepo)
+
+	// Create a scratch clone, add a commit, push to establish main
+	scratch := filepath.Join(h.tmpDir, "scratch")
+	h.run("", "git", "clone", h.bareRepo, scratch)
+	h.run(scratch, "git", "config", "user.name", "e2e")
+	h.run(scratch, "git", "config", "user.email", "e2e@example.com")
+	h.run(scratch, "git", "checkout", "-b", "main")
+
+	// Create an initial file and commit
+	readmePath := filepath.Join(scratch, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# Test Repo\n"), 0o644); err != nil {
+		h.t.Fatalf("write README: %v", err)
+	}
+	h.run(scratch, "git", "add", "README.md")
+	h.run(scratch, "git", "commit", "-m", "initial commit")
+	h.run(scratch, "git", "push", "-u", "origin", "main")
+}
+
+// installFakeClaude copies the fake-claude.sh script into the bin dir as "claude".
+func (h *Harness) installFakeClaude() {
+	h.t.Helper()
+
+	// Find the testdata directory relative to this source file
+	_, thisFile, _, _ := runtime.Caller(0)
+	srcScript := filepath.Join(filepath.Dir(thisFile), "testdata", "fake-claude.sh")
+
+	data, err := os.ReadFile(srcScript)
+	if err != nil {
+		h.t.Fatalf("read fake-claude.sh: %v", err)
+	}
+
+	dst := filepath.Join(h.binDir, "claude")
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		h.t.Fatalf("write claude: %v", err)
+	}
+}
+
+// writeGitConfig creates an isolated gitconfig that redirects GitHub URLs
+// to the local bare repo via insteadOf.
+func (h *Harness) writeGitConfig() {
+	h.t.Helper()
+
+	githubURL := fmt.Sprintf("https://github.com/%s/%s.git", h.owner, h.repo)
+
+	config := fmt.Sprintf(`[url "file://%s"]
+    insteadOf = %s
+[user]
+    name = e2e
+    email = e2e@example.com
+[init]
+    defaultBranch = main
+[safe]
+    directory = *
+[commit]
+    gpgsign = false
+[tag]
+    gpgsign = false
+`, h.bareRepo, githubURL)
+
+	gitconfigPath := filepath.Join(h.homeDir, ".gitconfig")
+	if err := os.WriteFile(gitconfigPath, []byte(config), 0o644); err != nil {
+		h.t.Fatalf("write gitconfig: %v", err)
+	}
+}
+
+// RunOompa executes the oompa binary with the given FakeGitHub server URL.
+// Returns stdout, stderr, and exit error (nil on success).
+func (h *Harness) RunOompa(githubURL string) (stdout, stderr string, err error) {
+	h.t.Helper()
+
+	args := []string{
+		"--repo", h.owner + "/" + h.repo,
+		"--label", h.label,
+		"--github-user", h.owner,
+		"--git-author-name", "e2e",
+		"--git-author-email", "e2e@example.com",
+		"--agent", "claudecode",
+		"--one-shot",
+		"--clone-dir", h.cloneDir,
+		"--log-level", "debug",
+	}
+
+	cmd := exec.Command(oompaBinary, args...)
+	// Inherit system env to preserve platform-specific variables (TMPDIR,
+	// SSL_CERT_DIR, etc.) and override only the vars needed for test isolation.
+	// Later values win when duplicates exist in exec.Cmd.Env.
+	cmd.Env = append(os.Environ(),
+		"GITHUB_TOKEN=fake-token",
+		fmt.Sprintf("OOMPA_GITHUB_API_URL=%s", githubURL),
+		fmt.Sprintf("GIT_CONFIG_GLOBAL=%s", filepath.Join(h.homeDir, ".gitconfig")),
+		fmt.Sprintf("HOME=%s", h.homeDir),
+		fmt.Sprintf("PATH=%s:%s", h.binDir, os.Getenv("PATH")),
+		// Prevent git from reading system configs that might interfere
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+
+	var stdoutBuf, stderrBuf strings.Builder
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+
+	return stdoutBuf.String(), stderrBuf.String(), err
+}
+
+// BareRepoHasBranch returns true if the bare repo contains the given branch.
+func (h *Harness) BareRepoHasBranch(branch string) bool {
+	h.t.Helper()
+	cmd := exec.Command("git", "-C", h.bareRepo, "rev-parse", "--verify", branch)
+	// Use the same isolated git config as run() to avoid safe.directory
+	// or other host git config issues.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GIT_CONFIG_GLOBAL=%s", filepath.Join(h.homeDir, ".gitconfig")),
+		fmt.Sprintf("HOME=%s", h.homeDir),
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	return cmd.Run() == nil
+}
+
+// run executes a command and fails the test on error.
+func (h *Harness) run(dir, name string, args ...string) {
+	h.t.Helper()
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	// Use isolated git config for all git operations
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GIT_CONFIG_GLOBAL=%s", filepath.Join(h.homeDir, ".gitconfig")),
+		fmt.Sprintf("HOME=%s", h.homeDir),
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		h.t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, string(out))
+	}
+}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(BuildOompa(m))
+}
+
+// TestE2ESmoke_NewIssueToPR verifies the full happy path:
+// a new labeled issue is discovered, assigned, commented on, implemented by
+// the fake agent, and a PR is created — all via a black-box oompa subprocess.
+func TestE2ESmoke_NewIssueToPR(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	// Set up fake GitHub
+	fg := NewFakeGitHub(t, owner, repo)
+	fg.SeedIssue(FakeIssue{
+		Number: 42,
+		Title:  "Fix the widget",
+		Body:   "The widget is broken, please fix it.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	// Set up harness (bare repo, fake claude, isolated gitconfig)
+	h := NewHarness(t, owner, repo, label)
+
+	// Run oompa
+	stdout, stderr, err := h.RunOompa(fg.URL())
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// === Assertions ===
+
+	// 1. Exactly one CreatePR call with correct head and base
+	fg.mu.Lock()
+	prCalls := fg.CreatePRCalls
+	fg.mu.Unlock()
+
+	if len(prCalls) != 1 {
+		t.Fatalf("expected exactly 1 CreatePR call, got %d", len(prCalls))
+	}
+	if prCalls[0].Head != "ai/issue-42" {
+		t.Errorf("expected PR head 'ai/issue-42', got %q", prCalls[0].Head)
+	}
+	if prCalls[0].Base != "main" {
+		t.Errorf("expected PR base 'main', got %q", prCalls[0].Base)
+	}
+
+	// 2. Issue was assigned then unassigned (verify both calls and final state)
+	fg.mu.Lock()
+	assignCalls := fg.AssignCalls
+	unassignCalls := fg.UnassignCalls
+	finalAssignees := fg.issues[42].Assignees
+	fg.mu.Unlock()
+
+	if len(assignCalls) < 1 {
+		t.Error("expected at least 1 AssignIssue call")
+	}
+	if len(unassignCalls) < 1 {
+		t.Error("expected at least 1 UnassignIssue call")
+	}
+	if len(finalAssignees) != 0 {
+		t.Errorf("expected issue to end with no assignees, got %v", finalAssignees)
+	}
+
+	// 3. At least one comment contains "working on this issue"
+	fg.mu.Lock()
+	commentCalls := fg.CommentCalls
+	fg.mu.Unlock()
+
+	foundWorkingComment := false
+	for _, c := range commentCalls {
+		if strings.Contains(c.Body, "working on this issue") {
+			foundWorkingComment = true
+			break
+		}
+	}
+	if !foundWorkingComment {
+		t.Error("expected a comment containing 'working on this issue'")
+	}
+
+	// 4. The bare repo has the pushed branch
+	if !h.BareRepoHasBranch("ai/issue-42") {
+		t.Error("expected branch 'ai/issue-42' in bare repo, but it was not found")
+	}
+}

--- a/test/e2e/testdata/fake-claude.sh
+++ b/test/e2e/testdata/fake-claude.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null                              # consume the prompt on stdin
+echo "e2e fix" > FIX.md
+git add FIX.md
+git commit -q -m "e2e: implement issue"     # MUST produce a commit (issues.go:198 checks origin/main..HEAD non-empty)
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"done"}'


### PR DESCRIPTION
Fixes #141

## Summary

Add an e2e test framework with a stateful GitHub mock server that exercises the full oompa lifecycle as a black-box subprocess. This is Iteration 1: foundation + one smoke test (new labeled issue -> PR created).

## Changes

- Add `OOMPA_GITHUB_API_URL` env var hook in `pkg/agent/github.go` to redirect GitHub API calls to a fake server (uses `WithEnterpriseURLs` for correct `/api/v3/` prefix handling)
- Add unit test for the env var override in `pkg/agent/github_test.go`
- Add `test/e2e/fakegithub.go`: stateful in-memory httptest server implementing the GitHub REST API endpoints needed for the new-issue happy path (issues, PRs, comments, assignees, timeline, labels)
- Add `test/e2e/harness.go`: builds the real oompa binary once in TestMain, creates isolated test environments with bare git repos, fake `claude` CLI on PATH, and gitconfig with `insteadOf` URL rewriting
- Add `test/e2e/testdata/fake-claude.sh`: minimal fake Claude Code CLI that creates a commit and emits valid stream-json output
- Add `test/e2e/smoke_test.go`: `TestE2ESmoke_NewIssueToPR` verifying the full happy path (issue discovered -> assigned -> commented -> agent runs -> branch pushed -> PR created -> unassigned)

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (FakeGitHub state is mutex-protected)
- [x] `staticcheck ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `pkg/agent/integration_test.go` is untouched and still passes

## Related Issues

Fixes #141

<!-- oompa-bot v:444b535 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for GitHub Enterprise by allowing a custom API base URL to be configured via the `OOMPA_GITHUB_API_URL` environment variable.

* **Tests**
  * Added end-to-end testing suite to validate core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->