### PR TITLE
bug: /oompa fails to fix commit message when explicitly asked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 
 # Agent workflow artifacts
 .pr-body.md
+.oompa-commit-msg
 
 # AgentReady reports
 .agentready/

--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -9,6 +9,44 @@ import (
 	"strings"
 )
 
+// commitMsgFile is the well-known filename an agent writes to request a commit
+// message change. The outer automation reads and deletes it during squash/amend.
+const commitMsgFile = ".oompa-commit-msg"
+
+// readCommitMsgFile reads and removes the commit message override file from the
+// worktree root. Returns the trimmed contents and true if the file existed and
+// was non-empty; returns ("", false) otherwise.
+func readCommitMsgFile(worktreePath string) (string, bool) {
+	path := filepath.Join(worktreePath, commitMsgFile)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	_ = os.Remove(path) //nolint:errcheck // best-effort cleanup
+	msg := strings.TrimSpace(string(content))
+	if msg == "" {
+		return "", false
+	}
+	return msg, true
+}
+
+// ensureTrailers appends configured Signed-off-by and Assisted-by trailers to
+// a commit message if they are not already present. This prevents DCO/policy
+// violations when the agent overrides the commit message via .oompa-commit-msg.
+func (a *Agent) ensureTrailers(msg string) string {
+	var trailers []string
+	if a.cfg.SignedOffBy != "" && !strings.Contains(msg, "Signed-off-by:") {
+		trailers = append(trailers, fmt.Sprintf("Signed-off-by: %s", a.cfg.SignedOffBy))
+	}
+	if a.cfg.AssistedBy != "" && !strings.Contains(msg, "Assisted-by:") {
+		trailers = append(trailers, fmt.Sprintf("Assisted-by: %s", a.cfg.AssistedBy))
+	}
+	if len(trailers) > 0 {
+		msg += "\n\n" + strings.Join(trailers, "\n")
+	}
+	return msg
+}
+
 // buildPRBody constructs a PR description. If Claude wrote a .pr-body.md file
 // (filled from the repo's PR template), that is used. Otherwise falls back to
 // constructing a body from the git log.
@@ -72,13 +110,25 @@ func (a *Agent) hasUncommittedChanges(ctx context.Context, worktreePath string) 
 }
 
 // gitAmendAll stages all changes and amends the current commit.
+// If the agent wrote a .oompa-commit-msg file, its contents replace the commit message.
 func (a *Agent) gitAmendAll(ctx context.Context, worktreePath string) error {
 	if a.cfg.DryRun {
 		a.logger.Info("[dry-run] would amend commit", "worktree", worktreePath)
 		return nil
 	}
+	// Read the commit message override BEFORE git add -A so it doesn't get staged.
+	newMsg, hasNewMsg := readCommitMsgFile(worktreePath)
+
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "add", "-A"); err != nil {
 		return fmt.Errorf("git add: %w (stderr: %s)", err, string(stderr))
+	}
+	if hasNewMsg {
+		a.logger.Info("using agent-provided commit message", "worktree", worktreePath)
+		newMsg = a.ensureTrailers(newMsg)
+		if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "-m", newMsg); err != nil {
+			return fmt.Errorf("git commit --amend -m: %w (stderr: %s)", err, string(stderr))
+		}
+		return nil
 	}
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
 		return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
