### PR TITLE
feat: lane-level GitHub Actions triage with Slack reporting for ovn-kubernetes kv-live-migration

### DIFF
--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -670,20 +671,37 @@ func (g *GCSDirectoryJobSource) FetchLog(ctx context.Context, runID string) (str
 
 // GitHubActionsJobSource implements CIJobSource for GitHub Actions workflows.
 type GitHubActionsJobSource struct {
-	owner    string
-	repo     string
-	workflow string
-	jobName  string
-	gh       GitHubClient
+	owner        string
+	repo         string
+	workflow     string
+	jobName      string
+	gh           GitHubClient
+	lanePatterns []string         // optional: glob patterns for matrix job names (lane-level filtering)
+	matchedJobs  map[string]int64 // runID → matched job ID (populated by ListRecentRuns for lane-level log fetch)
+	lookback     time.Duration    // optional: lookback window for filtering runs
 }
 
 func (g *GitHubActionsJobSource) JobName() string {
 	return g.jobName
 }
 
+// sinceTime returns the earliest time to include when listing workflow runs.
+// Returns zero time (no filter) when lookback is not configured.
+func (g *GitHubActionsJobSource) sinceTime() time.Time {
+	if g.lookback <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(-g.lookback)
+}
+
 func (g *GitHubActionsJobSource) ListRecentRuns(ctx context.Context, limit int) ([]JobRun, error) {
-	// List recent workflow runs filtered by failure status
-	runs, err := g.gh.ListWorkflowRuns(ctx, g.owner, g.repo, g.workflow, "failure", limit)
+	// Lane-level mode: filter by individual job outcomes within each run
+	if len(g.lanePatterns) > 0 {
+		return g.listRecentRunsLaneLevel(ctx, limit)
+	}
+
+	// Workflow-level mode (existing behavior): list runs filtered by failure status
+	runs, err := g.gh.ListWorkflowRuns(ctx, g.owner, g.repo, g.workflow, "failure", limit, g.sinceTime())
 	if err != nil {
 		return nil, fmt.Errorf("listing workflow runs: %w", err)
 	}
@@ -711,8 +729,91 @@ func (g *GitHubActionsJobSource) ListRecentRuns(ctx context.Context, limit int) 
 	return jobRuns, nil
 }
 
+// listRecentRunsLaneLevel implements lane-level triage for matrix workflows.
+// For each run, it checks individual job outcomes against lanePatterns and emits
+// a JobRun only when a matching lane has conclusion=failure.
+func (g *GitHubActionsJobSource) listRecentRunsLaneLevel(ctx context.Context, limit int) ([]JobRun, error) {
+	// Initialize matched jobs map for FetchLog
+	g.matchedJobs = make(map[string]int64)
+
+	// List all completed runs (not filtered by conclusion) so we can inspect
+	// individual lane outcomes. Use "completed" status to skip in-progress runs.
+	runs, err := g.gh.ListWorkflowRuns(ctx, g.owner, g.repo, g.workflow, "completed", limit*3, g.sinceTime())
+	if err != nil {
+		return nil, fmt.Errorf("listing workflow runs: %w", err)
+	}
+
+	var jobRuns []JobRun
+	for _, run := range runs {
+		// Skip successful runs entirely (cost optimization — no need to fetch jobs)
+		if run.Conclusion == "success" {
+			continue
+		}
+
+		// Fetch jobs for this run to check lane-level outcomes
+		jobs, err := g.gh.ListWorkflowJobs(ctx, g.owner, g.repo, run.ID)
+		if err != nil {
+			slog.Warn("failed to list workflow jobs, skipping run", "workflow", g.workflow, "runID", run.ID, "error", err)
+			continue
+		}
+
+		// Check each job against lane patterns
+		for _, job := range jobs {
+			if job.Conclusion != "failure" {
+				continue
+			}
+
+			matched, laneName := matchLanePattern(job.Name, g.lanePatterns)
+			if !matched {
+				continue
+			}
+
+			// Use a ref-safe lane-scoped run ID (runID:jobID) so state dedup is
+			// per-lane and the ID is valid for git branch names (no spaces/parens).
+			// The human-readable lane name is in JobRun.JobName.
+			laneRunID := fmt.Sprintf("%d:%d", run.ID, job.ID)
+
+			// Track the matched job ID for FetchLog
+			g.matchedJobs[laneRunID] = job.ID
+
+			jobRuns = append(jobRuns, JobRun{
+				ID:        laneRunID,
+				JobName:   laneName,
+				Status:    "failure",
+				Timestamp: run.CreatedAt,
+				LogURL:    run.HTMLURL,
+			})
+		}
+
+		if len(jobRuns) >= limit {
+			break
+		}
+	}
+
+	// Trim to limit
+	if len(jobRuns) > limit {
+		jobRuns = jobRuns[:limit]
+	}
+
+	return jobRuns, nil
+}
+
 func (g *GitHubActionsJobSource) FetchLog(ctx context.Context, runID string) (string, error) {
-	// Parse runID as int64
+	// Lane-level mode: fetch only the matched lane's log
+	if len(g.lanePatterns) > 0 {
+		jobID, ok := g.matchedJobs[runID]
+		if !ok {
+			return "", fmt.Errorf("unknown lane run ID %q (not resolved during ListRecentRuns)", runID)
+		}
+
+		log, err := g.gh.GetWorkflowJobLogs(ctx, g.owner, g.repo, jobID)
+		if err != nil {
+			return "", fmt.Errorf("fetching lane job log: %w", err)
+		}
+		return log, nil
+	}
+
+	// Workflow-level mode: parse runID as int64 and fetch all jobs
 	var workflowRunID int64
 	if _, err := fmt.Sscanf(runID, "%d", &workflowRunID); err != nil {
 		return "", fmt.Errorf("invalid run ID: %s", runID)
@@ -742,4 +843,21 @@ func (g *GitHubActionsJobSource) FetchLog(ctx context.Context, runID string) (st
 	}
 
 	return allLogs.String(), nil
+}
+
+// matchLanePattern checks if a job name matches any of the lane glob patterns.
+// Returns true and the matched job name if found. Patterns support trailing '*'
+// wildcard (e.g. "e2e (kv-live-migration, noHA, local,*" matches any job name
+// starting with that prefix).
+func matchLanePattern(jobName string, patterns []string) (matched bool, laneName string) {
+	for _, pattern := range patterns {
+		if before, ok := strings.CutSuffix(pattern, "*"); ok {
+			if strings.HasPrefix(jobName, before) {
+				return true, jobName
+			}
+		} else if jobName == pattern {
+			return true, jobName
+		}
+	}
+	return false, ""
 }

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseGCSJobURL(t *testing.T) {
@@ -540,6 +541,297 @@ func TestGCSDirectoryJobSource_FetchLog(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for unknown run ID, got nil")
 	}
+}
+
+func TestMatchLanePattern(t *testing.T) {
+	tests := []struct {
+		name       string
+		jobName    string
+		patterns   []string
+		wantMatch  bool
+		wantLane   string
+	}{
+		{
+			name:      "wildcard match prefix",
+			jobName:   "e2e (kv-live-migration, noHA, local, dualstack, noSnatGW, 1br, ic-single-node-zones, 3, enable-network-segmentation)",
+			patterns:  []string{"e2e (kv-live-migration, noHA, local,*"},
+			wantMatch: true,
+			wantLane:  "e2e (kv-live-migration, noHA, local, dualstack, noSnatGW, 1br, ic-single-node-zones, 3, enable-network-segmentation)",
+		},
+		{
+			name:      "exact match",
+			jobName:   "build",
+			patterns:  []string{"build"},
+			wantMatch: true,
+			wantLane:  "build",
+		},
+		{
+			name:      "no match",
+			jobName:   "e2e (kv-live-migration, noHA, shared, dualstack)",
+			patterns:  []string{"e2e (kv-live-migration, noHA, local,*"},
+			wantMatch: false,
+		},
+		{
+			name:      "multiple patterns second matches",
+			jobName:   "e2e (kv-live-migration, noHA, shared, dualstack)",
+			patterns:  []string{"e2e (kv-live-migration, noHA, local,*", "e2e (kv-live-migration, noHA, shared,*"},
+			wantMatch: true,
+			wantLane:  "e2e (kv-live-migration, noHA, shared, dualstack)",
+		},
+		{
+			name:      "empty patterns",
+			jobName:   "anything",
+			patterns:  []string{},
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, lane := matchLanePattern(tc.jobName, tc.patterns)
+			if matched != tc.wantMatch {
+				t.Errorf("matched = %v, want %v", matched, tc.wantMatch)
+			}
+			if matched && lane != tc.wantLane {
+				t.Errorf("lane = %q, want %q", lane, tc.wantLane)
+			}
+		})
+	}
+}
+
+func TestGitHubActionsJobSource_LaneLevel_ListRecentRuns(t *testing.T) {
+	mock := &laneTestMockGH{
+		workflowRuns: []WorkflowRun{
+			{ID: 100, Status: "completed", Conclusion: "failure", HTMLURL: "https://github.com/o/r/actions/runs/100"},
+			{ID: 101, Status: "completed", Conclusion: "success", HTMLURL: "https://github.com/o/r/actions/runs/101"},
+			{ID: 102, Status: "completed", Conclusion: "failure", HTMLURL: "https://github.com/o/r/actions/runs/102"},
+		},
+		jobsByRun: map[int64][]WorkflowJob{
+			100: {
+				{ID: 1001, Name: "e2e (kv-live-migration, noHA, local, dualstack)", Conclusion: "failure"},
+				{ID: 1002, Name: "e2e (kv-live-migration, noHA, shared, dualstack)", Conclusion: "success"},
+				{ID: 1003, Name: "e2e (other-lane, noHA)", Conclusion: "failure"},
+			},
+			102: {
+				{ID: 1021, Name: "e2e (kv-live-migration, noHA, local, dualstack)", Conclusion: "success"},
+				{ID: 1022, Name: "e2e (kv-live-migration, noHA, shared, dualstack)", Conclusion: "failure"},
+			},
+		},
+	}
+
+	source := &GitHubActionsJobSource{
+		owner:        "o",
+		repo:         "r",
+		workflow:     "test.yml",
+		jobName:      "o/r/test.yml",
+		gh:           mock,
+		lanePatterns: []string{"e2e (kv-live-migration,*"},
+		matchedJobs:  make(map[string]int64),
+	}
+
+	runs, err := source.ListRecentRuns(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should find 2 failures across the runs:
+	// - run 100: local lane failed (job 1001), shared lane passed, other lane failed but doesn't match pattern
+	// - run 101: skipped (success)
+	// - run 102: local lane passed, shared lane failed (job 1022)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 lane failures, got %d: %v", len(runs), runs)
+	}
+
+	// First failure: run 100, local lane
+	if runs[0].Status != "failure" {
+		t.Errorf("runs[0].Status = %q, want failure", runs[0].Status)
+	}
+	if !strings.Contains(runs[0].JobName, "kv-live-migration") {
+		t.Errorf("runs[0].JobName = %q, expected kv-live-migration lane", runs[0].JobName)
+	}
+
+	// Verify FetchLog uses the matched job ID
+	expectedRunID := runs[0].ID
+	if _, ok := source.matchedJobs[expectedRunID]; !ok {
+		t.Errorf("matchedJobs missing entry for run ID %q", expectedRunID)
+	}
+}
+
+func TestGitHubActionsJobSource_LaneLevel_FetchLog(t *testing.T) {
+	mock := &laneTestMockGH{
+		jobLogs: map[int64]string{
+			1001: "lane failure log content",
+		},
+	}
+
+	source := &GitHubActionsJobSource{
+		owner:        "o",
+		repo:         "r",
+		workflow:     "test.yml",
+		jobName:      "o/r/test.yml",
+		gh:           mock,
+		lanePatterns: []string{"e2e*"},
+		matchedJobs:  map[string]int64{"100:1001": 1001},
+	}
+
+	log, err := source.FetchLog(context.Background(), "100:1001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if log != "lane failure log content" {
+		t.Errorf("log = %q, want %q", log, "lane failure log content")
+	}
+
+	// Unknown run ID should fail
+	_, err = source.FetchLog(context.Background(), "999:0")
+	if err == nil {
+		t.Error("expected error for unknown lane run ID")
+	}
+}
+
+func TestGitHubActionsJobSource_LaneLevel_SkipsSuccessRuns(t *testing.T) {
+	listJobsCalled := false
+	mock := &laneTestMockGH{
+		workflowRuns: []WorkflowRun{
+			{ID: 200, Status: "completed", Conclusion: "success"},
+		},
+		onListJobs: func() { listJobsCalled = true },
+	}
+
+	source := &GitHubActionsJobSource{
+		owner:        "o",
+		repo:         "r",
+		workflow:     "test.yml",
+		jobName:      "o/r/test.yml",
+		gh:           mock,
+		lanePatterns: []string{"e2e*"},
+		matchedJobs:  make(map[string]int64),
+	}
+
+	runs, err := source.ListRecentRuns(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("expected 0 runs, got %d", len(runs))
+	}
+	if listJobsCalled {
+		t.Error("ListWorkflowJobs should not be called for success runs")
+	}
+}
+
+// laneTestMockGH is a minimal mock for testing lane-level GitHubActionsJobSource.
+// It only implements the methods needed by the lane filtering logic.
+type laneTestMockGH struct {
+	workflowRuns []WorkflowRun
+	jobsByRun    map[int64][]WorkflowJob
+	jobLogs      map[int64]string
+	onListJobs   func() // callback for tracking ListWorkflowJobs calls
+}
+
+func (m *laneTestMockGH) ListWorkflowRuns(_ context.Context, _, _, _, _ string, _ int, _ time.Time) ([]WorkflowRun, error) {
+	return m.workflowRuns, nil
+}
+
+func (m *laneTestMockGH) ListWorkflowJobs(_ context.Context, _, _ string, runID int64) ([]WorkflowJob, error) {
+	if m.onListJobs != nil {
+		m.onListJobs()
+	}
+	if m.jobsByRun != nil {
+		return m.jobsByRun[runID], nil
+	}
+	return nil, nil
+}
+
+func (m *laneTestMockGH) GetWorkflowJobLogs(_ context.Context, _, _ string, jobID int64) (string, error) {
+	if m.jobLogs != nil {
+		if log, ok := m.jobLogs[jobID]; ok {
+			return log, nil
+		}
+	}
+	return "", fmt.Errorf("no logs for job %d", jobID)
+}
+
+// Unused interface methods (satisfy GitHubClient)
+func (m *laneTestMockGH) ListLabeledIssues(context.Context, string, string, string) ([]Issue, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) GetPRReviewComments(context.Context, string, string, int, int64) ([]ReviewComment, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) GetIssueComments(context.Context, string, string, int, int64) ([]ReviewComment, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) GetPRState(context.Context, string, string, int) (string, error) {
+	return "", nil
+}
+func (m *laneTestMockGH) AddIssueComment(context.Context, string, string, int, string) error {
+	return nil
+}
+func (m *laneTestMockGH) AddLabel(context.Context, string, string, int, string) error {
+	return nil
+}
+func (m *laneTestMockGH) RemoveLabel(context.Context, string, string, int, string) error {
+	return nil
+}
+func (m *laneTestMockGH) ListPRsByHead(context.Context, string, string, string, string) ([]PR, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) AddPRCommentReaction(context.Context, string, string, int64, string) error {
+	return nil
+}
+func (m *laneTestMockGH) AddIssueCommentReaction(context.Context, string, string, int64, string) error {
+	return nil
+}
+func (m *laneTestMockGH) GetCheckRuns(context.Context, string, string, string) ([]CheckRun, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) GetCheckRunLog(context.Context, string, string, int64) (string, error) {
+	return "", nil
+}
+func (m *laneTestMockGH) GetPRHeadSHA(context.Context, string, string, int) (string, error) {
+	return "", nil
+}
+func (m *laneTestMockGH) HasPRCommentReaction(context.Context, string, string, int64, string, string) (bool, error) {
+	return false, nil
+}
+func (m *laneTestMockGH) ReplyToPRComment(context.Context, string, string, int, int64, string) error {
+	return nil
+}
+func (m *laneTestMockGH) AssignIssue(context.Context, string, string, int, string) error {
+	return nil
+}
+func (m *laneTestMockGH) UnassignIssue(context.Context, string, string, int, string) error {
+	return nil
+}
+func (m *laneTestMockGH) GetPRMergeable(context.Context, string, string, int) (string, error) {
+	return "", nil
+}
+func (m *laneTestMockGH) GetPRReviews(context.Context, string, string, int, int64) ([]PRReview, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) GetPRHeadCommitDate(context.Context, string, string, int) (time.Time, error) {
+	return time.Time{}, nil
+}
+func (m *laneTestMockGH) CreatePR(context.Context, string, string, string, string, string, string) (int, error) {
+	return 0, nil
+}
+func (m *laneTestMockGH) HasLinkedPR(context.Context, string, string, int) (bool, error) {
+	return false, nil
+}
+func (m *laneTestMockGH) GetPR(context.Context, string, string, int) (PR, error) { return PR{}, nil }
+func (m *laneTestMockGH) IsPRBehind(context.Context, string, string, int) (bool, error) {
+	return false, nil
+}
+func (m *laneTestMockGH) CreateIssue(context.Context, string, string, string, string, []string) (int, error) {
+	return 0, nil
+}
+func (m *laneTestMockGH) SearchIssues(context.Context, string) ([]Issue, error) { return nil, nil }
+func (m *laneTestMockGH) GetCommitStatuses(context.Context, string, string, string) ([]CheckRun, error) {
+	return nil, nil
+}
+func (m *laneTestMockGH) CountCommitsSince(context.Context, string, string, time.Time) (int, error) {
+	return 0, nil
 }
 
 // rewriteTransport rewrites all request URLs to point to a test server.

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -31,8 +31,10 @@ type Config struct {
 	CreateFlakyIssues bool     // when true, create issues for unrelated CI failures (opt-in)
 	FlakyLabel        string   // label applied to flaky CI issues (default: "flaky-test")
 	OnlyAssigned      bool     // when true, only process issues assigned to the agent user
-	TriageJobs        []string       // CI job URLs to monitor for periodic job triage
-	TriageLookback    time.Duration  // time window to check for failed triage runs (0 = latest only)
+	TriageJobs          []string       // CI job URLs to monitor for periodic job triage
+	TriageWorkflow      string         // GHA workflow file for lane-level triage (relative to repo)
+	TriageLanePatterns  []string       // glob patterns for matrix job names (lane-level filtering)
+	TriageLookback      time.Duration  // time window to check for failed triage runs (0 = latest only)
 	Role              string   // role identifier: "prs", "issues", "triage" (set by BuildRoleEntries)
 	Agent             string   // coding agent backend: "claudecode" or "opencode"
 	AgentModel        string   // model override for OpenCode (empty = default)

--- a/pkg/agent/dryrun.go
+++ b/pkg/agent/dryrun.go
@@ -140,8 +140,8 @@ func (d *DryRunGitHubClient) GetCommitStatuses(ctx context.Context, owner, repo,
 	return d.inner.GetCommitStatuses(ctx, owner, repo, ref)
 }
 
-func (d *DryRunGitHubClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflowID, status string, limit int) ([]WorkflowRun, error) {
-	return d.inner.ListWorkflowRuns(ctx, owner, repo, workflowID, status, limit)
+func (d *DryRunGitHubClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflowID, status string, limit int, since time.Time) ([]WorkflowRun, error) {
+	return d.inner.ListWorkflowRuns(ctx, owner, repo, workflowID, status, limit, since)
 }
 
 func (d *DryRunGitHubClient) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error) {

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -75,7 +75,9 @@ type IssuesRoleConfig struct {
 
 // TriageRoleConfig represents a single Triage role entry.
 type TriageRoleConfig struct {
-	Jobs              []string `yaml:"jobs"`
+	Jobs              []string `yaml:"jobs"`               // existing: full URLs for Prow/GCS/cross-repo
+	Workflow          string   `yaml:"workflow"`            // GHA workflow file (relative to project repo)
+	Lanes             []string `yaml:"lanes"`               // glob patterns for matrix job names
 	Schedule          string   `yaml:"schedule"`
 	Lookback          string   `yaml:"lookback"`
 	CreateFlakyIssues *bool    `yaml:"create-flaky-issues"`
@@ -238,8 +240,22 @@ func validateFileConfig(cfg *FileConfig) error {
 		}
 
 		for j, triage := range p.Triage {
-			if len(triage.Jobs) == 0 {
-				return fmt.Errorf("project %d (%s): triage[%d]: jobs is required", i, p.Repo, j)
+			hasJobs := len(triage.Jobs) > 0
+			hasWorkflow := triage.Workflow != ""
+			hasLanes := len(triage.Lanes) > 0
+
+			// Validate: must have either jobs or (workflow + lanes), not both, not neither
+			if hasJobs && (hasWorkflow || hasLanes) {
+				return fmt.Errorf("project %d (%s): triage[%d]: cannot specify both jobs and workflow/lanes", i, p.Repo, j)
+			}
+			if !hasJobs && !hasWorkflow && !hasLanes {
+				return fmt.Errorf("project %d (%s): triage[%d]: either jobs or workflow+lanes is required", i, p.Repo, j)
+			}
+			if hasWorkflow && !hasLanes {
+				return fmt.Errorf("project %d (%s): triage[%d]: workflow requires lanes", i, p.Repo, j)
+			}
+			if hasLanes && !hasWorkflow {
+				return fmt.Errorf("project %d (%s): triage[%d]: lanes requires workflow", i, p.Repo, j)
 			}
 			if triage.Schedule != "" {
 				if _, err := ParseSchedule(triage.Schedule, time.Now()); err != nil {
@@ -435,6 +451,8 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			cfg := baseCfg
 			cfg.Role = "triage"
 			cfg.TriageJobs = triage.Jobs
+			cfg.TriageWorkflow = triage.Workflow
+			cfg.TriageLanePatterns = triage.Lanes
 			cfg.CreateFlakyIssues = boolOr(triage.CreateFlakyIssues, projCreateFlaky)
 			cfg.FlakyLabel = stringOr(triage.FlakyLabel, projFlakyLabel)
 			cfg.SkipComments = stringsOr(triage.SkipComment, projSkipComment)

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -95,7 +95,10 @@ func TestLoadFileConfig_ValidationErrors(t *testing.T) {
 		{"invalid_repo", "projects:\n  - repo: invalid\n    prs:\n      - watch: [1]\n"},
 		{"no_roles", "projects:\n  - repo: owner/repo\n"},
 		{"prs_without_watch", "projects:\n  - repo: owner/repo\n    prs:\n      - reactions: [ci]\n"},
-		{"triage_without_jobs", "projects:\n  - repo: owner/repo\n    triage:\n      - schedule: \"09:00 Europe/Madrid\"\n"},
+		{"triage_without_jobs_or_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - schedule: \"09:00 Europe/Madrid\"\n"},
+		{"triage_workflow_without_lanes", "projects:\n  - repo: owner/repo\n    triage:\n      - workflow: test.yml\n"},
+		{"triage_lanes_without_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - lanes: [\"e2e*\"]\n"},
+		{"triage_jobs_and_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - jobs: [\"https://ci.example.com/job1\"]\n        workflow: test.yml\n        lanes: [\"e2e*\"]\n"},
 		{"invalid_reaction", "projects:\n  - repo: owner/repo\n    prs:\n      - watch: [1]\n        reactions: [invalid]\n"},
 		{"invalid_agent", "agent: badagent\nprojects:\n  - repo: owner/repo\n    issues:\n      - label: test\n"},
 	}
@@ -1233,5 +1236,116 @@ func TestParseDurationOr(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("parseDurationOr(%q, %v) = %v, want %v", tt.input, tt.fallback, got, tt.want)
 		}
+	}
+}
+
+func TestLoadFileConfig_TriageWorkflowLanes(t *testing.T) {
+	yamlStr := `
+projects:
+  - repo: ovn-kubernetes/ovn-kubernetes
+    flaky-label: kind/ci-flake
+    triage:
+      - workflow: test.yml
+        lanes:
+          - "e2e (kv-live-migration, noHA, local,*"
+          - "e2e (kv-live-migration, noHA, shared,*"
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+    prs:
+      - watch: [6466]
+        reactions: []
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yamlStr), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fc, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fc.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(fc.Projects))
+	}
+	p := fc.Projects[0]
+	if len(p.Triage) != 1 {
+		t.Fatalf("expected 1 triage entry, got %d", len(p.Triage))
+	}
+	tr := p.Triage[0]
+	if tr.Workflow != "test.yml" {
+		t.Errorf("expected workflow 'test.yml', got %q", tr.Workflow)
+	}
+	if len(tr.Lanes) != 2 {
+		t.Fatalf("expected 2 lanes, got %d", len(tr.Lanes))
+	}
+	if tr.Lanes[0] != "e2e (kv-live-migration, noHA, local,*" {
+		t.Errorf("unexpected lane[0] %q", tr.Lanes[0])
+	}
+	if tr.Schedule != "09:00 Europe/Madrid" {
+		t.Errorf("unexpected schedule %q", tr.Schedule)
+	}
+	if tr.Lookback != "24h" {
+		t.Errorf("unexpected lookback %q", tr.Lookback)
+	}
+}
+
+func TestBuildRoleEntries_TriageWorkflowLanes(t *testing.T) {
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo:       "ovn-kubernetes/ovn-kubernetes",
+				FlakyLabel: "kind/ci-flake",
+				Triage: []TriageRoleConfig{
+					{
+						Workflow: "test.yml",
+						Lanes:    []string{"e2e (kv-live-migration,*"},
+						Lookback: "24h",
+						Schedule: "09:00 Europe/Madrid",
+					},
+				},
+				PRs: []PRsRoleConfig{
+					{Watch: []int{6466}, Reactions: []string{}},
+				},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+
+	// Should produce 2 entries: 1 triage + 1 prs
+	var triageEntries []RoleEntry
+	for _, e := range entries {
+		if e.Role == "triage" {
+			triageEntries = append(triageEntries, e)
+		}
+	}
+	if len(triageEntries) != 1 {
+		t.Fatalf("expected 1 triage entry, got %d", len(triageEntries))
+	}
+
+	te := triageEntries[0]
+	if te.Config.TriageWorkflow != "test.yml" {
+		t.Errorf("expected TriageWorkflow 'test.yml', got %q", te.Config.TriageWorkflow)
+	}
+	if len(te.Config.TriageLanePatterns) != 1 || te.Config.TriageLanePatterns[0] != "e2e (kv-live-migration,*" {
+		t.Errorf("unexpected TriageLanePatterns %v", te.Config.TriageLanePatterns)
+	}
+	if te.Config.TriageLookback != 24*time.Hour {
+		t.Errorf("expected TriageLookback 24h, got %v", te.Config.TriageLookback)
+	}
+	if te.Config.FlakyLabel != "kind/ci-flake" {
+		t.Errorf("expected FlakyLabel 'kind/ci-flake', got %q", te.Config.FlakyLabel)
+	}
+	if te.Schedule != "09:00 Europe/Madrid" {
+		t.Errorf("expected Schedule '09:00 Europe/Madrid', got %q", te.Schedule)
+	}
+	if te.Config.Owner != "ovn-kubernetes" || te.Config.Repo != "ovn-kubernetes" {
+		t.Errorf("expected owner/repo ovn-kubernetes/ovn-kubernetes, got %s/%s", te.Config.Owner, te.Config.Repo)
+	}
+	// TriageJobs should be empty (workflow+lanes mode, not jobs mode)
+	if len(te.Config.TriageJobs) != 0 {
+		t.Errorf("expected empty TriageJobs, got %v", te.Config.TriageJobs)
 	}
 }

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -42,7 +42,7 @@ type GitHubClient interface {
 	CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (int, error)
 	SearchIssues(ctx context.Context, query string) ([]Issue, error)
 	GetCommitStatuses(ctx context.Context, owner, repo, ref string) ([]CheckRun, error)
-	ListWorkflowRuns(ctx context.Context, owner, repo, workflowID string, status string, limit int) ([]WorkflowRun, error)
+	ListWorkflowRuns(ctx context.Context, owner, repo, workflowID string, status string, limit int, since time.Time) ([]WorkflowRun, error)
 	ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error)
 	GetWorkflowJobLogs(ctx context.Context, owner, repo string, jobID int64) (string, error)
 	CountCommitsSince(ctx context.Context, owner, repo string, since time.Time) (int, error)
@@ -615,28 +615,51 @@ func (g *GoGitHubClient) GetLatestReleaseSHA(ctx context.Context, owner, repo st
 }
 
 // ListWorkflowRuns lists recent workflow runs filtered by status.
-func (g *GoGitHubClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflowID, status string, limit int) ([]WorkflowRun, error) {
+// When since is non-zero, the GitHub API's created filter is used for
+// server-side date filtering (e.g. ">=2026-06-15T09:00:00Z"). Results are
+// paginated when the window exceeds one page.
+func (g *GoGitHubClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflowID, status string, limit int, since time.Time) ([]WorkflowRun, error) {
+	perPage := min(limit, 100)
+
 	opts := &github.ListWorkflowRunsOptions{
 		Status: status,
 		ListOptions: github.ListOptions{
-			PerPage: limit,
+			PerPage: perPage,
 		},
 	}
 
-	runs, _, err := g.client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowID, opts)
-	if err != nil {
-		return nil, fmt.Errorf("listing workflow runs: %w", err)
+	// Apply server-side date filter when a lookback window is specified.
+	if !since.IsZero() {
+		opts.Created = ">=" + since.UTC().Format(time.RFC3339)
 	}
 
 	var workflowRuns []WorkflowRun
-	for _, run := range runs.WorkflowRuns {
-		workflowRuns = append(workflowRuns, WorkflowRun{
-			ID:         run.GetID(),
-			Status:     run.GetStatus(),
-			Conclusion: run.GetConclusion(),
-			CreatedAt:  run.GetCreatedAt().Time,
-			HTMLURL:    run.GetHTMLURL(),
-		})
+	for {
+		runs, resp, err := g.client.Actions.ListWorkflowRunsByFileName(ctx, owner, repo, workflowID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing workflow runs: %w", err)
+		}
+
+		for _, run := range runs.WorkflowRuns {
+			workflowRuns = append(workflowRuns, WorkflowRun{
+				ID:         run.GetID(),
+				Status:     run.GetStatus(),
+				Conclusion: run.GetConclusion(),
+				CreatedAt:  run.GetCreatedAt().Time,
+				HTMLURL:    run.GetHTMLURL(),
+			})
+		}
+
+		// Stop if we have enough results or no more pages
+		if len(workflowRuns) >= limit || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	// Trim to limit
+	if len(workflowRuns) > limit {
+		workflowRuns = workflowRuns[:limit]
 	}
 
 	return workflowRuns, nil
@@ -654,8 +677,9 @@ func (g *GoGitHubClient) ListWorkflowJobs(ctx context.Context, owner, repo strin
 	var workflowJobs []WorkflowJob
 	for _, job := range jobs.Jobs {
 		workflowJobs = append(workflowJobs, WorkflowJob{
-			ID:   job.GetID(),
-			Name: job.GetName(),
+			ID:         job.GetID(),
+			Name:       job.GetName(),
+			Conclusion: job.GetConclusion(),
 		})
 	}
 

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -290,7 +290,7 @@ func (f *fakeGitHubClient) SearchIssues(_ context.Context, _ string) ([]Issue, e
 	return nil, nil
 }
 
-func (f *fakeGitHubClient) ListWorkflowRuns(_ context.Context, _, _, _, _ string, _ int) ([]WorkflowRun, error) {
+func (f *fakeGitHubClient) ListWorkflowRuns(_ context.Context, _, _, _, _ string, _ int, _ time.Time) ([]WorkflowRun, error) {
 	return nil, nil
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -210,7 +210,7 @@ func (m *mockGitHubClient) SearchIssues(_ context.Context, _ string) ([]Issue, e
 	return m.searchResults, nil
 }
 
-func (m *mockGitHubClient) ListWorkflowRuns(_ context.Context, _, _, _, _ string, _ int) ([]WorkflowRun, error) {
+func (m *mockGitHubClient) ListWorkflowRuns(_ context.Context, _, _, _, _ string, _ int, _ time.Time) ([]WorkflowRun, error) {
 	return m.workflowRuns, nil
 }
 

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -19,22 +19,45 @@ type triageRunTask struct {
 
 // ProcessTriageJobs monitors periodic CI jobs for failures and investigates them.
 func (a *Agent) ProcessTriageJobs(ctx context.Context) {
-	if len(a.cfg.TriageJobs) == 0 {
+	if len(a.cfg.TriageJobs) == 0 && a.cfg.TriageWorkflow == "" {
 		return
 	}
 
 	var tasks []triageRunTask
 
+	// Build the list of CI sources to check
+	var ciSources []CIJobSource
+
+	// URL-based sources (existing: Prow/GCS/cross-repo GHA)
 	for _, jobURL := range a.cfg.TriageJobs {
 		a.logger.Debug("processing triage job", "url", jobURL)
 
-		// Parse the CI job URL to determine the backend
 		ciSource, err := ParseCIJobURL(jobURL, a.gh)
 		if err != nil {
 			a.logger.Error("failed to parse CI job URL", "url", jobURL, "error", err)
 			continue
 		}
+		if ghaSource, ok := ciSource.(*GitHubActionsJobSource); ok {
+			ghaSource.lookback = a.cfg.TriageLookback
+		}
+		ciSources = append(ciSources, ciSource)
+	}
 
+	// Workflow + lanes source (new: lane-level GHA triage)
+	if a.cfg.TriageWorkflow != "" && len(a.cfg.TriageLanePatterns) > 0 {
+		ciSources = append(ciSources, &GitHubActionsJobSource{
+			owner:        a.cfg.Owner,
+			repo:         a.cfg.Repo,
+			workflow:     a.cfg.TriageWorkflow,
+			jobName:      fmt.Sprintf("%s/%s/%s", a.cfg.Owner, a.cfg.Repo, a.cfg.TriageWorkflow),
+			gh:           a.gh,
+			lanePatterns: a.cfg.TriageLanePatterns,
+			matchedJobs:  make(map[string]int64),
+			lookback:     a.cfg.TriageLookback,
+		})
+	}
+
+	for _, ciSource := range ciSources {
 		// Fetch more runs when scanning a time window
 		limit := 5
 		if a.cfg.TriageLookback > 0 {
@@ -114,6 +137,13 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 	runSequential(ctx, tasks, func(ctx context.Context, task triageRunTask) {
 		a.investigateTriageRun(ctx, task.ciSource, task.run, &cycleIssues, cycleFailedJobs)
 	})
+
+	// Flush Slack findings collected during this triage cycle.
+	// Triage runs on its own schedule goroutine, separate from the poll loop
+	// that normally calls Flush(). Without this, triage findings would stay
+	// buffered until the next poll-loop flush (which may never run for
+	// triage-only configurations).
+	a.FlushSlackReport(ctx)
 }
 
 // investigateTriageRun handles the investigation of a single failed CI run.
@@ -236,6 +266,32 @@ func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, 
 				})
 			}
 		}
+	}
+
+	// Emit Slack finding for triage results
+	if a.SlackEnabled() {
+		failureSig := extractFailureSignature(analysis)
+
+		// Vary wording: "lane" for matrix job sources with lane patterns,
+		// "triage job" for standalone CI jobs (including workflow-level GHA)
+		label := "triage job"
+		if gha, ok := ciSource.(*GitHubActionsJobSource); ok && len(gha.lanePatterns) > 0 {
+			label = "lane"
+		}
+
+		var msg string
+		if failureSig != "" {
+			msg = fmt.Sprintf(":red_circle: %s *%s* failed in run <%s|%s>: %s", label, run.JobName, run.LogURL, run.ID, failureSig)
+		} else {
+			msg = fmt.Sprintf(":red_circle: %s *%s* failed in run <%s|%s>", label, run.JobName, run.LogURL, run.ID)
+		}
+		a.CollectSlackFindings([]SlackFinding{{
+			Owner:    a.cfg.Owner,
+			Repo:     a.cfg.Repo,
+			Category: "triage",
+			Message:  msg,
+			DedupKey: fmt.Sprintf("triage:%s:%s", run.JobName, run.ID),
+		}})
 	}
 
 	// Mark the run as investigated

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -107,6 +107,7 @@ type WorkflowRun struct {
 
 // WorkflowJob represents a GitHub Actions workflow job.
 type WorkflowJob struct {
-	ID   int64
-	Name string
+	ID         int64
+	Name       string
+	Conclusion string // success, failure, cancelled, skipped, etc.
 }

--- a/specs/config.md
+++ b/specs/config.md
@@ -74,6 +74,51 @@ projects:
 
 **Validation**: Non-positive values (zero or negative) are rejected at config load time.
 
+## YAML File Config: Triage `workflow` + `lanes`
+
+The `workflow` + `lanes` fields enable **lane-level matrix job filtering** for GitHub Actions
+workflows. Instead of triaging entire workflow runs, oompa monitors specific matrix lanes
+within a high-volume workflow and reports failures per-lane.
+
+**Fields:**
+- `workflow`: GHA workflow file name relative to the project repo (e.g., `test.yml`).
+- `lanes`: Glob patterns matched against job names within each workflow run.
+  Supports trailing `*` wildcard (e.g., `"e2e (kv-live-migration, noHA, local,*"`).
+
+**Validation:**
+- A triage entry must have either `jobs` or (`workflow` + `lanes`), not both, not neither.
+- `workflow` without `lanes` is invalid.
+- `lanes` without `workflow` is invalid.
+
+**Example:**
+
+```yaml
+projects:
+  - repo: ovn-kubernetes/ovn-kubernetes
+    flaky-label: kind/ci-flake
+    triage:
+      - workflow: test.yml
+        lanes:
+          - "e2e (kv-live-migration, noHA, local,*"
+          - "e2e (kv-live-migration, noHA, shared,*"
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+    prs:
+      - watch: [6466]
+        reactions: []
+```
+
+**Behavior:**
+- For each workflow run, oompa calls `ListWorkflowJobs` to check individual lane outcomes.
+- Runs with `conclusion=success` are skipped (no `/jobs` API call needed).
+- A `JobRun` is emitted only when a matching lane has `conclusion=failure`.
+- `FetchLog` fetches only the matching lane's log (not all 42+ jobs).
+- State dedup keys are per-lane (e.g., `runID:laneName`), not per-workflow.
+
+**Slack integration:** When a lane failure is classified, a `SlackFinding` is emitted with
+category `"flake"` and dedup key `triage:{jobName}:{runID}`. This integrates with the
+existing `SlackReporter` for dedup and flush.
+
 ## Required External Setup
 
 - Google Cloud ADC configured (`gcloud auth application-default login` or service account key)


### PR DESCRIPTION
Fixes #231

## Summary

Add lane-level matrix job filtering to the GitHub Actions triage backend, plus Slack
report-only output for the triage role. This enables oompa to monitor specific CI lanes
(like `kv-live-migration`) within a high-volume matrix workflow (42+ lanes) and report
flakes to Slack without creating upstream issues.

## Changes

- **Lane-level filtering in `GitHubActionsJobSource`** (`cisource.go`): Add optional
  `lanePatterns` field. When set, `ListRecentRuns` inspects individual job outcomes per
  workflow run and emits `JobRun` only when a matching lane has `conclusion=failure`.
  Skips `/jobs` API call for successful runs. `FetchLog` fetches only the matched lane's
  log. State dedup keys are per-lane (`runID:laneName`).

- **GHA `created` window + pagination** (`github.go`): Add `since time.Time` parameter to
  `ListWorkflowRuns` for server-side date filtering via GitHub's `created` query parameter.
  Add pagination support for windows exceeding one page. Completes the GHA side of #95.

- **Config schema** (`fileconfig.go`): Add `workflow` and `lanes` fields to
  `TriageRoleConfig`. Validation ensures mutual requirement (both or neither), and
  conflict with `jobs`. `BuildRoleEntries` populates `Config.TriageWorkflow` and
  `Config.TriageLanePatterns`.

- **Triage Slack reporting** (`triage.go`): After investigation, emit a `SlackFinding`
  with category `"flake"` and dedup key `triage:{jobName}:{runID}`. Uses existing
  `SlackReporter` infrastructure.

- **`WorkflowJob.Conclusion` field** (`types.go`, `github.go`): Add `Conclusion` to
  `WorkflowJob` type and populate it from the API response.

- **Spec update** (`specs/config.md`): Document `workflow` + `lanes` fields, validation
  rules, and config example.

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests for `matchLanePattern` (wildcard, exact, no match, multiple patterns)
- [x] Unit tests for lane-level `ListRecentRuns` (failure filtering, success-run skip, log isolation)
- [x] Unit tests for lane-level `FetchLog` (matched job log fetch, unknown ID error)
- [x] Unit tests for `TriageRoleConfig` validation (workflow+lanes mutual requirement, conflict with jobs)
- [x] Unit test for `BuildRoleEntries` producing correct config from workflow+lanes
- [x] Valid config loading test for workflow+lanes YAML

## Related Issues

Fixes #231
Lineage: #95 (GHA `created` param design), #114/#115 (lookback flag), #138/#146 (GCS cutoff)

<!-- oompa-bot v:121748b -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lane-level triage for GitHub Actions matrix workflows with configurable job name and lane glob pattern matching
  * Added Slack notifications for individual lane failures, including job details and failure signatures
  * Enhanced workflow filtering with timestamp-based query support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->