### PR TITLE
bug: oompa re-processes already-handled PR comments after version upgrade restart

### DIFF
--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -58,6 +58,48 @@ func recoverLastRebaseTime(ctx context.Context, gh GitHubClient, cfg Config, wor
 	}
 }
 
+// recoverCommentCursors recovers the comment cursors (LastCommentID, LastReviewID,
+// LastIssueCommentID) from GitHub by fetching all existing comments/reviews and
+// setting each cursor to the max ID. This prevents re-processing old comments
+// after a restart (e.g., --exit-on-new-version).
+func recoverCommentCursors(ctx context.Context, gh GitHubClient, cfg Config, work *IssueWork, prNumber int, logger *slog.Logger) {
+	// Recover LastCommentID from PR review comments
+	comments, err := gh.GetPRReviewComments(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
+	if err != nil {
+		logger.Warn("failed to get PR review comments for cursor recovery", "pr", prNumber, "error", err)
+	} else {
+		for _, c := range comments {
+			if c.ID > work.LastCommentID {
+				work.LastCommentID = c.ID
+			}
+		}
+	}
+
+	// Recover LastReviewID from PR reviews
+	reviews, err := gh.GetPRReviews(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
+	if err != nil {
+		logger.Warn("failed to get PR reviews for cursor recovery", "pr", prNumber, "error", err)
+	} else {
+		for _, r := range reviews {
+			if r.ID > work.LastReviewID {
+				work.LastReviewID = r.ID
+			}
+		}
+	}
+
+	// Recover LastIssueCommentID from PR conversation comments (Issues API)
+	issueComments, err := gh.GetIssueComments(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
+	if err != nil {
+		logger.Warn("failed to get issue comments for cursor recovery", "pr", prNumber, "error", err)
+	} else {
+		for _, c := range issueComments {
+			if c.ID > work.LastIssueCommentID {
+				work.LastIssueCommentID = c.ID
+			}
+		}
+	}
+}
+
 // BuildStateFromGitHub reconstructs state by scanning labeled issues and their PRs.
 func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, cloneDir string, logger *slog.Logger) *State {
 	state := NewState()
@@ -98,7 +140,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 				case openPR != nil:
 					work.PRNumber = openPR.Number
 					work.Status = StatusPROpen
-					// lastCommentID stays 0 — ProcessReviewComments uses :eyes: reaction to skip already-handled comments
+					recoverCommentCursors(ctx, gh, cfg, work, openPR.Number, logger)
 					recoverLastRebaseTime(ctx, gh, cfg, work, openPR.Number, logger)
 					logger.Info("recovered state from GitHub", "issue", issue.Number, "pr", work.PRNumber)
 				case hasMerged:
@@ -158,6 +200,7 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 			CreatedAt:    time.Now(),
 		}
 
+		recoverCommentCursors(ctx, gh, cfg, work, prNumber, logger)
 		recoverLastRebaseTime(ctx, gh, cfg, work, prNumber, logger)
 
 		state.ActiveIssues[IssueKey(cfg.Owner, cfg.Repo, prNumber)] = work

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -35,6 +35,13 @@ func TestBuildStateFromGitHub_RecoversPRState(t *testing.T) {
 			{ID: 10, User: "alice", Body: "looks good"},
 			{ID: 20, User: "bob", Body: "fix this"},
 		},
+		prReviews: []PRReview{
+			{ID: 5, User: "carol", State: "CHANGES_REQUESTED", Body: "needs work"},
+			{ID: 15, User: "dave", State: "APPROVED", Body: "lgtm"},
+		},
+		issueComments: []ReviewComment{
+			{ID: 30, User: "eve", Body: "/oompa fix tests"},
+		},
 	}
 	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai"}
 
@@ -50,8 +57,16 @@ func TestBuildStateFromGitHub_RecoversPRState(t *testing.T) {
 	if work.Status != "pr-open" {
 		t.Errorf("expected status 'pr-open', got %q", work.Status)
 	}
-	if work.LastCommentID != 0 {
-		t.Errorf("expected lastCommentID 0 (reactions used instead), got %d", work.LastCommentID)
+	// Comment cursors should be recovered to max existing IDs to prevent
+	// re-processing old comments after a restart.
+	if work.LastCommentID != 20 {
+		t.Errorf("expected LastCommentID 20, got %d", work.LastCommentID)
+	}
+	if work.LastReviewID != 15 {
+		t.Errorf("expected LastReviewID 15, got %d", work.LastReviewID)
+	}
+	if work.LastIssueCommentID != 30 {
+		t.Errorf("expected LastIssueCommentID 30, got %d", work.LastIssueCommentID)
 	}
 }
 
@@ -189,5 +204,69 @@ func TestNewState_InvestigatedRuns(t *testing.T) {
 	}
 	if len(s.InvestigatedRuns) != 0 {
 		t.Errorf("expected empty InvestigatedRuns, got %d", len(s.InvestigatedRuns))
+	}
+}
+
+func TestBuildStateFromGitHub_WatchPRsRecoversCursors(t *testing.T) {
+	gh := &mockGitHubClient{
+		prs: []PR{
+			{Number: 500, State: "open", Head: "feature-branch", Title: "My Feature"},
+		},
+		prComments: []ReviewComment{
+			{ID: 100, User: "alice", Body: "fix this"},
+			{ID: 200, User: "bob", Body: "also this"},
+		},
+		prReviews: []PRReview{
+			{ID: 50, User: "carol", State: "CHANGES_REQUESTED", Body: "needs work"},
+		},
+		issueComments: []ReviewComment{
+			{ID: 300, User: "eve", Body: "/oompa fix tests"},
+		},
+	}
+	cfg := Config{
+		Owner:    "owner",
+		Repo:     "repo",
+		WatchPRs: []int{500},
+	}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 500)]
+	if !ok {
+		t.Fatal("expected watched PR 500 in state")
+	}
+	if work.LastCommentID != 200 {
+		t.Errorf("expected LastCommentID 200, got %d", work.LastCommentID)
+	}
+	if work.LastReviewID != 50 {
+		t.Errorf("expected LastReviewID 50, got %d", work.LastReviewID)
+	}
+	if work.LastIssueCommentID != 300 {
+		t.Errorf("expected LastIssueCommentID 300, got %d", work.LastIssueCommentID)
+	}
+}
+
+func TestBuildStateFromGitHub_RecoversCursorsNoComments(t *testing.T) {
+	// When a PR has no comments/reviews, cursors should stay at 0.
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 7, Title: "Clean PR", Labels: []string{"good-for-ai"}}},
+		prs:    []PR{{Number: 77, State: "open", Head: "ai/issue-7"}},
+	}
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai"}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 7)]
+	if !ok {
+		t.Fatal("expected issue 7 in state")
+	}
+	if work.LastCommentID != 0 {
+		t.Errorf("expected LastCommentID 0, got %d", work.LastCommentID)
+	}
+	if work.LastReviewID != 0 {
+		t.Errorf("expected LastReviewID 0, got %d", work.LastReviewID)
+	}
+	if work.LastIssueCommentID != 0 {
+		t.Errorf("expected LastIssueCommentID 0, got %d", work.LastIssueCommentID)
 	}
 }

