### PR TITLE
feat: e2e test scenarios for regression coverage (review, CI, Slack, events, rebase)

### DIFF
--- a/test/e2e/ci_test.go
+++ b/test/e2e/ci_test.go
@@ -1,0 +1,242 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestE2E_CIFailureTriage verifies CI failure detection and triage:
+// oompa discovers a PR with failing check runs, invokes the agent to classify
+// the failure, and posts a consolidated CI comment.
+// This scenario catches regressions in: #140, #192, #200, #216, #218.
+func TestE2E_CIFailureTriage(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	// Seed an issue with an existing PR.
+	fg.SeedIssue(FakeIssue{
+		Number: 20,
+		Title:  "Improve performance",
+		Body:   "Optimize the hot loop.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 300,
+		Title:  "Improve performance",
+		Body:   "Fixes #20",
+		State:  "open",
+		Head:   "ai/issue-20",
+		Base:   "main",
+	})
+
+	headSHA := "ci-test-sha-001"
+	fg.SetPRHeadSHA(300, headSHA)
+
+	// Seed a failing check run (catches #140: check runs registered after PR creation).
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         5001,
+		Name:       "integration-tests",
+		Status:     "completed",
+		Conclusion: "failure",
+		Output: struct {
+			Title   string `json:"title"`
+			Summary string `json:"summary"`
+			Text    string `json:"text"`
+		}{
+			Title:   "Integration Tests Failed",
+			Summary: "1 test failed",
+			Text:    "FAIL: TestNetworkTimeout - connection timed out after 30s",
+		},
+		HTMLURL: "https://github.com/testowner/testrepo/runs/5001",
+	})
+
+	// Seed a second failing check run to test dedup across jobs (catches #218).
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         5002,
+		Name:       "e2e-tests",
+		Status:     "completed",
+		Conclusion: "failure",
+		Output: struct {
+			Title   string `json:"title"`
+			Summary string `json:"summary"`
+			Text    string `json:"text"`
+		}{
+			Title:   "E2E Tests Failed",
+			Summary: "Network related failure",
+			Text:    "FAIL: TestNetworkTimeout - connection timed out after 30s",
+		},
+		HTMLURL: "https://github.com/testowner/testrepo/runs/5002",
+	})
+
+	// Also seed a passing check run to verify it's not reported.
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         5003,
+		Name:       "lint",
+		Status:     "completed",
+		Conclusion: "success",
+	})
+
+	h := NewHarness(t, owner, repo, label)
+	// Install the CI-specific fake claude that outputs UNRELATED classification.
+	h.InstallFakeClaudeScript("fake-claude-ci.sh")
+	pushBranchToBare(t, h, "ai/issue-20")
+
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{300},
+		Reactions: []string{"ci"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// === Assertions ===
+
+	// 1. CI failure was detected — a comment should be posted.
+	fg.mu.Lock()
+	commentCalls := make([]FakeComment, len(fg.CommentCalls))
+	copy(commentCalls, fg.CommentCalls)
+	fg.mu.Unlock()
+
+	foundCIComment := false
+	for _, c := range commentCalls {
+		if strings.Contains(c.Body, "CI Failure Analysis") {
+			foundCIComment = true
+			break
+		}
+	}
+	if !foundCIComment {
+		t.Error("expected a CI Failure Analysis comment to be posted")
+	}
+
+	// 2. Both failing checks should appear in a single consolidated comment.
+	consolidatedComment := ""
+	for _, c := range commentCalls {
+		if strings.Contains(c.Body, "CI Failure Analysis") {
+			consolidatedComment = c.Body
+			break
+		}
+	}
+	if consolidatedComment != "" {
+		if !strings.Contains(consolidatedComment, "integration-tests") {
+			t.Error("consolidated CI comment missing 'integration-tests'")
+		}
+		if !strings.Contains(consolidatedComment, "e2e-tests") {
+			t.Error("consolidated CI comment missing 'e2e-tests'")
+		}
+	}
+
+	// 3. Verify that the agent was invoked with the CI context.
+	stdinMarker := findStdinMarker(t, h.CloneDir())
+	if stdinMarker == "" {
+		t.Error("expected .oompa-stdin-marker — agent was not invoked for CI investigation")
+	}
+}
+
+// TestE2E_CIFailureTriage_DedupOnRepoll verifies that the same CI failure
+// is not re-investigated on the next poll cycle (catches #200).
+func TestE2E_CIFailureTriage_DedupOnRepoll(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	fg.SeedIssue(FakeIssue{
+		Number: 21,
+		Title:  "Dedup test",
+		Body:   "Test CI dedup.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 301,
+		Title:  "Dedup test",
+		Body:   "Fixes #21",
+		State:  "open",
+		Head:   "ai/issue-21",
+		Base:   "main",
+	})
+
+	headSHA := "dedup-sha-001"
+	fg.SetPRHeadSHA(301, headSHA)
+
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         6001,
+		Name:       "unit-tests",
+		Status:     "completed",
+		Conclusion: "failure",
+		Output: struct {
+			Title   string `json:"title"`
+			Summary string `json:"summary"`
+			Text    string `json:"text"`
+		}{
+			Text: "FAIL: TestSomething - assertion failed",
+		},
+	})
+
+	h := NewHarness(t, owner, repo, label)
+	h.InstallFakeClaudeScript("fake-claude-ci.sh")
+	pushBranchToBare(t, h, "ai/issue-21")
+
+	// First run: should investigate and post comment.
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{301},
+		Reactions: []string{"ci"},
+	})
+	if err != nil {
+		t.Fatalf("first run failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	fg.mu.Lock()
+	firstRunComments := len(fg.CommentCalls)
+	fg.mu.Unlock()
+
+	if firstRunComments == 0 {
+		t.Fatal("expected at least 1 comment from first CI run")
+	}
+
+	// Second run: same SHA, same check — should NOT post a duplicate comment.
+	// The dedup marker comment from the first run should prevent re-investigation.
+	stdout2, stderr2, err2 := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{301},
+		Reactions: []string{"ci"},
+	})
+	if err2 != nil {
+		t.Fatalf("second run failed: %v\nstdout:\n%s\nstderr:\n%s", err2, stdout2, stderr2)
+	}
+
+	// The CI marker comment contains "<!-- oompa-bot ci:SHA:checkName -->"
+	// which deduplicates across runs. No new CI analysis comments should appear.
+	// Note: state is rebuilt from GitHub API on each run, but the marker comments
+	// persist in the fake server's state.
+	// Copy new comment bodies under a single lock acquisition to avoid
+	// data races from concurrent HTTP server goroutines.
+	fg.mu.Lock()
+	var newBodies []string
+	for i := firstRunComments; i < len(fg.CommentCalls); i++ {
+		newBodies = append(newBodies, fg.CommentCalls[i].Body)
+	}
+	fg.mu.Unlock()
+
+	if len(newBodies) > 1 {
+		// Allow at most 1 extra comment (e.g., state-rebuild noise) but not another
+		// full CI Failure Analysis block.
+		var newCIComments int
+		for _, body := range newBodies {
+			if strings.Contains(body, "CI Failure Analysis") {
+				newCIComments++
+			}
+		}
+		if newCIComments > 0 {
+			t.Errorf("expected no duplicate CI Failure Analysis comment on re-poll, got %d new", newCIComments)
+		}
+	}
+}

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -1,0 +1,109 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestE2E_EventCategories is an end-to-end smoke test for issue discovery and
+// processing. It verifies that oompa successfully scans for issues, invokes the
+// agent, and creates a PR — exercising the full event emission pipeline.
+// The event server emits category-tagged events internally; this test validates
+// the observable outcomes (PR creation, log entries) rather than inspecting
+// the event stream directly, since the Unix socket is unavailable after the
+// subprocess exits.
+func TestE2E_EventCategories(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	// Seed an issue so oompa has something to discover and process.
+	fg.SeedIssue(FakeIssue{
+		Number: 50,
+		Title:  "Event category test",
+		Body:   "Test event categories.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	h := NewHarness(t, owner, repo, label)
+
+	stdout, stderr, err := h.RunOompa(fg.URL())
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Verify oompa processes the issue correctly. The main assertions are
+	// that issue scanning and processing work end-to-end with events being
+	// emitted (verified by the fact that the PR is created successfully).
+
+	// Verify the issue was processed (PR created).
+	fg.mu.Lock()
+	prCalls := fg.CreatePRCalls
+	fg.mu.Unlock()
+
+	if len(prCalls) != 1 {
+		t.Fatalf("expected exactly 1 CreatePR call, got %d\nstderr:\n%s", len(prCalls), stderr)
+	}
+
+	// Verify through logs that issue processing occurred.
+	if !strings.Contains(stderr, "processing new issue") {
+		t.Error("expected 'processing new issue' log entry in debug output")
+	}
+	if !strings.Contains(stderr, "created PR") {
+		t.Error("expected 'created PR' log entry in debug output")
+	}
+}
+
+// TestE2E_EventCategories_WatchPRs verifies that --watch-prs mode correctly
+// bootstraps tracked PRs and runs the poll cycle. This is a smoke test for
+// the watch-prs bootstrapping path — it checks that the PR is discovered and
+// the review check runs without errors, validating the observable log output.
+func TestE2E_EventCategories_WatchPRs(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	// Seed an existing PR to watch.
+	fg.SeedIssue(FakeIssue{
+		Number: 51,
+		Title:  "PR watch event test",
+		Body:   "Test events in watch mode.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 500,
+		Title:  "PR watch event test",
+		Body:   "Fixes #51",
+		State:  "open",
+		Head:   "ai/issue-51",
+		Base:   "main",
+	})
+	fg.SetPRHeadSHA(500, "event-test-sha-001")
+
+	h := NewHarness(t, owner, repo, label)
+	pushBranchToBare(t, h, "ai/issue-51")
+
+	// Run in watch mode with reviews — should emit "Checking for review comments".
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{500},
+		Reactions: []string{"reviews"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Verify oompa ran in watch-prs mode. The bootstrapping should log the PR.
+	if !strings.Contains(stderr, "recovered watched PR state") &&
+		!strings.Contains(stderr, "bootstrapped watched PR") {
+		t.Error("expected PR bootstrap log message in debug output")
+	}
+}

--- a/test/e2e/fakegithub.go
+++ b/test/e2e/fakegithub.go
@@ -42,13 +42,14 @@ type FakePR struct {
 
 // fakePRJSON is the JSON representation returned by the API.
 type fakePRJSON struct {
-	Number int            `json:"number"`
-	Title  string         `json:"title"`
-	Body   string         `json:"body"`
-	State  string         `json:"state"`
-	Merged bool           `json:"merged"`
-	Head   map[string]any `json:"head"`
-	Base   map[string]any `json:"base"`
+	Number         int            `json:"number"`
+	Title          string         `json:"title"`
+	Body           string         `json:"body"`
+	State          string         `json:"state"`
+	Merged         bool           `json:"merged"`
+	Head           map[string]any `json:"head"`
+	Base           map[string]any `json:"base"`
+	MergeableState string         `json:"mergeable_state,omitempty"`
 }
 
 // CreatePRCall records the arguments of a CreatePR API call.
@@ -65,6 +66,40 @@ type AssignCall struct {
 	Assignees   []string
 }
 
+// FakeReviewComment represents an inline review comment on a PR.
+type FakeReviewComment struct {
+	ID          int64          `json:"id"`
+	InReplyToID int64          `json:"in_reply_to_id,omitempty"`
+	Body        string         `json:"body"`
+	Path        string         `json:"path"`
+	Line        int            `json:"line"`
+	User        map[string]any `json:"user"`
+}
+
+// FakeCheckRun represents a GitHub check run.
+type FakeCheckRun struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	Output     struct {
+		Title   string `json:"title"`
+		Summary string `json:"summary"`
+		Text    string `json:"text"`
+	} `json:"output"`
+	HTMLURL     string `json:"html_url"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+// FakeReview represents a GitHub PR review.
+type FakeReview struct {
+	ID          int64          `json:"id"`
+	User        map[string]any `json:"user"`
+	State       string         `json:"state"`
+	Body        string         `json:"body"`
+	SubmittedAt string         `json:"submitted_at"`
+}
+
 // FakeGitHub is a stateful in-memory GitHub API mock backed by httptest.
 type FakeGitHub struct {
 	mu     sync.Mutex
@@ -72,28 +107,70 @@ type FakeGitHub struct {
 	server *httptest.Server
 
 	// State
-	issues        map[int]*FakeIssue     // issue number -> issue
-	comments      map[int][]*FakeComment // issue number -> comments
-	prs           map[int]*FakePR        // PR number -> PR
-	nextCommentID int64
-	nextPRNumber  int
+	issues          map[int]*FakeIssue           // issue number -> issue
+	comments        map[int][]*FakeComment       // issue number -> comments
+	prs             map[int]*FakePR              // PR number -> PR
+	reviewComments  map[int][]*FakeReviewComment // PR number -> inline review comments
+	checkRuns       map[string][]*FakeCheckRun   // SHA -> check runs
+	reviews         map[int][]*FakeReview        // PR number -> reviews
+	prHeadSHAs      map[int]string               // PR number -> HEAD SHA override
+	prMergeStates   map[int]string               // PR number -> mergeable_state
+	commitStatuses  map[string][]map[string]any  // SHA -> commit statuses
+	reactions       map[int64][]map[string]any   // commentID -> reactions
+	nextCommentID   int64
+	nextPRNumber    int
+	nextReviewComID int64
+	nextIssueNumber int
 
 	// Recorders for assertions
-	CreatePRCalls []CreatePRCall
-	AssignCalls   []AssignCall
-	UnassignCalls []AssignCall
-	CommentCalls  []FakeComment // all comments posted via API
+	CreatePRCalls    []CreatePRCall
+	CreateIssueCalls []CreateIssueCall
+	AssignCalls      []AssignCall
+	UnassignCalls    []AssignCall
+	CommentCalls     []FakeComment     // all comments posted via API
+	ReviewReplyCalls []ReviewReplyCall // replies to PR review threads
+	ReactionCalls    []ReactionCall    // reactions added
+	SearchIssueCalls []string          // search queries
+}
+
+// CreateIssueCall records the arguments of a CreateIssue API call.
+type CreateIssueCall struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// ReviewReplyCall records a reply to a PR review comment.
+type ReviewReplyCall struct {
+	PRNumber  int
+	CommentID int64
+	Body      string
+}
+
+// ReactionCall records a reaction added.
+type ReactionCall struct {
+	CommentID int64
+	Reaction  string
 }
 
 // NewFakeGitHub creates a new stateful fake GitHub server.
 func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
 	fg := &FakeGitHub{
-		t:             t,
-		issues:        make(map[int]*FakeIssue),
-		comments:      make(map[int][]*FakeComment),
-		prs:           make(map[int]*FakePR),
-		nextCommentID: 1,
-		nextPRNumber:  100,
+		t:               t,
+		issues:          make(map[int]*FakeIssue),
+		comments:        make(map[int][]*FakeComment),
+		prs:             make(map[int]*FakePR),
+		reviewComments:  make(map[int][]*FakeReviewComment),
+		checkRuns:       make(map[string][]*FakeCheckRun),
+		reviews:         make(map[int][]*FakeReview),
+		prHeadSHAs:      make(map[int]string),
+		prMergeStates:   make(map[int]string),
+		commitStatuses:  make(map[string][]map[string]any),
+		reactions:       make(map[int64][]map[string]any),
+		nextCommentID:   1,
+		nextPRNumber:    100,
+		nextReviewComID: 1,
+		nextIssueNumber: 900,
 	}
 
 	prefix := fmt.Sprintf("/api/v3/repos/%s/%s", owner, repo)
@@ -102,9 +179,7 @@ func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
 	// GET /repos/{o}/{r}/issues - list issues with label filtering
 	mux.HandleFunc(prefix+"/issues", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
-			// Create issue (not needed for smoke test, but handle gracefully)
-			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"number": 999})
+			fg.handleCreateIssue(w, r)
 			return
 		}
 		fg.mu.Lock()
@@ -187,9 +262,8 @@ func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
 		fg.handleListPRs(w, r)
 	})
 
-	// Handle /repos/{o}/{r}/pulls/{n} for individual PR operations
+	// Handle /repos/{o}/{r}/pulls/{n} and sub-resources
 	mux.HandleFunc(prefix+"/pulls/", func(w http.ResponseWriter, r *http.Request) {
-		// GET /repos/{o}/{r}/pulls/{n} - get single PR
 		path := strings.TrimPrefix(r.URL.Path, prefix+"/pulls/")
 		parts := strings.SplitN(path, "/", 2)
 		prNum, err := strconv.Atoi(parts[0])
@@ -197,13 +271,195 @@ func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
 			http.Error(w, "bad PR number", http.StatusBadRequest)
 			return
 		}
-		fg.mu.Lock()
-		defer fg.mu.Unlock()
-		if pr, ok := fg.prs[prNum]; ok {
-			_ = json.NewEncoder(w).Encode(fg.prToJSON(pr))
-		} else {
+
+		if len(parts) < 2 {
+			// GET /repos/{o}/{r}/pulls/{n} - get single PR
+			fg.mu.Lock()
+			defer fg.mu.Unlock()
+			if pr, ok := fg.prs[prNum]; ok {
+				_ = json.NewEncoder(w).Encode(fg.prToJSON(pr))
+			} else {
+				http.NotFound(w, r)
+			}
+			return
+		}
+
+		subResource := parts[1]
+		switch subResource {
+		case "comments":
+			fg.handlePRReviewComments(w, r, prNum)
+		case "reviews":
+			fg.handlePRReviews(w, r, prNum)
+		case "commits":
+			fg.handlePRCommits(w, r, prNum)
+		default:
+			log.Printf("[FakeGitHub] unhandled PR sub-resource: %s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
+	})
+
+	// GET /repos/{o}/{r}/commits - list commits (for CountCommitsSince)
+	mux.HandleFunc(prefix+"/commits", func(w http.ResponseWriter, r *http.Request) {
+		// Return empty list (no recent commits = quiet main branch)
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	})
+
+	// GET /repos/{o}/{r}/commits/{sha}/check-runs or /commits/{sha}/status or /commits/{sha}
+	mux.HandleFunc(prefix+"/commits/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, prefix+"/commits/")
+		parts := strings.SplitN(path, "/", 2)
+		sha := parts[0]
+		if len(parts) >= 2 && parts[1] == "check-runs" {
+			fg.handleCheckRuns(w, r, sha)
+			return
+		}
+		if len(parts) >= 2 && parts[1] == "status" {
+			fg.handleCommitStatuses(w, r, sha)
+			return
+		}
+		// GET /repos/{o}/{r}/commits/{sha} - single commit
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sha": sha,
+			"commit": map[string]any{
+				"committer": map[string]any{
+					"date": "2025-01-01T00:00:00Z",
+				},
+			},
+		})
+	})
+
+	// GET /repos/{o}/{r}/compare/{base}...{head}
+	mux.HandleFunc(prefix+"/compare/", func(w http.ResponseWriter, r *http.Request) {
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ahead_by":  0,
+			"behind_by": 0,
+			"status":    "identical",
+		})
+	})
+
+	// GET /api/v3/search/issues
+	mux.HandleFunc("/api/v3/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		fg.mu.Lock()
+		defer fg.mu.Unlock()
+		query := r.URL.Query().Get("q")
+		fg.SearchIssueCalls = append(fg.SearchIssueCalls, query)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 0,
+			"items":       []any{},
+		})
+	})
+
+	// Handle reactions on PR comments: /repos/{o}/{r}/pulls/comments/{id}/reactions
+	mux.HandleFunc(prefix+"/pulls/comments/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, prefix+"/pulls/comments/")
+		parts := strings.SplitN(path, "/", 2)
+		commentID, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			http.Error(w, "bad comment ID", http.StatusBadRequest)
+			return
+		}
+		// GET or POST .../reactions
+		if len(parts) >= 2 && parts[1] == "reactions" {
+			fg.mu.Lock()
+			defer fg.mu.Unlock()
+			if r.Method == "POST" {
+				var body struct {
+					Content string `json:"content"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, "bad body", http.StatusBadRequest)
+					return
+				}
+				fg.ReactionCalls = append(fg.ReactionCalls, ReactionCall{
+					CommentID: commentID,
+					Reaction:  body.Content,
+				})
+				fg.reactions[commentID] = append(fg.reactions[commentID], map[string]any{
+					"id":      int64(len(fg.reactions[commentID]) + 1),
+					"content": body.Content,
+					"user":    map[string]any{"login": "oompa-bot"},
+				})
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      1,
+					"content": body.Content,
+				})
+				return
+			}
+			// GET reactions - return persisted reactions for this comment
+			_ = json.NewEncoder(w).Encode(fg.reactions[commentID])
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	// Handle reactions on issue comments: /repos/{o}/{r}/issues/comments/{id}/reactions
+	mux.HandleFunc(prefix+"/issues/comments/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, prefix+"/issues/comments/")
+		parts := strings.SplitN(path, "/", 2)
+		commentID, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil {
+			http.Error(w, "bad comment ID", http.StatusBadRequest)
+			return
+		}
+		if len(parts) >= 2 && parts[1] == "reactions" {
+			fg.mu.Lock()
+			defer fg.mu.Unlock()
+			if r.Method == "POST" {
+				var body struct {
+					Content string `json:"content"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, "bad body", http.StatusBadRequest)
+					return
+				}
+				fg.ReactionCalls = append(fg.ReactionCalls, ReactionCall{
+					CommentID: commentID,
+					Reaction:  body.Content,
+				})
+				fg.reactions[commentID] = append(fg.reactions[commentID], map[string]any{
+					"id":      int64(len(fg.reactions[commentID]) + 1),
+					"content": body.Content,
+					"user":    map[string]any{"login": "oompa-bot"},
+				})
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      1,
+					"content": body.Content,
+				})
+				return
+			}
+			// GET reactions - return persisted reactions for this comment
+			_ = json.NewEncoder(w).Encode(fg.reactions[commentID])
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	// Handle check-runs/{id} for log fetching
+	mux.HandleFunc(prefix+"/check-runs/", func(w http.ResponseWriter, r *http.Request) {
+		// Return empty log for check run log requests
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(""))
+	})
+
+	// Handle actions/jobs/{id}/logs for GetCheckRunLog
+	// go-github expects a 302 redirect to the actual log content.
+	mux.HandleFunc(prefix+"/actions/jobs/", func(w http.ResponseWriter, r *http.Request) {
+		// Return 302 redirect to a dummy log URL
+		http.Redirect(w, r, fg.server.URL+"/fake-logs", http.StatusFound)
+	})
+
+	// Serve fake log content for redirected log requests
+	mux.HandleFunc("/fake-logs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("(no logs available)"))
 	})
 
 	// Default 404 handler for unmatched routes under /api/v3/
@@ -241,10 +497,13 @@ func (fg *FakeGitHub) handleIssueComments(w http.ResponseWriter, r *http.Request
 	fg.mu.Lock()
 	defer fg.mu.Unlock()
 
-	// Return 404 if the issue doesn't exist, matching real GitHub API behavior.
+	// Return 404 if neither an issue nor a PR exists for this number.
+	// In GitHub's API, PRs are also issues and share the same comment endpoint.
 	if _, ok := fg.issues[issueNum]; !ok {
-		http.NotFound(w, r)
-		return
+		if _, ok := fg.prs[issueNum]; !ok {
+			http.NotFound(w, r)
+			return
+		}
 	}
 
 	switch r.Method {
@@ -407,8 +666,261 @@ func (fg *FakeGitHub) handleCreatePR(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(fg.prToJSON(pr))
 }
 
+// SeedPR adds a PR to the fake server's state.
+func (fg *FakeGitHub) SeedPR(pr FakePR) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if pr.State == "" {
+		pr.State = "open"
+	}
+	fg.prs[pr.Number] = &pr
+}
+
+// SeedReviewComment adds an inline review comment to a PR.
+func (fg *FakeGitHub) SeedReviewComment(prNumber int, comment FakeReviewComment) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if comment.ID == 0 {
+		comment.ID = fg.nextReviewComID
+		fg.nextReviewComID++
+	} else if comment.ID >= fg.nextReviewComID {
+		fg.nextReviewComID = comment.ID + 1
+	}
+	if comment.User == nil {
+		comment.User = map[string]any{"login": "reviewer"}
+	}
+	fg.reviewComments[prNumber] = append(fg.reviewComments[prNumber], &comment)
+}
+
+// SeedCheckRun adds a check run for a commit SHA.
+func (fg *FakeGitHub) SeedCheckRun(sha string, cr FakeCheckRun) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	fg.checkRuns[sha] = append(fg.checkRuns[sha], &cr)
+}
+
+// SeedReview adds a PR review.
+func (fg *FakeGitHub) SeedReview(prNumber int, review FakeReview) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	fg.reviews[prNumber] = append(fg.reviews[prNumber], &review)
+}
+
+// SetPRHeadSHA overrides the HEAD SHA for a PR.
+func (fg *FakeGitHub) SetPRHeadSHA(prNumber int, sha string) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	fg.prHeadSHAs[prNumber] = sha
+}
+
+// SetPRMergeState sets the mergeable_state for a PR.
+func (fg *FakeGitHub) SetPRMergeState(prNumber int, state string) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	fg.prMergeStates[prNumber] = state
+}
+
+// SeedIssueComment adds a comment to an issue.
+func (fg *FakeGitHub) SeedIssueComment(issueNumber int, comment FakeComment) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if comment.ID == 0 {
+		comment.ID = fg.nextCommentID
+		fg.nextCommentID++
+	} else if comment.ID >= fg.nextCommentID {
+		fg.nextCommentID = comment.ID + 1
+	}
+	if comment.User == nil {
+		comment.User = map[string]any{"login": "reviewer"}
+	}
+	fg.comments[issueNumber] = append(fg.comments[issueNumber], &comment)
+}
+
+func (fg *FakeGitHub) handlePRReviewComments(w http.ResponseWriter, r *http.Request, prNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	switch r.Method {
+	case "POST":
+		// Reply to a review comment
+		var body struct {
+			Body      string `json:"body"`
+			InReplyTo int64  `json:"in_reply_to"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		reply := &FakeReviewComment{
+			ID:          fg.nextReviewComID,
+			InReplyToID: body.InReplyTo,
+			Body:        body.Body,
+			User:        map[string]any{"login": "oompa-bot"},
+		}
+		fg.nextReviewComID++
+		fg.reviewComments[prNum] = append(fg.reviewComments[prNum], reply)
+		fg.ReviewReplyCalls = append(fg.ReviewReplyCalls, ReviewReplyCall{
+			PRNumber:  prNum,
+			CommentID: body.InReplyTo,
+			Body:      body.Body,
+		})
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(reply)
+	case "GET":
+		// Return review comments with pagination support.
+		comments := fg.reviewComments[prNum]
+		if comments == nil {
+			comments = []*FakeReviewComment{}
+		}
+		q := r.URL.Query()
+		page, _ := strconv.Atoi(q.Get("page"))
+		perPage, _ := strconv.Atoi(q.Get("per_page"))
+		if page < 1 {
+			page = 1
+		}
+		if perPage <= 0 {
+			perPage = 30
+		}
+		start := min((page-1)*perPage, len(comments))
+		end := min(start+perPage, len(comments))
+		// Set Link header for next page if more results exist
+		if end < len(comments) {
+			nextURL := fmt.Sprintf("<%s?page=%d&per_page=%d>; rel=\"next\"",
+				r.URL.Path, page+1, perPage)
+			w.Header().Set("Link", nextURL)
+		}
+		_ = json.NewEncoder(w).Encode(comments[start:end])
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (fg *FakeGitHub) handlePRReviews(w http.ResponseWriter, r *http.Request, prNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	switch r.Method {
+	case "POST":
+		// Submit a review (not needed for e2e, but return success)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+	case "GET":
+		reviews := fg.reviews[prNum]
+		if reviews == nil {
+			reviews = []*FakeReview{}
+		}
+		_ = json.NewEncoder(w).Encode(reviews)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (fg *FakeGitHub) handlePRCommits(w http.ResponseWriter, _ *http.Request, prNum int) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	sha := "fake-sha-" + strconv.Itoa(prNum)
+	if override, ok := fg.prHeadSHAs[prNum]; ok {
+		sha = override
+	}
+	_ = json.NewEncoder(w).Encode([]map[string]any{
+		{
+			"sha": sha,
+			"commit": map[string]any{
+				"message": "initial commit",
+			},
+		},
+	})
+}
+
+func (fg *FakeGitHub) handleCheckRuns(w http.ResponseWriter, _ *http.Request, sha string) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	runs := fg.checkRuns[sha]
+	if runs == nil {
+		runs = []*FakeCheckRun{}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"total_count": len(runs),
+		"check_runs":  runs,
+	})
+}
+
+func (fg *FakeGitHub) handleCommitStatuses(w http.ResponseWriter, _ *http.Request, sha string) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	statuses := fg.commitStatuses[sha]
+	if statuses == nil {
+		statuses = []map[string]any{}
+	}
+	// Return "success" when no statuses are seeded to avoid masking future bugs
+	// if production code ever checks the combined state field.
+	combinedState := "success"
+	if len(statuses) > 0 {
+		combinedState = "failure"
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"state":    combinedState,
+		"statuses": statuses,
+	})
+}
+
+func (fg *FakeGitHub) handleCreateIssue(w http.ResponseWriter, r *http.Request) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+
+	var body struct {
+		Title  string   `json:"title"`
+		Body   string   `json:"body"`
+		Labels []string `json:"labels"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+
+	issueNum := fg.nextIssueNumber
+	fg.nextIssueNumber++
+
+	// Persist the new issue into fake state so subsequent list/get flows see it.
+	labels := make([]map[string]any, 0, len(body.Labels))
+	for _, l := range body.Labels {
+		labels = append(labels, map[string]any{"name": l})
+	}
+	fg.issues[issueNum] = &FakeIssue{
+		Number: issueNum,
+		Title:  body.Title,
+		Body:   body.Body,
+		State:  "open",
+		Labels: labels,
+	}
+
+	fg.CreateIssueCalls = append(fg.CreateIssueCalls, CreateIssueCall{
+		Title:  body.Title,
+		Body:   body.Body,
+		Labels: body.Labels,
+	})
+
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"number": issueNum,
+		"title":  body.Title,
+		"body":   body.Body,
+	})
+}
+
 // prToJSON converts a FakePR to the JSON structure go-github expects.
 func (fg *FakeGitHub) prToJSON(pr *FakePR) fakePRJSON {
+	sha := "fake-sha-" + strconv.Itoa(pr.Number)
+	if override, ok := fg.prHeadSHAs[pr.Number]; ok {
+		sha = override
+	}
+	mergeableState := "clean"
+	if ms, ok := fg.prMergeStates[pr.Number]; ok {
+		mergeableState = ms
+	}
 	return fakePRJSON{
 		Number: pr.Number,
 		Title:  pr.Title,
@@ -417,10 +929,11 @@ func (fg *FakeGitHub) prToJSON(pr *FakePR) fakePRJSON {
 		Merged: false,
 		Head: map[string]any{
 			"ref": pr.Head,
-			"sha": "fake-sha-" + strconv.Itoa(pr.Number),
+			"sha": sha,
 		},
 		Base: map[string]any{
 			"ref": pr.Base,
 		},
+		MergeableState: mergeableState,
 	}
 }

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -115,14 +116,19 @@ func (h *Harness) seedBareRepo() {
 // installFakeClaude copies the fake-claude.sh script into the bin dir as "claude".
 func (h *Harness) installFakeClaude() {
 	h.t.Helper()
+	h.InstallFakeClaudeScript("fake-claude.sh")
+}
 
-	// Find the testdata directory relative to this source file
+// InstallFakeClaudeScript installs a specific fake-claude script from testdata/ as "claude".
+func (h *Harness) InstallFakeClaudeScript(scriptName string) {
+	h.t.Helper()
+
 	_, thisFile, _, _ := runtime.Caller(0)
-	srcScript := filepath.Join(filepath.Dir(thisFile), "testdata", "fake-claude.sh")
+	srcScript := filepath.Join(filepath.Dir(thisFile), "testdata", scriptName)
 
 	data, err := os.ReadFile(srcScript)
 	if err != nil {
-		h.t.Fatalf("read fake-claude.sh: %v", err)
+		h.t.Fatalf("read %s: %v", scriptName, err)
 	}
 
 	dst := filepath.Join(h.binDir, "claude")
@@ -159,9 +165,17 @@ func (h *Harness) writeGitConfig() {
 	}
 }
 
+// RunOompaOpts configures optional arguments for RunOompa.
+type RunOompaOpts struct {
+	ExtraArgs []string            // additional CLI flags
+	ExtraEnv  []string            // additional environment variables
+	WatchPRs  []int               // --watch-prs values
+	Reactions []string            // --reactions values
+}
+
 // RunOompa executes the oompa binary with the given FakeGitHub server URL.
 // Returns stdout, stderr, and exit error (nil on success).
-func (h *Harness) RunOompa(githubURL string) (stdout, stderr string, err error) {
+func (h *Harness) RunOompa(githubURL string, opts ...RunOompaOpts) (stdout, stderr string, err error) {
 	h.t.Helper()
 
 	args := []string{
@@ -176,11 +190,7 @@ func (h *Harness) RunOompa(githubURL string) (stdout, stderr string, err error) 
 		"--log-level", "debug",
 	}
 
-	cmd := exec.Command(oompaBinary, args...)
-	// Inherit system env to preserve platform-specific variables (TMPDIR,
-	// SSL_CERT_DIR, etc.) and override only the vars needed for test isolation.
-	// Later values win when duplicates exist in exec.Cmd.Env.
-	cmd.Env = append(os.Environ(),
+	env := append(os.Environ(),
 		"GITHUB_TOKEN=fake-token",
 		fmt.Sprintf("OOMPA_GITHUB_API_URL=%s", githubURL),
 		fmt.Sprintf("GIT_CONFIG_GLOBAL=%s", filepath.Join(h.homeDir, ".gitconfig")),
@@ -188,7 +198,29 @@ func (h *Harness) RunOompa(githubURL string) (stdout, stderr string, err error) 
 		fmt.Sprintf("PATH=%s:%s", h.binDir, os.Getenv("PATH")),
 		// Prevent git from reading system configs that might interfere
 		"GIT_CONFIG_NOSYSTEM=1",
+		// Isolate XDG state from host
+		fmt.Sprintf("XDG_STATE_HOME=%s", filepath.Join(h.tmpDir, "xdg-state")),
+		fmt.Sprintf("XDG_RUNTIME_DIR=%s", filepath.Join(h.tmpDir, "xdg-runtime")),
 	)
+
+	if len(opts) > 0 {
+		opt := opts[0]
+		if len(opt.WatchPRs) > 0 {
+			var nums []string
+			for _, n := range opt.WatchPRs {
+				nums = append(nums, strconv.Itoa(n))
+			}
+			args = append(args, "--watch-prs", strings.Join(nums, ","))
+		}
+		if len(opt.Reactions) > 0 {
+			args = append(args, "--reactions", strings.Join(opt.Reactions, ","))
+		}
+		args = append(args, opt.ExtraArgs...)
+		env = append(env, opt.ExtraEnv...)
+	}
+
+	cmd := exec.Command(oompaBinary, args...)
+	cmd.Env = env
 
 	var stdoutBuf, stderrBuf strings.Builder
 	cmd.Stdout = &stdoutBuf
@@ -197,6 +229,48 @@ func (h *Harness) RunOompa(githubURL string) (stdout, stderr string, err error) 
 	err = cmd.Run()
 
 	return stdoutBuf.String(), stderrBuf.String(), err
+}
+
+// CloneDir returns the clone directory path for external use (e.g., pre-creating corrupt worktrees).
+func (h *Harness) CloneDir() string {
+	return h.cloneDir
+}
+
+// TmpDir returns the root temporary directory for this test harness.
+func (h *Harness) TmpDir() string {
+	return h.tmpDir
+}
+
+// BareRepo returns the bare repo path for external manipulation.
+func (h *Harness) BareRepo() string {
+	return h.bareRepo
+}
+
+// HomeDir returns the isolated HOME directory.
+func (h *Harness) HomeDir() string {
+	return h.homeDir
+}
+
+// AddCommitToBareMain adds a commit to the bare repo's main branch.
+// This simulates upstream activity on main.
+func (h *Harness) AddCommitToBareMain(filename, content, message string) {
+	h.t.Helper()
+
+	scratch := filepath.Join(h.tmpDir, "scratch-diverge")
+	// Clean up any previous scratch dir
+	os.RemoveAll(scratch)
+	h.run("", "git", "clone", h.bareRepo, scratch)
+	h.run(scratch, "git", "config", "user.name", "e2e")
+	h.run(scratch, "git", "config", "user.email", "e2e@example.com")
+	h.run(scratch, "git", "checkout", "main")
+
+	fpath := filepath.Join(scratch, filename)
+	if err := os.WriteFile(fpath, []byte(content), 0o644); err != nil {
+		h.t.Fatalf("write file %s: %v", filename, err)
+	}
+	h.run(scratch, "git", "add", filename)
+	h.run(scratch, "git", "commit", "-m", message)
+	h.run(scratch, "git", "push", "origin", "main")
 }
 
 // BareRepoHasBranch returns true if the bare repo contains the given branch.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile creates a file in the given directory with the specified content.
+func writeFile(t interface{ Fatalf(string, ...any) }, dir, name, content string) {
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+}
+
+// newGitCommand creates an exec.Command for a git operation.
+func newGitCommand(args ...string) *exec.Cmd {
+	return exec.Command("git", args...)
+}
+
+// gitEnv returns the environment variables for isolated git operations.
+func gitEnv(h *Harness) []string {
+	return append(os.Environ(),
+		fmt.Sprintf("GIT_CONFIG_GLOBAL=%s", filepath.Join(h.HomeDir(), ".gitconfig")),
+		fmt.Sprintf("HOME=%s", h.HomeDir()),
+		"GIT_CONFIG_NOSYSTEM=1",
+	)
+}
+
+// findMarkerFile searches for a named marker file in the directory tree.
+func findMarkerFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	var found string
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.Name() == name {
+			found = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// bareBranchSHA returns the commit SHA of a branch in the bare repo.
+func bareBranchSHA(t *testing.T, h *Harness, branchName string) string {
+	t.Helper()
+	cmd := newGitCommand("--git-dir", h.BareRepo(), "rev-parse", "refs/heads/"+branchName)
+	cmd.Env = gitEnv(h)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse %s failed: %v\n%s", branchName, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/test/e2e/rebase_test.go
+++ b/test/e2e/rebase_test.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestE2E_RebaseWithDivergedMain verifies that oompa can rebase a PR branch
+// when main has diverged (new commits pushed upstream).
+// This scenario catches regression #144 (rebase with unstaged changes from
+// upstream file deletions).
+func TestE2E_RebaseWithDivergedMain(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	// Seed an issue with an existing PR.
+	fg.SeedIssue(FakeIssue{
+		Number: 60,
+		Title:  "Rebase test",
+		Body:   "Test rebase with diverged main.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 600,
+		Title:  "Rebase test",
+		Body:   "Fixes #60",
+		State:  "open",
+		Head:   "ai/issue-60",
+		Base:   "main",
+	})
+
+	fg.SetPRHeadSHA(600, "rebase-sha-001")
+	// Set PR as "behind" — triggers rebase processing.
+	fg.SetPRMergeState(600, "behind")
+
+	h := NewHarness(t, owner, repo, label)
+	pushBranchToBare(t, h, "ai/issue-60")
+
+	// Add a new commit to main AFTER the branch was created.
+	// This diverges main from the branch, triggering a rebase.
+	h.AddCommitToBareMain("new-file.txt", "upstream content\n", "upstream: add new file")
+
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{600},
+		Reactions: []string{"rebase"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// === Assertions ===
+
+	// 1. Rebase was attempted — check debug logs.
+	if !strings.Contains(stderr, "rebase") && !strings.Contains(stderr, "Rebase") {
+		t.Error("expected rebase-related log messages in debug output")
+	}
+
+	// 2. Branch should still exist in bare repo (rebase doesn't delete it).
+	if !h.BareRepoHasBranch("ai/issue-60") {
+		t.Error("expected branch 'ai/issue-60' in bare repo after rebase")
+	}
+
+	// 3. Check for a rebase comment (if not skipped).
+	fg.mu.Lock()
+	commentCalls := make([]FakeComment, len(fg.CommentCalls))
+	copy(commentCalls, fg.CommentCalls)
+	fg.mu.Unlock()
+
+	foundRebaseComment := false
+	for _, c := range commentCalls {
+		if strings.Contains(c.Body, "Rebased") || strings.Contains(c.Body, "rebase") {
+			foundRebaseComment = true
+			break
+		}
+	}
+	if !foundRebaseComment {
+		t.Error("expected a rebase comment to be posted on the PR")
+	}
+}
+
+// TestE2E_RebaseConflict verifies that oompa handles rebase conflicts by
+// invoking the agent for conflict resolution when automatic rebase fails.
+func TestE2E_RebaseConflict(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	fg.SeedIssue(FakeIssue{
+		Number: 61,
+		Title:  "Rebase conflict test",
+		Body:   "Test conflict resolution.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 601,
+		Title:  "Rebase conflict test",
+		Body:   "Fixes #61",
+		State:  "open",
+		Head:   "ai/issue-61",
+		Base:   "main",
+	})
+
+	fg.SetPRHeadSHA(601, "conflict-sha-001")
+	// Set PR as "dirty" — triggers conflict resolution processing.
+	fg.SetPRMergeState(601, "dirty")
+
+	h := NewHarness(t, owner, repo, label)
+	h.InstallFakeClaudeScript("fake-claude-rebase.sh")
+	pushBranchToBare(t, h, "ai/issue-61")
+
+	// Add a conflicting commit to main — modifies the same file the branch has.
+	h.AddCommitToBareMain("BRANCH.md", "conflicting content from main\n", "upstream: modify BRANCH.md")
+
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{601},
+		Reactions: []string{"conflicts"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Verify rebase/conflict processing was attempted.
+	if !strings.Contains(stderr, "conflict") && !strings.Contains(stderr, "rebase") {
+		t.Error("expected conflict/rebase log messages in debug output")
+	}
+
+	// Branch should still exist regardless of outcome.
+	if !h.BareRepoHasBranch("ai/issue-61") {
+		t.Error("expected branch 'ai/issue-61' in bare repo after conflict resolution attempt")
+	}
+
+	// Verify the agent script actually executed git operations (not just silently failed).
+	// The fake-claude-rebase.sh writes a marker file when rebase --continue or commit succeeds.
+	rebaseMarker := findMarkerFile(t, h.CloneDir(), ".oompa-rebase-marker")
+	if rebaseMarker == "" {
+		t.Error("expected .oompa-rebase-marker — agent script did not execute git operations")
+	}
+}

--- a/test/e2e/review_test.go
+++ b/test/e2e/review_test.go
@@ -1,0 +1,226 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestE2E_ReviewFeedback verifies the PR review feedback loop:
+// oompa discovers an existing PR with review comments, invokes the agent to
+// address them, and pushes the changes.
+// This scenario catches regressions in: #137, #151, #149, #162, #164, #181, #211.
+func TestE2E_ReviewFeedback(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	// Seed an issue that already has an open PR — oompa must discover the
+	// existing PR via ListPRsByHead and track it as StatusPROpen.
+	fg.SeedIssue(FakeIssue{
+		Number: 10,
+		Title:  "Add logging middleware",
+		Body:   "Add structured logging middleware for HTTP handlers.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	// Seed the existing PR for this issue.
+	fg.SeedPR(FakePR{
+		Number: 200,
+		Title:  "Add logging middleware",
+		Body:   "Fixes #10",
+		State:  "open",
+		Head:   "ai/issue-10",
+		Base:   "main",
+	})
+
+	// Seed 35 review comments to exercise the pagination loop (catches #151).
+	// The pre-#151 code used PerPage=30, which would drop comments after page 1.
+	// Comments 1001-1002 are the primary review feedback; 1003-1035 are filler
+	// to push total count past the old pagination boundary.
+	fg.SeedReviewComment(200, FakeReviewComment{
+		ID:   1001,
+		Body: "Please add error handling for the nil case.",
+		Path: "middleware.go",
+		Line: 42,
+		User: map[string]any{"login": "reviewer1"},
+	})
+	fg.SeedReviewComment(200, FakeReviewComment{
+		ID:   1002,
+		Body: "Consider using a context logger instead of the global one.",
+		Path: "middleware.go",
+		Line: 55,
+		User: map[string]any{"login": "reviewer1"},
+	})
+	for i := int64(1003); i <= 1035; i++ {
+		fg.SeedReviewComment(200, FakeReviewComment{
+			ID:   i,
+			Body: fmt.Sprintf("Review comment %d for pagination test.", i),
+			Path: "middleware.go",
+			Line: int(i - 1000),
+			User: map[string]any{"login": "reviewer1"},
+		})
+	}
+
+	// Set HEAD SHA so the PR appears valid.
+	fg.SetPRHeadSHA(200, "abc123deadbeef")
+
+	h := NewHarness(t, owner, repo, label)
+	// Install the review-specific fake claude that creates fixup commits.
+	h.InstallFakeClaudeScript("fake-claude-review.sh")
+
+	// Push the initial branch to the bare repo so the worktree has something to work with.
+	pushBranchToBare(t, h, "ai/issue-10")
+	beforeSHA := bareBranchSHA(t, h, "ai/issue-10")
+
+	// Run oompa with --watch-prs to directly watch the PR
+	// and --reactions reviews to enable review processing only.
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{200},
+		Reactions: []string{"reviews"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// === Assertions ===
+
+	// 1. Eyes reactions were added to signal processing of all 35 seeded comments.
+	fg.mu.Lock()
+	reactionCalls := make([]ReactionCall, len(fg.ReactionCalls))
+	copy(reactionCalls, fg.ReactionCalls)
+	fg.mu.Unlock()
+
+	eyesByCommentID := map[int64]bool{}
+	for _, rc := range reactionCalls {
+		if rc.Reaction == "eyes" {
+			eyesByCommentID[rc.CommentID] = true
+		}
+	}
+	// Verify all 35 seeded comments (1001-1035) received eyes reactions.
+	// This exercises the pagination loop: with PerPage=30 in the fake,
+	// comments 31-35 are only visible on page 2.
+	for id := int64(1001); id <= 1035; id++ {
+		if !eyesByCommentID[id] {
+			t.Errorf("expected 'eyes' reaction on review comment %d (pagination regression)", id)
+		}
+	}
+
+	// 2. Branch was pushed and advanced (agent made changes).
+	afterSHA := bareBranchSHA(t, h, "ai/issue-10")
+	if afterSHA == beforeSHA {
+		t.Error("expected branch 'ai/issue-10' to advance after review processing")
+	}
+
+	// 3. Verify prompt was delivered via stdin (catches #169 regression).
+	stdinMarker := findStdinMarker(t, h.CloneDir())
+	if stdinMarker == "" {
+		t.Fatal("expected .oompa-stdin-marker file — prompt was not delivered via stdin")
+	}
+	data, err := readFileContent(t, stdinMarker)
+	if err != nil {
+		t.Fatalf("reading stdin marker: %v", err)
+	}
+	if !strings.Contains(data, "error handling") || !strings.Contains(data, "context logger") {
+		t.Error("expected review prompt to contain review comment text")
+	}
+}
+
+// TestE2E_ReviewFeedback_PRConversationComment verifies that /oompa prefixed
+// comments on the PR conversation tab are processed as directives.
+func TestE2E_ReviewFeedback_PRConversationComment(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+
+	fg.SeedIssue(FakeIssue{
+		Number: 11,
+		Title:  "Update docs",
+		Body:   "Update the README.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 201,
+		Title:  "Update docs",
+		Body:   "Fixes #11",
+		State:  "open",
+		Head:   "ai/issue-11",
+		Base:   "main",
+	})
+
+	// Seed an issue comment (PR conversation tab) with /oompa prefix.
+	fg.SeedIssueComment(201, FakeComment{
+		ID:   2001,
+		Body: "/oompa please also update the CHANGELOG",
+		User: map[string]any{"login": "reviewer1"},
+	})
+
+	fg.SetPRHeadSHA(201, "def456deadbeef")
+
+	h := NewHarness(t, owner, repo, label)
+	h.InstallFakeClaudeScript("fake-claude-review.sh")
+	pushBranchToBare(t, h, "ai/issue-11")
+	beforeSHA := bareBranchSHA(t, h, "ai/issue-11")
+
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{201},
+		Reactions: []string{"reviews"},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Branch should be pushed and advanced from addressing the /oompa directive.
+	afterSHA := bareBranchSHA(t, h, "ai/issue-11")
+	if afterSHA == beforeSHA {
+		t.Error("expected branch 'ai/issue-11' to advance after /oompa directive processing")
+	}
+}
+
+// pushBranchToBare creates and pushes a branch to the bare repo so oompa
+// can create a worktree from it.
+func pushBranchToBare(t *testing.T, h *Harness, branchName string) {
+	t.Helper()
+	scratch := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := newGitCommand(args...)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		cmd.Env = gitEnv(h)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	run("", "clone", h.BareRepo(), scratch)
+	run(scratch, "config", "user.name", "e2e")
+	run(scratch, "config", "user.email", "e2e@example.com")
+	run(scratch, "checkout", "-b", branchName)
+	writeFile(t, scratch, "BRANCH.md", "# Branch "+branchName+"\n")
+	run(scratch, "add", "BRANCH.md")
+	run(scratch, "commit", "-m", "initial branch commit")
+	run(scratch, "push", "origin", branchName)
+}
+
+// readFileContent reads a file and returns its trimmed content.
+func readFileContent(t *testing.T, path string) (string, error) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/test/e2e/slack_test.go
+++ b/test/e2e/slack_test.go
@@ -1,0 +1,257 @@
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// FakeSlack is an httptest server that records received Slack webhook payloads.
+type FakeSlack struct {
+	mu       sync.Mutex
+	t        *testing.T
+	server   *httptest.Server
+	payloads []json.RawMessage
+}
+
+// NewFakeSlack creates a fake Slack webhook receiver.
+func NewFakeSlack(t *testing.T) *FakeSlack {
+	fs := &FakeSlack{t: t}
+
+	fs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusBadRequest)
+			return
+		}
+
+		fs.mu.Lock()
+		fs.payloads = append(fs.payloads, json.RawMessage(body))
+		fs.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	t.Cleanup(fs.server.Close)
+	return fs
+}
+
+// URL returns the webhook URL.
+func (fs *FakeSlack) URL() string {
+	return fs.server.URL
+}
+
+// Payloads returns a copy of all received payloads.
+func (fs *FakeSlack) Payloads() []json.RawMessage {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	result := make([]json.RawMessage, len(fs.payloads))
+	copy(result, fs.payloads)
+	return result
+}
+
+// TestE2E_SlackReporting verifies that oompa sends Slack webhook reports
+// when CI failures are detected (via report-only checks).
+// This scenario catches regressions in: #195, #202, #205.
+func TestE2E_SlackReporting(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+	slack := NewFakeSlack(t)
+
+	// Seed an issue with an existing PR that has a failing check run.
+	fg.SeedIssue(FakeIssue{
+		Number: 30,
+		Title:  "Slack test issue",
+		Body:   "Test Slack reporting.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 400,
+		Title:  "Slack test PR",
+		Body:   "Fixes #30",
+		State:  "open",
+		Head:   "ai/issue-30",
+		Base:   "main",
+	})
+
+	headSHA := "slack-test-sha-001"
+	fg.SetPRHeadSHA(400, headSHA)
+
+	// Seed a failing check run — report-only CI check should detect this.
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         7001,
+		Name:       "build",
+		Status:     "completed",
+		Conclusion: "failure",
+		HTMLURL:    "https://github.com/testowner/testrepo/runs/7001",
+	})
+
+	h := NewHarness(t, owner, repo, label)
+	pushBranchToBare(t, h, "ai/issue-30")
+
+	// Run oompa with Slack webhook and with CI NOT in reactions
+	// (so it runs as report-only).
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{400},
+		Reactions: []string{"reviews"}, // ci NOT in reactions → report-only mode
+		ExtraEnv:  []string{"OOMPA_SLACK_WEBHOOK=" + slack.URL()},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// === Assertions ===
+
+	// 1. At least one Slack payload was delivered.
+	payloads := slack.Payloads()
+	if len(payloads) == 0 {
+		t.Fatal("expected at least 1 Slack webhook payload, got 0")
+	}
+
+	// 2. Payload contains correct structure (Block Kit JSON).
+	var msg struct {
+		Blocks []struct {
+			Type string `json:"type"`
+			Text *struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"text,omitempty"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(payloads[0], &msg); err != nil {
+		t.Fatalf("failed to parse Slack payload as JSON: %v\npayload: %s", err, string(payloads[0]))
+	}
+	if len(msg.Blocks) == 0 {
+		t.Fatal("expected Slack message to contain blocks")
+	}
+
+	// 3. Header block mentions "oompa report".
+	foundHeader := false
+	for _, block := range msg.Blocks {
+		if block.Type == "header" && block.Text != nil && strings.Contains(block.Text.Text, "oompa report") {
+			foundHeader = true
+			break
+		}
+	}
+	if !foundHeader {
+		t.Error("expected Slack message header containing 'oompa report'")
+	}
+
+	// 4. Content mentions the failing check run.
+	payload := string(payloads[0])
+	if !strings.Contains(payload, "build") {
+		t.Error("expected Slack payload to mention the 'build' check run")
+	}
+}
+
+// TestE2E_SlackReporting_DedupWithinBatch verifies that findings within
+// the same flush batch are deduplicated (catches #195).
+func TestE2E_SlackReporting_DedupWithinBatch(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+	slack := NewFakeSlack(t)
+
+	fg.SeedIssue(FakeIssue{
+		Number: 31,
+		Title:  "Slack dedup test",
+		Body:   "Test dedup.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	fg.SeedPR(FakePR{
+		Number: 401,
+		Title:  "Slack dedup PR",
+		Body:   "Fixes #31",
+		State:  "open",
+		Head:   "ai/issue-31",
+		Base:   "main",
+	})
+
+	headSHA := "slack-dedup-sha-001"
+	fg.SetPRHeadSHA(401, headSHA)
+
+	// Seed two failing check runs with the same name to exercise in-batch dedup.
+	// Both should collapse into a single finding in the Slack message.
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         7010,
+		Name:       "unit-tests",
+		Status:     "completed",
+		Conclusion: "failure",
+	})
+	fg.SeedCheckRun(headSHA, FakeCheckRun{
+		ID:         7011,
+		Name:       "unit-tests",
+		Status:     "completed",
+		Conclusion: "failure",
+	})
+
+	// Set PR as behind to also trigger rebase finding — tests multi-finding dedup.
+	fg.SetPRMergeState(401, "behind")
+
+	h := NewHarness(t, owner, repo, label)
+	pushBranchToBare(t, h, "ai/issue-31")
+
+	// Use RunOompaOpts.Reactions to enable ONLY reviews. This means CI, rebase,
+	// and conflict checks run in report-only mode and findings go to Slack.
+	stdout, stderr, err := h.RunOompa(fg.URL(), RunOompaOpts{
+		WatchPRs:  []int{401},
+		Reactions: []string{"reviews"}, // only reviews active → ci runs as report-only
+		ExtraEnv:  []string{"OOMPA_SLACK_WEBHOOK=" + slack.URL()},
+	})
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	payloads := slack.Payloads()
+	if len(payloads) == 0 {
+		t.Fatal("expected at least 1 Slack webhook payload")
+	}
+
+	// Verify the payload mentions the check run.
+	payload := string(payloads[0])
+	if !strings.Contains(payload, "unit-tests") {
+		t.Error("expected Slack payload to mention 'unit-tests'")
+	}
+
+	// Two check runs with the same name were seeded. The dedup logic should
+	// collapse them into a single finding. Assert structurally on the parsed
+	// blocks rather than string-counting (more robust against format changes).
+	var dedupMsg struct {
+		Blocks []struct {
+			Type string `json:"type"`
+			Text *struct {
+				Text string `json:"text"`
+			} `json:"text,omitempty"`
+		} `json:"blocks"`
+	}
+	if err := json.Unmarshal(payloads[0], &dedupMsg); err != nil {
+		t.Fatalf("failed to parse Slack dedup payload: %v", err)
+	}
+	// Count how many section blocks mention "unit-tests" — should be exactly 1
+	// after dedup (the detail section). The header and divider blocks don't count.
+	unitTestSections := 0
+	for _, block := range dedupMsg.Blocks {
+		if block.Type == "section" && block.Text != nil && strings.Contains(block.Text.Text, "unit-tests") {
+			unitTestSections++
+		}
+	}
+	if unitTestSections != 1 {
+		t.Errorf("expected exactly 1 section block mentioning 'unit-tests' after dedup, got %d", unitTestSections)
+	}
+}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -92,4 +93,113 @@ func TestE2ESmoke_NewIssueToPR(t *testing.T) {
 	if !h.BareRepoHasBranch("ai/issue-42") {
 		t.Error("expected branch 'ai/issue-42' in bare repo, but it was not found")
 	}
+
+	// 5. Prompt was delivered via stdin (catches #169)
+	// The fake-claude.sh writes stdin content to .oompa-stdin-marker.
+	// Find the worktree directory and check for the marker file.
+	stdinMarker := findStdinMarker(t, h.CloneDir())
+	if stdinMarker == "" {
+		t.Error("expected .oompa-stdin-marker file to exist (stdin prompt delivery), but not found")
+	} else {
+		data, err := os.ReadFile(stdinMarker)
+		if err != nil {
+			t.Fatalf("reading stdin marker: %v", err)
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			t.Error("stdin marker file is empty — prompt was not delivered via stdin (regression #169)")
+		}
+		// Verify the prompt contains issue context
+		if !strings.Contains(content, "Fix the widget") {
+			t.Error("stdin prompt does not contain issue title 'Fix the widget'")
+		}
+	}
+}
+
+// TestE2ESmoke_CorruptWorktreeRecovery verifies that oompa recovers from a corrupt
+// worktree and still produces a PR. This catches regression #190.
+func TestE2ESmoke_CorruptWorktreeRecovery(t *testing.T) {
+	const (
+		owner = "testowner"
+		repo  = "testrepo"
+		label = "good-for-ai"
+	)
+
+	fg := NewFakeGitHub(t, owner, repo)
+	fg.SeedIssue(FakeIssue{
+		Number: 55,
+		Title:  "Fix the corrupt widget",
+		Body:   "Widget corrupted, needs fixing.",
+		Labels: []map[string]any{{"name": label}},
+	})
+
+	h := NewHarness(t, owner, repo, label)
+
+	// First, clone the base repo manually so EnsureRepoCloned finds it.
+	// This simulates the state where oompa has previously cloned the repo.
+	baseCloneDir := filepath.Join(h.CloneDir(), owner, repo)
+	cloneAndSetup(t, h, baseCloneDir)
+
+	// Pre-create a corrupt worktree directory.
+	// The recovery path fires when:
+	//   1. The worktree directory exists
+	//   2. It has a .git file (not directory — worktrees use .git files pointing to main repo)
+	//   3. But git status fails
+	worktreeDir := filepath.Join(baseCloneDir, "worktrees", "ai", "issue-55")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	// Create a .git file that makes it look like a worktree but points nowhere valid
+	gitFile := filepath.Join(worktreeDir, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: /nonexistent/path\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	stdout, stderr, err := h.RunOompa(fg.URL())
+	if err != nil {
+		t.Fatalf("oompa exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+
+	// Assert oompa recovered and still created a PR
+	fg.mu.Lock()
+	prCalls := fg.CreatePRCalls
+	fg.mu.Unlock()
+
+	if len(prCalls) != 1 {
+		t.Fatalf("expected exactly 1 CreatePR call after worktree recovery, got %d", len(prCalls))
+	}
+	if prCalls[0].Head != "ai/issue-55" {
+		t.Errorf("expected PR head 'ai/issue-55', got %q", prCalls[0].Head)
+	}
+
+	if !h.BareRepoHasBranch("ai/issue-55") {
+		t.Error("expected branch 'ai/issue-55' in bare repo after recovery")
+	}
+}
+
+// cloneAndSetup clones the bare repo into the given directory with proper git config.
+func cloneAndSetup(t *testing.T, h *Harness, dir string) {
+	t.Helper()
+	run := func(d string, args ...string) {
+		t.Helper()
+		cmd := newGitCommand(args...)
+		if d != "" {
+			cmd.Dir = d
+		}
+		cmd.Env = gitEnv(h)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	run("", "clone", h.BareRepo(), dir)
+	run(dir, "config", "user.name", "e2e")
+	run(dir, "config", "user.email", "e2e@example.com")
+}
+
+// findStdinMarker searches for the .oompa-stdin-marker file in the clone directory tree.
+func findStdinMarker(t *testing.T, cloneDir string) string {
+	t.Helper()
+	return findMarkerFile(t, cloneDir, ".oompa-stdin-marker")
 }

--- a/test/e2e/testdata/fake-claude-ci.sh
+++ b/test/e2e/testdata/fake-claude-ci.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stream stdin directly to marker file (avoids echo flag interpretation).
+cat > .oompa-stdin-marker
+
+# For CI scenarios: just output classification without making changes.
+# The CI handler looks for RELATED/UNRELATED/INFRASTRUCTURE keywords.
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"UNRELATED\nERROR_SUMMARY: Flaky network timeout\nROOT_CAUSE: Test depends on external service\nFAILING_TEST: TestNetworkTimeout\nRECOMMENDATION: Add retry logic"}'

--- a/test/e2e/testdata/fake-claude-rebase.sh
+++ b/test/e2e/testdata/fake-claude-rebase.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stream stdin directly to marker file (avoids echo flag interpretation).
+cat > .oompa-stdin-marker
+
+# For rebase scenarios: resolve conflicts by accepting the current branch version.
+# This script is only called if automatic rebase fails with conflicts.
+git add -A
+if git rebase --continue 2>/dev/null; then
+  echo "rebase-continued" > .oompa-rebase-marker
+elif git commit --allow-empty -m "resolve conflicts" 2>/dev/null; then
+  echo "commit-fallback" > .oompa-rebase-marker
+else
+  echo "all-failed" > .oompa-rebase-marker
+fi
+
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"done"}'

--- a/test/e2e/testdata/fake-claude-review.sh
+++ b/test/e2e/testdata/fake-claude-review.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stream stdin directly to marker file (avoids echo flag interpretation).
+cat > .oompa-stdin-marker
+
+# For review scenarios: make a small change to simulate addressing feedback.
+echo "review fix $(date +%s)" >> REVIEW-FIX.md
+git add REVIEW-FIX.md
+# Create a fixup commit that the review handler will autosquash
+git commit -q -m "fixup! e2e: implement issue"
+
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"done"}'

--- a/test/e2e/testdata/fake-claude.sh
+++ b/test/e2e/testdata/fake-claude.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cat >/dev/null                              # consume the prompt on stdin
+
+# Stream stdin directly to a marker file so tests can assert prompt delivery.
+# Using cat > file avoids echo's flag interpretation (-n, -e) and keeps memory
+# usage bounded for large prompts.
+cat > .oompa-stdin-marker
+
+# If stdin was empty, exit with error — the prompt must be delivered via stdin.
+if [ ! -s .oompa-stdin-marker ]; then
+  printf '%s\n' '{"type":"result","subtype":"error","is_error":true,"result":"empty stdin"}'
+  exit 1
+fi
+
 echo "e2e fix" > FIX.md
 git add FIX.md
 git commit -q -m "e2e: implement issue"     # MUST produce a commit (issues.go:198 checks origin/main..HEAD non-empty)


### PR DESCRIPTION
Fixes #221

## Summary

Add e2e test scenarios covering PR review feedback, CI failure triage, Slack reporting, event stream assertions, corrupt worktree recovery, and rebase with diverged main. These scenarios exercise subsystems that the existing smoke test never touches, providing regression coverage for 20 historical bugs.

## Changes

- **FakeGitHub extensions**: Add support for PR review comments, check runs, PR reviews, commit statuses, reactions, issue creation, search, compare, and log fetching. Allow comments on PRs (not just issues) since GitHub's API treats PRs as issues for comment endpoints.
- **Harness extensions**: Add `RunOompaOpts` for configurable `--watch-prs`, `--reactions`, extra args/env. Add `InstallFakeClaudeScript` for scenario-specific agent scripts. Add `AddCommitToBareMain` for diverged-main scenarios. Export `CloneDir`, `TmpDir`, `BareRepo`, `HomeDir` accessors. Isolate `XDG_STATE_HOME` and `XDG_RUNTIME_DIR` per test.
- **fake-claude.sh hardened**: Now writes stdin to `.oompa-stdin-marker` and fails if stdin is empty, catching prompt delivery regressions (#169).
- **Scenario-specific agent scripts**: `fake-claude-review.sh` (creates fixup commits), `fake-claude-ci.sh` (outputs UNRELATED classification), `fake-claude-rebase.sh` (resolves conflicts).
- **Scenario 1 (review_test.go)**: Tests review comment processing with eyes reactions and PR conversation `/oompa` directives. Covers #137, #149, #151, #162, #164, #181, #211.
- **Scenario 2 (ci_test.go)**: Tests CI failure detection, consolidated comment posting, and dedup across re-polls. Covers #140, #192, #200, #216, #218.
- **Scenario 3 (slack_test.go)**: Tests Slack webhook delivery, Block Kit payload structure, and dedup within batches. Includes `FakeSlack` httptest receiver. Covers #195, #202, #205.
- **Scenario 4 (events_test.go)**: Tests event emission through successful issue processing and PR watch mode bootstrapping. Covers #165, #198.
- **Scenario 5 (smoke_test.go)**: Hardened smoke test with stdin prompt validation (#169) and corrupt worktree recovery (#190).
- **Scenario 6 (rebase_test.go)**: Tests rebase with diverged main and conflict resolution fallback. Covers #144.

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] Manual testing (if applicable)

## Related Issues

Fixes #221

<!-- oompa-bot v:6e8c59c -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering CI failure analysis with deduplication, event categorization, PR review feedback workflows, and rebase conflict resolution.
  * Added Slack webhook integration tests with payload validation.
  * Enhanced test harness with improved isolation and configurable runner options.
  * Expanded fake GitHub server capabilities to support more API surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->