@@ -88,11 +138,15 @@ func (a *Agent) gitAmendAll(ctx context.Context, worktreePath string) error {
 
 // gitSquashInto squashes all commits after the given SHA into that commit.
 // Used to fold agent-created review feedback commits back into the original HEAD.
+// If the agent wrote a .oompa-commit-msg file, its contents replace the commit message.
 func (a *Agent) gitSquashInto(ctx context.Context, worktreePath, targetSHA string) error {
 	if a.cfg.DryRun {
 		a.logger.Info("[dry-run] would squash into", "worktree", worktreePath, "target", shortSHA(targetSHA))
 		return nil
 	}
+	// Read the commit message override BEFORE git add -A so it doesn't get staged.
+	newMsg, hasNewMsg := readCommitMsgFile(worktreePath)
+
 	// Stage all changes first to capture any unstaged modifications the agent left behind
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "add", "-A"); err != nil {
 		return fmt.Errorf("git add: %w (stderr: %s)", err, string(stderr))
@@ -101,9 +155,17 @@ func (a *Agent) gitSquashInto(ctx context.Context, worktreePath, targetSHA strin
 	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "reset", "--soft", targetSHA); err != nil {
 		return fmt.Errorf("git reset --soft %s: %w (stderr: %s)", shortSHA(targetSHA), err, string(stderr))
 	}
-	// Amend the target commit with the staged changes
-	if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
-		return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
+	// Amend the target commit with the staged changes, using the new message if provided
+	if hasNewMsg {
+		a.logger.Info("using agent-provided commit message", "worktree", worktreePath)
+		newMsg = a.ensureTrailers(newMsg)
+		if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "-m", newMsg); err != nil {
+			return fmt.Errorf("git commit --amend -m: %w (stderr: %s)", err, string(stderr))
+		}
+	} else {
+		if _, stderr, err := a.runner.Run(ctx, worktreePath, "git", "commit", "--amend", "--no-edit"); err != nil {
+			return fmt.Errorf("git commit --amend: %w (stderr: %s)", err, string(stderr))
+		}
 	}
 	return nil
 }

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -5920,6 +5922,344 @@ func TestProcessReviewComments_OompaCommandIgnoresBotComments(t *testing.T) {
 		if c.Name == "claude" {
 			t.Error("should not invoke claude for bot-posted /oompa comment")
 		}
+	}
+}
+
+func TestReadCommitMsgFile_Present(t *testing.T) {
+	// When .oompa-commit-msg exists and is non-empty, readCommitMsgFile should
+	// return its trimmed contents and true, then delete the file.
+	dir := t.TempDir()
+	msgPath := filepath.Join(dir, commitMsgFile)
+	want := "feat: new commit subject\n\nBody paragraph"
+	if err := os.WriteFile(msgPath, []byte(want+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, ok := readCommitMsgFile(dir)
+	if !ok {
+		t.Fatal("expected readCommitMsgFile to return true when file exists")
+	}
+	if msg != want {
+		t.Errorf("expected %q, got %q", want, msg)
+	}
+
+	// File should have been deleted
+	if _, err := os.Stat(msgPath); !os.IsNotExist(err) {
+		t.Error("expected .oompa-commit-msg to be deleted after reading")
+	}
+}
+
+func TestReadCommitMsgFile_Absent(t *testing.T) {
+	// When .oompa-commit-msg does not exist, readCommitMsgFile should return ("", false).
+	dir := t.TempDir()
+	msg, ok := readCommitMsgFile(dir)
+	if ok {
+		t.Error("expected readCommitMsgFile to return false when file is absent")
+	}
+	if msg != "" {
+		t.Errorf("expected empty string, got %q", msg)
+	}
+}
+
+func TestReadCommitMsgFile_Empty(t *testing.T) {
+	// When .oompa-commit-msg exists but is empty/whitespace-only, return ("", false).
+	dir := t.TempDir()
+	msgPath := filepath.Join(dir, commitMsgFile)
+	if err := os.WriteFile(msgPath, []byte("  \n  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, ok := readCommitMsgFile(dir)
+	if ok {
+		t.Error("expected readCommitMsgFile to return false for empty file")
+	}
+	if msg != "" {
+		t.Errorf("expected empty string, got %q", msg)
+	}
+
+	// File should have been deleted even when empty
+	if _, err := os.Stat(msgPath); !os.IsNotExist(err) {
+		t.Error("expected .oompa-commit-msg to be deleted after reading empty file")
+	}
+}
+
+// commitMsgCodeAgent is a mock CodeAgent that writes .oompa-commit-msg to the workdir.
+type commitMsgCodeAgent struct {
+	commitMsg string
+	result    AgentResult
+	err       error
+	prompts   []string
+}
+
+func (m *commitMsgCodeAgent) Run(_ context.Context, _ CommandRunner, workDir, prompt string, _ *slog.Logger, _ bool) (AgentResult, error) {
+	m.prompts = append(m.prompts, prompt)
+	if m.commitMsg != "" {
+		// Simulate the agent writing the commit message file
+		if err := os.WriteFile(filepath.Join(workDir, commitMsgFile), []byte(m.commitMsg), 0o644); err != nil {
+			return AgentResult{}, err
+		}
+	}
+	return m.result, m.err
+}
+
+// fixedPathWorktreeManager returns a fixed path from CreateWorktree, allowing tests
+// to use a real temp directory for commit message file tests.
+type fixedPathWorktreeManager struct {
+	mockWorktreeManager
+	fixedPath string
+}
+
+func (m *fixedPathWorktreeManager) CreateWorktree(_ context.Context, branchName string) (string, error) {
+	m.createdBranches = append(m.createdBranches, branchName)
+	return m.fixedPath, nil
+}
+
+func TestProcessReviewComments_SquashUsesCommitMsgFile(t *testing.T) {
+	// When the agent commits directly AND writes .oompa-commit-msg,
+	// gitSquashInto should use -m with the file's contents instead of --no-edit.
+	// Configured trailers should be appended automatically.
+	worktreeDir := t.TempDir()
+
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+		},
+	}
+	runner := &reviewSquashRunner{
+		mockCommandRunner: &mockCommandRunner{},
+		headSHAs:          []string{"original-sha", "agent-committed-sha"},
+	}
+	wt := &fixedPathWorktreeManager{fixedPath: worktreeDir}
+
+	agent := &Agent{
+		gh:        gh,
+		runner:    runner,
+		worktrees: wt,
+		state:     NewState(),
+		cfg: Config{
+			Owner:       "owner",
+			Repo:        "repo",
+			Label:       "good-for-ai",
+			FlakyLabel:  "flaky-test",
+			GitHubUser:  "test-bot",
+			SignedOffBy: "Test User <test@example.com>",
+			AssistedBy:  "Claude <noreply@anthropic.com>",
+		},
+		logger: slog.Default(),
+		codeAgent: &commitMsgCodeAgent{
+			commitMsg: "fix: corrected commit subject\n\nProper body",
+			result:    AgentResult{Result: "Done"},
+		},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: worktreeDir,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Verify git commit --amend -m was called with the new message plus trailers
+	foundAmendWithMsg := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "commit" && c.Args[1] == "--amend" && c.Args[2] == "-m" {
+			foundAmendWithMsg = true
+			if len(c.Args) >= 4 {
+				msg := c.Args[3]
+				if !strings.Contains(msg, "fix: corrected commit subject") {
+					t.Errorf("commit message missing subject, got %q", msg)
+				}
+				if !strings.Contains(msg, "Proper body") {
+					t.Errorf("commit message missing body, got %q", msg)
+				}
+				if !strings.Contains(msg, "Signed-off-by: Test User <test@example.com>") {
+					t.Errorf("commit message missing Signed-off-by trailer, got %q", msg)
+				}
+				if !strings.Contains(msg, "Assisted-by: Claude <noreply@anthropic.com>") {
+					t.Errorf("commit message missing Assisted-by trailer, got %q", msg)
+				}
+			}
+		}
+	}
+	if !foundAmendWithMsg {
+		t.Error("expected git commit --amend -m <msg> when .oompa-commit-msg is present")
+	}
+
+	// The .oompa-commit-msg file should have been cleaned up
+	if _, err := os.Stat(filepath.Join(worktreeDir, commitMsgFile)); !os.IsNotExist(err) {
+		t.Error("expected .oompa-commit-msg to be deleted after use")
+	}
+}
+
+func TestProcessReviewComments_AmendUsesCommitMsgFile(t *testing.T) {
+	// When the agent leaves uncommitted changes AND writes .oompa-commit-msg,
+	// gitAmendAll should use -m with the file's contents instead of --no-edit.
+	// Configured trailers should be appended automatically.
+	worktreeDir := t.TempDir()
+
+	gh := &mockGitHubClient{
+		issueComments: []ReviewComment{
+			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+		},
+	}
+	// Use changeSummaryRunner which simulates uncommitted changes (git status returns dirty)
+	runner := &changeSummaryRunner{
+		mockCommandRunner: &mockCommandRunner{},
+		headSHA:           "after-sha",
+		diffStat:          " pkg/agent/review.go | 5 +++--\n",
+	}
+	wt := &fixedPathWorktreeManager{fixedPath: worktreeDir}
+
+	agent := &Agent{
+		gh:        gh,
+		runner:    runner,
+		worktrees: wt,
+		state:     NewState(),
+		cfg: Config{
+			Owner:       "owner",
+			Repo:        "repo",
+			Label:       "good-for-ai",
+			FlakyLabel:  "flaky-test",
+			GitHubUser:  "test-bot",
+			SignedOffBy: "Test User <test@example.com>",
+			AssistedBy:  "Claude <noreply@anthropic.com>",
+		},
+		logger: slog.Default(),
+		codeAgent: &commitMsgCodeAgent{
+			commitMsg: "fix: updated commit message\n\nNew body",
+			result:    AgentResult{Result: "Done"},
+		},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		Status:       "pr-open",
+		WorktreePath: worktreeDir,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Verify git commit --amend -m was called with the new message plus trailers
+	foundAmendWithMsg := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "commit" && c.Args[1] == "--amend" && c.Args[2] == "-m" {
+			foundAmendWithMsg = true
+			if len(c.Args) >= 4 {
+				msg := c.Args[3]
+				if !strings.Contains(msg, "fix: updated commit message") {
+					t.Errorf("commit message missing subject, got %q", msg)
+				}
+				if !strings.Contains(msg, "New body") {
+					t.Errorf("commit message missing body, got %q", msg)
+				}
+				if !strings.Contains(msg, "Signed-off-by: Test User <test@example.com>") {
+					t.Errorf("commit message missing Signed-off-by trailer, got %q", msg)
+				}
+				if !strings.Contains(msg, "Assisted-by: Claude <noreply@anthropic.com>") {
+					t.Errorf("commit message missing Assisted-by trailer, got %q", msg)
+				}
+			}
+		}
+	}
+	if !foundAmendWithMsg {
+		t.Error("expected git commit --amend -m <msg> when .oompa-commit-msg is present")
+	}
+
+	// The .oompa-commit-msg file should have been cleaned up
+	if _, err := os.Stat(filepath.Join(worktreeDir, commitMsgFile)); !os.IsNotExist(err) {
+		t.Error("expected .oompa-commit-msg to be deleted after use")
+	}
+}
+
+func TestEnsureTrailers_AppendsWhenMissing(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.cfg.AssistedBy = "Claude <noreply@anthropic.com>"
+
+	msg := agent.ensureTrailers("fix: subject\n\nbody text")
+
+	if !strings.Contains(msg, "Signed-off-by: Test User <test@example.com>") {
+		t.Error("expected Signed-off-by trailer to be appended")
+	}
+	if !strings.Contains(msg, "Assisted-by: Claude <noreply@anthropic.com>") {
+		t.Error("expected Assisted-by trailer to be appended")
+	}
+	if !strings.Contains(msg, "fix: subject") {
+		t.Error("original subject should be preserved")
+	}
+	if !strings.Contains(msg, "body text") {
+		t.Error("original body should be preserved")
+	}
+}
+
+func TestEnsureTrailers_SkipsWhenPresent(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	agent.cfg.SignedOffBy = "Test User <test@example.com>"
+	agent.cfg.AssistedBy = "Claude <noreply@anthropic.com>"
+
+	msg := "fix: subject\n\nbody text\n\nSigned-off-by: Test User <test@example.com>\nAssisted-by: Claude <noreply@anthropic.com>"
+	result := agent.ensureTrailers(msg)
+
+	if result != msg {
+		t.Errorf("expected message to be unchanged when trailers already present, got %q", result)
+	}
+}
+
+func TestEnsureTrailers_NoConfigNoChange(t *testing.T) {
+	agent := newTestAgent(&mockGitHubClient{}, &mockCommandRunner{}, &mockWorktreeManager{})
+	// No SignedOffBy or AssistedBy configured
+
+	msg := "fix: subject\n\nbody text"
+	result := agent.ensureTrailers(msg)
+
+	if result != msg {
+		t.Errorf("expected message to be unchanged when no trailers configured, got %q", result)
+	}
+}
+
+func TestProcessReviewComments_SquashWithoutCommitMsgFileUsesNoEdit(t *testing.T) {
+	// When the agent commits directly but does NOT write .oompa-commit-msg,
+	// gitSquashInto should use --no-edit (preserving the original message).
+	gh := &mockGitHubClient{
+		prComments: []ReviewComment{
+			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+		},
+	}
+	runner := &reviewSquashRunner{
+		mockCommandRunner: &mockCommandRunner{},
+		headSHAs:          []string{"original-sha", "agent-committed-sha"},
+	}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.codeAgent = &sequentialMockCodeAgent{
+		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+	}
+	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
+		IssueNumber:   42,
+		IssueTitle:    "Fix bug",
+		PRNumber:      100,
+		Status:        "pr-open",
+		WorktreePath:  "/tmp/worktree",
+		LastCommentID: 50,
+	}
+
+	agent.ProcessReviewComments(context.Background())
+
+	// Verify git commit --amend --no-edit was called (NOT -m)
+	foundNoEdit := false
+	for _, c := range runner.calls {
+		if c.Name == "git" && len(c.Args) >= 2 && c.Args[0] == "commit" && c.Args[1] == "--amend" {
+			if len(c.Args) >= 3 && c.Args[2] == "--no-edit" {
+				foundNoEdit = true
+			}
+		}
+	}
+	if !foundNoEdit {
+		t.Error("expected git commit --amend --no-edit when no .oompa-commit-msg file exists")
 	}
 }
 

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -104,7 +104,12 @@ There is NO fallback — if the skill does not reply to a thread, it will remain
 
 CRITICAL: Do NOT commit, push, or amend — the outer agent handles git operations automatically.
 If you make code changes, leave them UNCOMMITTED. Do NOT run "git add", "git commit", or "git push".
-Do NOT run "git push" even if the skill tries to — skip step 7 (commit/push) from the skill workflow.`)
+Do NOT run "git push" even if the skill tries to — skip step 7 (commit/push) from the skill workflow.
+
+COMMIT MESSAGE CHANGES: If asked to fix or change the commit message, write the full desired
+commit message (subject + body) to a file named ".oompa-commit-msg" in the repository root.
+Do NOT run "git commit --amend" yourself — the outer agent will read this file and apply it
+during the squash/amend step. Do NOT git add or commit the .oompa-commit-msg file.`)
 
 	return prompt.String()
 }

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -328,3 +328,25 @@ func TestBuildFlakyMatchPrompt_RootCauseInstructions(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildReviewResponsePrompt_CommitMessageInstructions(t *testing.T) {
+	work := IssueWork{
+		IssueNumber: 42,
+		IssueTitle:  "Fix nil pointer in handler",
+		PRNumber:    100,
+	}
+
+	prompt := buildReviewResponsePrompt(work, nil, nil, nil, "owner", "repo")
+
+	checks := []string{
+		".oompa-commit-msg",
+		"commit message",
+		"Do NOT run \"git commit --amend\"",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #242

## Summary

Fix `/oompa` commands failing to update commit messages when explicitly asked by a reviewer. The squash and amend operations unconditionally used `--no-edit`, preserving the original commit message even when the agent was asked to change it.

## Changes

- Add `.oompa-commit-msg` file mechanism: the agent writes the desired commit message to this file, and the outer automation reads it during squash/amend
- Modify `gitSquashInto` to use `-m <msg>` instead of `--no-edit` when `.oompa-commit-msg` is present
- Modify `gitAmendAll` to use `-m <msg>` instead of `--no-edit` when `.oompa-commit-msg` is present
- Update the review response prompt to instruct the agent to write `.oompa-commit-msg` for commit message changes
- Add `.oompa-commit-msg` to `.gitignore` alongside `.pr-body.md`
- Add unit tests for `readCommitMsgFile` and integration tests for both squash and amend paths

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests: `TestReadCommitMsgFile_{Present,Absent,Empty}`, `TestProcessReviewComments_{SquashUsesCommitMsgFile,AmendUsesCommitMsgFile,SquashWithoutCommitMsgFileUsesNoEdit}`, `TestBuildReviewResponsePrompt_CommitMessageInstructions`

## Related Issues

Fixes #242

<!-- oompa-bot v:921fca9 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding commit messages via a `.oompa-commit-msg` file in the repository root; amend/squash operations now use its contents (including applying configured sign-off/help trailers) and remove the file after use.
  * Updated review-response prompt guidance to direct commit message changes through `.oompa-commit-msg` (instead of directly amending commits).

* **Tests**
  * Added unit tests covering presence/absence/empty behavior of `.oompa-commit-msg`, correct amend/squash behavior, trailer handling, and deletion after use.

* **Chores**
  * Updated ignore rules to avoid committing the `.oompa-commit-msg` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->