### PR TITLE
bug: issue fixer creates PRs with invalid commit messages for kubevirt repos

### DIFF
--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -117,6 +117,31 @@ func isConventionalCommitTitle(title string) bool {
 	return conventionalCommitRe.MatchString(title)
 }
 
+// maxSubjectLen is the maximum length of a commit subject line.
+const maxSubjectLen = 72
+
+// truncateSubject shortens a commit subject to fit within maxLen runes.
+// If truncation is needed, it breaks at the last word boundary before the limit
+// and appends "...". If there is no word boundary, it hard-truncates.
+// Operates on runes to avoid splitting multi-byte UTF-8 sequences.
+func truncateSubject(subject string, maxLen int) string {
+	runes := []rune(subject)
+	if len(runes) <= maxLen {
+		return subject
+	}
+	// Reserve space for the ellipsis suffix.
+	cutoff := maxLen - 3
+	if cutoff <= 0 {
+		return string(runes[:maxLen])
+	}
+	// Try to break at the last space before the cutoff.
+	truncated := string(runes[:cutoff])
+	if idx := strings.LastIndex(truncated, " "); idx > 0 {
+		return truncated[:idx] + "..."
+	}
+	return truncated + "..."
+}
+
 // gitSquashCommits squashes all commits since the origin default branch into a single commit.
 func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issueNumber int, issueTitle string) error {
 	// Get all commit messages since origin default branch
@@ -138,15 +163,13 @@ func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issue
 	// Strip any Signed-off-by/Assisted-by trailers Claude may have added to individual
 	// commits before building the body, then append exactly one canonical set of trailers.
 	//
-	// When the issue title already starts with a conventional commit prefix (e.g. "feat:",
-	// "build:", "refactor(scope):"), use the title as-is for the subject and move the issue
-	// reference to the body. Otherwise, use the legacy "Fix #N: <title>" format.
+	// The subject line uses the issue title directly (truncated to 72 chars).
+	// The issue reference goes in the body as "Related-to: #N" to avoid
+	// auto-close keywords (Fix, Fixes, Closes) that some CI systems reject
+	// (e.g. kubevirt prow's invalid-commit-message check).
+	subject := truncateSubject(issueTitle, maxSubjectLen)
 	var commitMsg string
-	if isConventionalCommitTitle(issueTitle) {
-		commitMsg = fmt.Sprintf("%s\n\nFixes #%d", issueTitle, issueNumber)
-	} else {
-		commitMsg = fmt.Sprintf("Fix #%d: %s", issueNumber, issueTitle)
-	}
+	commitMsg = fmt.Sprintf("%s\n\nRelated-to: #%d", subject, issueNumber)
 	if commitMessages != "" {
 		commitMsg += "\n\n" + stripTrailers(commitMessages)
 	}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3118,8 +3118,8 @@ func TestProcessNewIssues_SquashesCommits(t *testing.T) {
 				// Verify commit message includes issue number
 				if len(c.Args) >= 3 {
 					commitMsg := c.Args[2]
-					if !strings.Contains(commitMsg, "Fix #42") {
-						t.Errorf("expected commit message to contain 'Fix #42', got: %s", commitMsg)
+					if !strings.Contains(commitMsg, "Related-to: #42") {
+						t.Errorf("expected commit message to contain 'Related-to: #42', got: %s", commitMsg)
 					}
 					if !strings.Contains(commitMsg, "Signed-off-by") {
 						t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
@@ -3201,6 +3201,35 @@ func TestIsConventionalCommitTitle(t *testing.T) {
 	}
 }
 
+func TestTruncateSubject(t *testing.T) {
+	tests := []struct {
+		name     string
+		subject  string
+		maxLen   int
+		expected string
+	}{
+		{"short subject unchanged", "fix: short title", 72, "fix: short title"},
+		{"exactly 72 chars unchanged", strings.Repeat("a", 72), 72, strings.Repeat("a", 72)},
+		{"long title truncated at word boundary", "CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The pull-e2e-cluster-network-addons-operator-monitoring-k8s", 72, "CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s..."},
+		{"long single word hard truncated", strings.Repeat("x", 100), 72, strings.Repeat("x", 69) + "..."},
+		{"empty string unchanged", "", 72, ""},
+		{"breaks at last space before cutoff", "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12 word13", 72, "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11..."},
+		{"multi-byte runes not split", "Ошибка CI: " + strings.Repeat("слово ", 20), 30, "Ошибка CI: слово слово..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateSubject(tt.subject, tt.maxLen)
+			if got != tt.expected {
+				t.Errorf("truncateSubject(%q, %d) =\n  %q (len=%d)\nwant:\n  %q (len=%d)", tt.subject, tt.maxLen, got, len(got), tt.expected, len(tt.expected))
+			}
+			if len([]rune(got)) > tt.maxLen {
+				t.Errorf("truncateSubject result exceeds maxLen: got %d runes, max %d", len([]rune(got)), tt.maxLen)
+			}
+		})
+	}
+}
+
 func TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle(t *testing.T) {
 	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
 	gh := &mockGitHubClient{
@@ -3213,8 +3242,8 @@ func TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle(t *testing.T) 
 	agent.cfg.SignedOffBy = "Test User <test@example.com>"
 	agent.ProcessNewIssues(context.Background())
 
-	// Verify the commit message uses the conventional commit title as-is
-	// and puts "Fixes #N" in the body instead of "Fix #N: <title>"
+	// Verify the commit message uses the issue title as the subject
+	// and puts "Related-to: #N" in the body (no auto-close keywords)
 	for _, c := range runner.calls {
 		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
 			continue
@@ -3225,13 +3254,13 @@ func TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle(t *testing.T) 
 		if lines[0] != "build: consolidate multi-arch container build scripts" {
 			t.Errorf("expected subject line to be the conventional commit title, got: %q", lines[0])
 		}
-		// Should NOT contain "Fix #1532:" prefix
-		if strings.Contains(commitMsg, "Fix #1532:") {
-			t.Errorf("commit message should not contain 'Fix #1532:' for conventional commit titles, got: %s", commitMsg)
+		// Should NOT contain auto-close keywords
+		if strings.Contains(commitMsg, "Fix #1532") || strings.Contains(commitMsg, "Fixes #1532") || strings.Contains(commitMsg, "Closes #1532") {
+			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
 		}
-		// Should contain "Fixes #1532" in the body
-		if !strings.Contains(commitMsg, "Fixes #1532") {
-			t.Errorf("expected commit body to contain 'Fixes #1532', got: %s", commitMsg)
+		// Should contain "Related-to: #1532" in the body
+		if !strings.Contains(commitMsg, "Related-to: #1532") {
+			t.Errorf("expected commit body to contain 'Related-to: #1532', got: %s", commitMsg)
 		}
 		// Should still have trailers
 		if !strings.Contains(commitMsg, "Signed-off-by") {
@@ -3254,22 +3283,66 @@ func TestProcessNewIssues_SquashesCommits_NonConventionalTitle(t *testing.T) {
 	agent.cfg.SignedOffBy = "Test User <test@example.com>"
 	agent.ProcessNewIssues(context.Background())
 
-	// Verify the commit message uses the legacy "Fix #N: <title>" format
+	// Verify the commit message uses the issue title as subject and
+	// references the issue in the body with "Related-to:" (no auto-close keywords)
 	for _, c := range runner.calls {
 		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
 			continue
 		}
 		commitMsg := c.Args[2]
-		if !strings.Contains(commitMsg, "Fix #42: implement feature X") {
-			t.Errorf("expected commit message to contain 'Fix #42: implement feature X', got: %s", commitMsg)
-		}
-		// Should NOT contain standalone "Fixes #42" in body (that's for conventional commits)
 		lines := strings.SplitN(commitMsg, "\n", 2)
-		if lines[0] != "Fix #42: implement feature X" {
-			t.Errorf("expected subject line to be 'Fix #42: implement feature X', got: %q", lines[0])
+		if lines[0] != "implement feature X" {
+			t.Errorf("expected subject line to be 'implement feature X', got: %q", lines[0])
+		}
+		// Should NOT contain auto-close keywords
+		if strings.Contains(commitMsg, "Fix #42") || strings.Contains(commitMsg, "Fixes #42") || strings.Contains(commitMsg, "Closes #42") {
+			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
+		}
+		// Should contain "Related-to: #42" in the body
+		if !strings.Contains(commitMsg, "Related-to: #42") {
+			t.Errorf("expected commit body to contain 'Related-to: #42', got: %s", commitMsg)
 		}
 		if !strings.Contains(commitMsg, "Signed-off-by") {
 			t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+		}
+		return
+	}
+	t.Error("expected git commit -m to be called")
+}
+
+func TestProcessNewIssues_SquashesCommits_LongTitle(t *testing.T) {
+	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
+	longTitle := "CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The pull-e2e-cluster-network-addons-operator-monitoring-k8s"
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 2799, Title: longTitle, Body: "CI is failing"}},
+	}
+	runner := &mockCommandRunner{stdout: claudeResult}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.ProcessNewIssues(context.Background())
+
+	// Verify the commit subject is truncated to 72 characters
+	for _, c := range runner.calls {
+		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
+			continue
+		}
+		commitMsg := c.Args[2]
+		lines := strings.SplitN(commitMsg, "\n", 2)
+		subject := lines[0]
+		if len(subject) > 72 {
+			t.Errorf("subject line exceeds 72 chars (%d): %q", len(subject), subject)
+		}
+		if !strings.HasSuffix(subject, "...") {
+			t.Errorf("truncated subject should end with '...', got: %q", subject)
+		}
+		// Should NOT contain auto-close keywords
+		if strings.Contains(commitMsg, "Fix #2799") || strings.Contains(commitMsg, "Fixes #2799") {
+			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
+		}
+		// Should contain "Related-to: #2799" in the body
+		if !strings.Contains(commitMsg, "Related-to: #2799") {
+			t.Errorf("expected commit body to contain 'Related-to: #2799', got: %s", commitMsg)
 		}
 		return
 	}


### PR DESCRIPTION
Fixes #229

## Summary

Fix commit message format to avoid auto-close keywords and enforce 72-character subject lines, preventing kubevirt prow's `invalid-commit-message` check from rejecting oompa-created PRs.

## Changes

- Replace `Fix #N: <title>` and `Fixes #N` commit subject formats with the issue title directly and `Related-to: #N` in the body
- Add `truncateSubject()` helper that truncates at word boundaries with `...` suffix when the subject exceeds 72 characters
- Update all existing commit message tests to verify the new format
- Add new test for long issue titles verifying truncation behavior
- Add unit tests for `truncateSubject` edge cases

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #229

<!-- oompa-bot v:921fca9 -->