### PR TITLE
feat: per-project agent-model configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,7 @@ exit-on-new-version: qinqon/oompa
 projects:
   - repo: ovn-kubernetes/ovn-kubernetes
     # Project-level defaults — inherited by all roles
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514  # cheaper for report-only
     create-flaky-issues: true
     flaky-label: kind/ci-flake
     prs:
@@ -27,6 +28,7 @@ projects:
         # inherits create-flaky-issues: true from project
 
   - repo: openperouter/openperouter
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514  # cheaper for report-only
     prs:
       - watch: [313, 304]
         reactions: [ci, conflicts, rebase]
@@ -52,6 +54,7 @@ projects:
         reactions: [ci, conflicts, rebase]
 
   - repo: qinqon/oompa
+    # inherits global agent-model (Opus)
     issues:
       - label: good-for-ai
         # Role-level reviewers override project-level (and global)

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -25,8 +25,9 @@ type FileConfig struct {
 
 // ProjectConfig represents a single project in the YAML config.
 type ProjectConfig struct {
-	Repo string `yaml:"repo"` // "owner/repo"
-	Fork string `yaml:"fork"` // "owner/repo" for fork
+	Repo       string `yaml:"repo"`        // "owner/repo"
+	Fork       string `yaml:"fork"`        // "owner/repo" for fork
+	AgentModel string `yaml:"agent-model"` // model override for this project (empty = inherit global)
 
 	// Project-level defaults (inherited by roles unless overridden)
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
@@ -166,6 +167,16 @@ func validateFileConfig(cfg *FileConfig) error {
 			forkParts := strings.SplitN(p.Fork, "/", 2)
 			if len(forkParts) != 2 || forkParts[0] == "" || forkParts[1] == "" {
 				return fmt.Errorf("project %d: fork must be owner/repo, got %q", i, p.Fork)
+			}
+		}
+
+		// Validate project-level agent-model: requires agent: opencode
+		if p.AgentModel != "" {
+			if cfg.Agent == "" {
+				return fmt.Errorf("project %d (%s): agent-model requires agent to be explicitly set to opencode at the global level", i, p.Repo)
+			}
+			if cfg.Agent != "opencode" {
+				return fmt.Errorf("project %d (%s): agent-model can only be used with agent: opencode", i, p.Repo)
 			}
 		}
 
@@ -342,6 +353,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		projOnlyAssigned := boolOr(p.OnlyAssigned, false)
 		projReviewers := stringsOr(p.Reviewers, globalCfg.Reviewers)
 		projRebaseInterval := parseDurationOr(p.RebaseInterval, 4*time.Hour)
+		projAgentModel := stringOr(p.AgentModel, agentModel)
 
 		// Base config for this project (shared fields)
 		baseCfg := Config{
@@ -353,7 +365,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			DryRun:       fc.DryRun || globalCfg.DryRun,
 			OneShot:      fc.OneShot || globalCfg.OneShot,
 			Agent:        agent,
-			AgentModel:   agentModel,
+			AgentModel:   projAgentModel,
 			ForkOwner:    projForkOwner,
 			ForkRepo:     projForkRepo,
 			// These are inherited from the global config (set by main from auth)

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1109,6 +1110,110 @@ func TestBuildRoleEntries_RebaseIntervalDefault(t *testing.T) {
 	// Default should be 4h
 	if entries[0].Config.RebaseInterval != 4*time.Hour {
 		t.Errorf("expected RebaseInterval 4h (default), got %v", entries[0].Config.RebaseInterval)
+	}
+}
+
+func TestBuildRoleEntries_AgentModelTwoTierInheritance(t *testing.T) {
+	fc := &FileConfig{
+		Agent:      "opencode",
+		AgentModel: "global-model",
+		Projects: []ProjectConfig{
+			{
+				Repo:       "org/with-override",
+				AgentModel: "project-model", // Override global
+				PRs:        []PRsRoleConfig{{Watch: []int{1}}},
+				Issues:     []IssuesRoleConfig{{Label: "ai"}},
+				Triage:     []TriageRoleConfig{{Jobs: []string{"https://ci.example.com/job"}}},
+			},
+			{
+				Repo: "org/inherits-global",
+				// No agent-model — inherits global
+				PRs: []PRsRoleConfig{{Watch: []int{2}}},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode", AgentModel: "cli-model"})
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	// First project: all roles get project-level model
+	if entries[0].Config.AgentModel != "project-model" {
+		t.Errorf("PRs: expected 'project-model', got %q", entries[0].Config.AgentModel)
+	}
+	if entries[1].Config.AgentModel != "project-model" {
+		t.Errorf("Issues: expected 'project-model', got %q", entries[1].Config.AgentModel)
+	}
+	if entries[2].Config.AgentModel != "project-model" {
+		t.Errorf("Triage: expected 'project-model', got %q", entries[2].Config.AgentModel)
+	}
+	// Second project: inherits global (file-level overrides CLI-level)
+	if entries[3].Config.AgentModel != "global-model" {
+		t.Errorf("Inherited: expected 'global-model', got %q", entries[3].Config.AgentModel)
+	}
+}
+
+func TestLoadFileConfig_ProjectAgentModelValid(t *testing.T) {
+	yaml := `
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+projects:
+  - repo: owner/repo
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fc.Projects[0].AgentModel != "google-vertex-anthropic/claude-sonnet-4-20250514" {
+		t.Errorf("expected project agent-model, got %q", fc.Projects[0].AgentModel)
+	}
+}
+
+func TestLoadFileConfig_ProjectAgentModelWithoutOpenCode(t *testing.T) {
+	yaml := `
+agent: claudecode
+projects:
+  - repo: owner/repo
+    agent-model: some-model
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for project agent-model with claudecode")
+	}
+}
+
+func TestLoadFileConfig_ProjectAgentModelWithoutAgentSet(t *testing.T) {
+	yaml := `
+projects:
+  - repo: owner/repo
+    agent-model: some-model
+    prs:
+      - watch: [1]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
+
+	_, err := LoadFileConfig(path)
+	if err == nil {
+		t.Fatal("expected error for project agent-model without explicit agent")
+	}
+	// Error message should guide user to set agent at global level
+	if !strings.Contains(err.Error(), "global level") {
+		t.Errorf("expected error to mention 'global level', got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
Fixes #224

## Summary

Add per-project `agent-model` configuration to allow different LLM models per project, enabling cost optimization by using cheaper models for report-only projects.

## Changes

- Add `AgentModel` field to `ProjectConfig` in `pkg/agent/fileconfig.go`
- Resolve per-project model in `BuildRoleEntries()` using `stringOr(p.AgentModel, agentModel)` with two-tier inheritance (project-level overrides global)
- Add validation: project-level `agent-model` requires `agent: opencode` (same constraint as global)
- Update `config.example.yaml` with per-project `agent-model` examples
- Add tests for two-tier inheritance, valid parsing, and validation errors

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests cover inheritance, valid config, and validation errors

## Related Issues

Fixes #224

<!-- oompa-bot v:93e4587 -->