--- a/test/e2e/fakegithub.go
+++ b/test/e2e/fakegithub.go
@@ -122,6 +122,14 @@ type FakeGitHub struct {
 	nextReviewComID int64
 	nextIssueNumber int
 
+	// Deferred items: only become visible after the first GET on the same resource.
+	// This simulates comments arriving after state recovery (first GET) but before
+	// ProcessReviewComments (second GET), which is the normal production scenario.
+	deferredReviewComments map[int][]*FakeReviewComment // PR number -> deferred review comments
+	deferredIssueComments  map[int][]*FakeComment       // issue number -> deferred issue comments
+	reviewCommentsGets     map[int]int                  // PR number -> GET request count
+	issueCommentsGets      map[int]int                  // issue number -> GET request count
+
 	// Recorders for assertions
 	CreatePRCalls    []CreatePRCall
 	CreateIssueCalls []CreateIssueCall
@@ -156,21 +164,25 @@ type ReactionCall struct {
 // NewFakeGitHub creates a new stateful fake GitHub server.
 func NewFakeGitHub(t *testing.T, owner, repo string) *FakeGitHub {
 	fg := &FakeGitHub{
-		t:               t,
-		issues:          make(map[int]*FakeIssue),
-		comments:        make(map[int][]*FakeComment),
-		prs:             make(map[int]*FakePR),
-		reviewComments:  make(map[int][]*FakeReviewComment),
-		checkRuns:       make(map[string][]*FakeCheckRun),
-		reviews:         make(map[int][]*FakeReview),
-		prHeadSHAs:      make(map[int]string),
-		prMergeStates:   make(map[int]string),
-		commitStatuses:  make(map[string][]map[string]any),
-		reactions:       make(map[int64][]map[string]any),
-		nextCommentID:   1,
-		nextPRNumber:    100,
-		nextReviewComID: 1,
-		nextIssueNumber: 900,
+		t:                      t,
+		issues:                 make(map[int]*FakeIssue),
+		comments:               make(map[int][]*FakeComment),
+		prs:                    make(map[int]*FakePR),
+		reviewComments:         make(map[int][]*FakeReviewComment),
+		checkRuns:              make(map[string][]*FakeCheckRun),
+		reviews:                make(map[int][]*FakeReview),
+		prHeadSHAs:             make(map[int]string),
+		prMergeStates:          make(map[int]string),
+		commitStatuses:         make(map[string][]map[string]any),
+		reactions:              make(map[int64][]map[string]any),
+		nextCommentID:          1,
+		nextPRNumber:           100,
+		nextReviewComID:        1,
+		nextIssueNumber:        900,
+		deferredReviewComments: make(map[int][]*FakeReviewComment),
+		deferredIssueComments:  make(map[int][]*FakeComment),
+		reviewCommentsGets:     make(map[int]int),
+		issueCommentsGets:      make(map[int]int),
 	}
 
 	prefix := fmt.Sprintf("/api/v3/repos/%s/%s", owner, repo)
@@ -508,6 +520,15 @@ func (fg *FakeGitHub) handleIssueComments(w http.ResponseWriter, r *http.Request
 
 	switch r.Method {
 	case "GET":
+		// Promote deferred issue comments after the first GET (state recovery).
+		fg.issueCommentsGets[issueNum]++
+		if fg.issueCommentsGets[issueNum] > 1 {
+			if deferred, ok := fg.deferredIssueComments[issueNum]; ok && len(deferred) > 0 {
+				fg.comments[issueNum] = append(fg.comments[issueNum], deferred...)
+				delete(fg.deferredIssueComments, issueNum)
+			}
+		}
+
 		comments := fg.comments[issueNum]
 		if comments == nil {
 			comments = []*FakeComment{}
@@ -692,6 +713,42 @@ func (fg *FakeGitHub) SeedReviewComment(prNumber int, comment FakeReviewComment)
 	fg.reviewComments[prNumber] = append(fg.reviewComments[prNumber], &comment)
 }
 
+// SeedReviewCommentDeferred adds an inline review comment that only becomes
+// visible after the first GET on the PR's review comments endpoint. This
+// simulates a comment arriving after state recovery but before the poll loop.
+func (fg *FakeGitHub) SeedReviewCommentDeferred(prNumber int, comment FakeReviewComment) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if comment.ID == 0 {
+		comment.ID = fg.nextReviewComID
+		fg.nextReviewComID++
+	} else if comment.ID >= fg.nextReviewComID {
+		fg.nextReviewComID = comment.ID + 1
+	}
+	if comment.User == nil {
+		comment.User = map[string]any{"login": "reviewer"}
+	}
+	fg.deferredReviewComments[prNumber] = append(fg.deferredReviewComments[prNumber], &comment)
+}
+
+// SeedIssueCommentDeferred adds an issue comment that only becomes visible
+// after the first GET on the issue's comments endpoint. This simulates a
+// comment arriving after state recovery but before the poll loop.
+func (fg *FakeGitHub) SeedIssueCommentDeferred(issueNumber int, comment FakeComment) {
+	fg.mu.Lock()
+	defer fg.mu.Unlock()
+	if comment.ID == 0 {
+		comment.ID = fg.nextCommentID
+		fg.nextCommentID++
+	} else if comment.ID >= fg.nextCommentID {
+		fg.nextCommentID = comment.ID + 1
+	}
+	if comment.User == nil {
+		comment.User = map[string]any{"login": "reviewer"}
+	}
+	fg.deferredIssueComments[issueNumber] = append(fg.deferredIssueComments[issueNumber], &comment)
+}
+
 // SeedCheckRun adds a check run for a commit SHA.
 func (fg *FakeGitHub) SeedCheckRun(sha string, cr FakeCheckRun) {
 	fg.mu.Lock()
@@ -767,17 +824,30 @@ func (fg *FakeGitHub) handlePRReviewComments(w http.ResponseWriter, r *http.Requ
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(reply)
 	case "GET":
+		// Promote deferred review comments after the first GET (state recovery).
+		// Page 1 counts as the initial GET; subsequent page requests within the
+		// same logical listing are not counted again.
+		q := r.URL.Query()
+		page, _ := strconv.Atoi(q.Get("page"))
+		if page < 1 {
+			page = 1
+		}
+		if page == 1 {
+			fg.reviewCommentsGets[prNum]++
+			if fg.reviewCommentsGets[prNum] > 1 {
+				if deferred, ok := fg.deferredReviewComments[prNum]; ok && len(deferred) > 0 {
+					fg.reviewComments[prNum] = append(fg.reviewComments[prNum], deferred...)
+					delete(fg.deferredReviewComments, prNum)
+				}
+			}
+		}
+
 		// Return review comments with pagination support.
 		comments := fg.reviewComments[prNum]
 		if comments == nil {
 			comments = []*FakeReviewComment{}
 		}
-		q := r.URL.Query()
-		page, _ := strconv.Atoi(q.Get("page"))
 		perPage, _ := strconv.Atoi(q.Get("per_page"))
-		if page < 1 {
-			page = 1
-		}
 		if perPage <= 0 {
 			perPage = 30
 		}

--- a/test/e2e/review_test.go
+++ b/test/e2e/review_test.go
@@ -39,18 +39,24 @@ func TestE2E_ReviewFeedback(t *testing.T) {
 		Base:   "main",
 	})
 
-	// Seed 35 review comments to exercise the pagination loop (catches #151).
-	// The pre-#151 code used PerPage=30, which would drop comments after page 1.
-	// Comments 1001-1002 are the primary review feedback; 1003-1035 are filler
-	// to push total count past the old pagination boundary.
-	fg.SeedReviewComment(200, FakeReviewComment{
+	// Seed 35 review comments using SeedReviewCommentDeferred so they only
+	// become visible after state recovery (first GET). This simulates comments
+	// arriving after oompa starts, preventing cursor recovery from advancing
+	// past them — which is the normal production scenario. (#244)
+	//
+	// Note: the 35-comment count is preserved from the original pagination
+	// regression test (pre-#151, when PerPage was 30). With the current
+	// PerPage=100, all 35 fit in a single page so pagination is not exercised
+	// here; the value of this test is verifying that every comment receives
+	// an :eyes: reaction regardless of deferred seeding timing.
+	fg.SeedReviewCommentDeferred(200, FakeReviewComment{
 		ID:   1001,
 		Body: "Please add error handling for the nil case.",
 		Path: "middleware.go",
 		Line: 42,
 		User: map[string]any{"login": "reviewer1"},
 	})
-	fg.SeedReviewComment(200, FakeReviewComment{
+	fg.SeedReviewCommentDeferred(200, FakeReviewComment{
 		ID:   1002,
 		Body: "Consider using a context logger instead of the global one.",
 		Path: "middleware.go",
@@ -58,7 +64,7 @@ func TestE2E_ReviewFeedback(t *testing.T) {
 		User: map[string]any{"login": "reviewer1"},
 	})
 	for i := int64(1003); i <= 1035; i++ {
-		fg.SeedReviewComment(200, FakeReviewComment{
+		fg.SeedReviewCommentDeferred(200, FakeReviewComment{
 			ID:   i,
 			Body: fmt.Sprintf("Review comment %d for pagination test.", i),
 			Path: "middleware.go",
@@ -159,7 +165,9 @@ func TestE2E_ReviewFeedback_PRConversationComment(t *testing.T) {
 	})
 
 	// Seed an issue comment (PR conversation tab) with /oompa prefix.
-	fg.SeedIssueComment(201, FakeComment{
+	// Use deferred seeding so the comment only appears after state recovery,
+	// simulating a comment arriving after oompa starts. (#244)
+	fg.SeedIssueCommentDeferred(201, FakeComment{
 		ID:   2001,
 		Body: "/oompa please also update the CHANGELOG",
 		User: map[string]any{"login": "reviewer1"},


### PR DESCRIPTION
Fixes #244

## Summary

Recover comment cursors (`LastCommentID`, `LastReviewID`, `LastIssueCommentID`) during state recovery from GitHub, preventing re-processing of already-handled PR comments after a version upgrade restart.

## Changes

- Add `recoverCommentCursors()` function in `pkg/agent/state.go` that fetches all existing PR review comments, PR reviews, and issue comments during state recovery and sets each cursor to the max existing ID
- Call `recoverCommentCursors()` for both labeled-issue PRs and watched PRs in `BuildStateFromGitHub`
- Add `SeedReviewCommentDeferred()` and `SeedIssueCommentDeferred()` to the E2E fake GitHub server to simulate comments arriving after state recovery (the normal production scenario)
- Update E2E review tests to use deferred seeding so they correctly test the "new comment after startup" flow
- Add unit tests for cursor recovery in both labeled-issue and watched-PR paths

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #244

<!-- oompa-bot v:94977a2 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed state recovery to properly restore the agent's position when resuming pull request work, ensuring review comments, PR reviews, and issue comments are correctly tracked from their last processed point.

* **Tests**
  * Expanded test coverage for comment cursor recovery, including edge cases and multiple comment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->