### PR TITLE
feat: honor conventional-commit prefix from issue title instead of always prepending Fix #N:

### DIFF
--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -107,6 +108,15 @@ func (a *Agent) gitSquashInto(ctx context.Context, worktreePath, targetSHA strin
 	return nil
 }
 
+// conventionalCommitRe matches issue titles that start with a conventional commit prefix.
+// Supports standard prefixes with optional scope and breaking change indicator.
+var conventionalCommitRe = regexp.MustCompile(`^(feat|fix|build|refactor|docs|chore|test|ci|perf|style|revert)(\([^)]+\))?!?:`)
+
+// isConventionalCommitTitle returns true if the title starts with a conventional commit prefix.
+func isConventionalCommitTitle(title string) bool {
+	return conventionalCommitRe.MatchString(title)
+}
+
 // gitSquashCommits squashes all commits since the origin default branch into a single commit.
 func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issueNumber int, issueTitle string) error {
 	// Get all commit messages since origin default branch
@@ -127,7 +137,16 @@ func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issue
 	// Create a single commit with a meaningful message.
 	// Strip any Signed-off-by/Assisted-by trailers Claude may have added to individual
 	// commits before building the body, then append exactly one canonical set of trailers.
-	commitMsg := fmt.Sprintf("Fix #%d: %s", issueNumber, issueTitle)
+	//
+	// When the issue title already starts with a conventional commit prefix (e.g. "feat:",
+	// "build:", "refactor(scope):"), use the title as-is for the subject and move the issue
+	// reference to the body. Otherwise, use the legacy "Fix #N: <title>" format.
+	var commitMsg string
+	if isConventionalCommitTitle(issueTitle) {
+		commitMsg = fmt.Sprintf("%s\n\nFixes #%d", issueTitle, issueNumber)
+	} else {
+		commitMsg = fmt.Sprintf("Fix #%d: %s", issueNumber, issueTitle)
+	}
 	if commitMessages != "" {
 		commitMsg += "\n\n" + stripTrailers(commitMessages)
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3140,6 +3140,131 @@ func TestProcessNewIssues_SquashesCommits(t *testing.T) {
 	}
 }
 
+func TestIsConventionalCommitTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		expected bool
+	}{
+		// Conventional commit prefixes — should match
+		{"feat prefix", "feat: add new feature", true},
+		{"fix prefix", "fix: resolve crash on startup", true},
+		{"build prefix", "build: consolidate multi-arch container build scripts", true},
+		{"refactor prefix", "refactor: simplify handler logic", true},
+		{"docs prefix", "docs: update README", true},
+		{"chore prefix", "chore: bump dependencies", true},
+		{"test prefix", "test: add unit tests for parser", true},
+		{"ci prefix", "ci: fix GitHub Actions workflow", true},
+		{"perf prefix", "perf: optimize database queries", true},
+		{"style prefix", "style: fix formatting", true},
+		{"revert prefix", "revert: undo previous change", true},
+
+		// With scope
+		{"feat with scope", "feat(api): add pagination support", true},
+		{"fix with scope", "fix(auth): handle expired tokens", true},
+		{"refactor with scope", "refactor(build): consolidate scripts", true},
+
+		// With breaking change indicator
+		{"breaking without scope", "feat!: remove deprecated API", true},
+		{"breaking with scope", "feat(api)!: change response format", true},
+
+		// Non-conventional titles — should NOT match
+		{"capitalized word", "Fix the bug", false},
+		{"lowercase no prefix", "implement feature X", false},
+		{"sentence case", "Update README with new instructions", false},
+		{"issue ref prefix", "Fix #42: something", false},
+		{"invalid prefix word", "feature: this is not a valid prefix", false},
+		{"uppercase prefix", "FEAT: uppercase doesn't match", false},
+		{"missing colon", "feat - missing colon", false},
+		{"no space after colon", "feat:missing space is fine", true},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isConventionalCommitTitle(tt.title)
+			if got != tt.expected {
+				t.Errorf("isConventionalCommitTitle(%q) = %v, want %v", tt.title, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 1532, Title: "build: consolidate multi-arch container build scripts", Body: "Consolidate build scripts"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify the commit message uses the conventional commit title as-is
+	// and puts "Fixes #N" in the body instead of "Fix #N: <title>"
+	for _, c := range runner.calls {
+		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
+			continue
+		}
+		commitMsg := c.Args[2]
+		// The subject line should be the issue title as-is
+		lines := strings.SplitN(commitMsg, "\n", 2)
+		if lines[0] != "build: consolidate multi-arch container build scripts" {
+			t.Errorf("expected subject line to be the conventional commit title, got: %q", lines[0])
+		}
+		// Should NOT contain "Fix #1532:" prefix
+		if strings.Contains(commitMsg, "Fix #1532:") {
+			t.Errorf("commit message should not contain 'Fix #1532:' for conventional commit titles, got: %s", commitMsg)
+		}
+		// Should contain "Fixes #1532" in the body
+		if !strings.Contains(commitMsg, "Fixes #1532") {
+			t.Errorf("expected commit body to contain 'Fixes #1532', got: %s", commitMsg)
+		}
+		// Should still have trailers
+		if !strings.Contains(commitMsg, "Signed-off-by") {
+			t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+		}
+		return
+	}
+	t.Error("expected git commit -m to be called")
+}
+
+func TestProcessNewIssues_SquashesCommits_NonConventionalTitle(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "implement feature X", Body: "broken"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify the commit message uses the legacy "Fix #N: <title>" format
+	for _, c := range runner.calls {
+		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
+			continue
+		}
+		commitMsg := c.Args[2]
+		if !strings.Contains(commitMsg, "Fix #42: implement feature X") {
+			t.Errorf("expected commit message to contain 'Fix #42: implement feature X', got: %s", commitMsg)
+		}
+		// Should NOT contain standalone "Fixes #42" in body (that's for conventional commits)
+		lines := strings.SplitN(commitMsg, "\n", 2)
+		if lines[0] != "Fix #42: implement feature X" {
+			t.Errorf("expected subject line to be 'Fix #42: implement feature X', got: %q", lines[0])
+		}
+		if !strings.Contains(commitMsg, "Signed-off-by") {
+			t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+		}
+		return
+	}
+	t.Error("expected git commit -m to be called")
+}
+
 func TestProcessTriageJobs_NoJobsConfigured(t *testing.T) {
 	gh := &mockGitHubClient{}
 	runner := &mockCommandRunner{}


### PR DESCRIPTION
Fixes #227

## Summary

Honor conventional-commit prefix from issue title instead of always prepending `Fix #N:`. When the issue title already starts with a conventional commit prefix (e.g., `feat:`, `build:`, `refactor(scope)!:`), use the title as-is for the commit subject and move `Fixes #N` to the commit body. Non-conventional titles keep the existing `Fix #N: <title>` format.

## Changes

- Add `isConventionalCommitTitle()` function with regex matching standard conventional commit prefixes (`feat`, `fix`, `build`, `refactor`, `docs`, `chore`, `test`, `ci`, `perf`, `style`, `revert`) with optional scope and breaking change indicator
- Update `gitSquashCommits()` to detect conventional commit titles and format the commit message accordingly:
  - Conventional: `<title>\n\nFixes #N\n\n<body>\n\n<trailers>`
  - Non-conventional (fallback): `Fix #N: <title>\n\n<body>\n\n<trailers>`

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- Added `TestIsConventionalCommitTitle` — table-driven test covering all standard prefixes, scoped prefixes, breaking change indicators, and negative cases
- Added `TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle` — integration test verifying the new formatting path
- Added `TestProcessNewIssues_SquashesCommits_NonConventionalTitle` — integration test verifying the legacy formatting path is preserved

## Related Issues

Fixes #227

<!-- oompa-bot v:804f545 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit messages now support conventional commit format detection when squashing commits; titles matching the format are used directly with issue reference in the body.
  * Legacy commit message format maintained for backwards compatibility with non-conventional titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->