### PR TITLE
bug: change summary comment shows raw diff stat instead of semantic descriptions

### DIFF
--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -496,9 +496,9 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 		}
 	}
 	runner.mu.Unlock()
-	// 1 for implementation + 1 for review
-	if claudeCalls != 2 {
-		t.Errorf("expected 2 total claude calls (implement + review), got %d", claudeCalls)
+	// 1 for implementation + 1 for review + 1 for change summary
+	if claudeCalls != 3 {
+		t.Errorf("expected 3 total claude calls (implement + review + summary), got %d", claudeCalls)
 	}
 
 	// === Phase 3: No new comments, nothing happens ===
@@ -716,9 +716,9 @@ func TestIntegration_ReviewerWhitelist(t *testing.T) {
 	}
 	runner.mu.Unlock()
 
-	// 1 call for whitelisted reviewer
-	if claudeCallsAfter != 1 {
-		t.Errorf("expected 1 claude call for whitelisted reviewer, got %d", claudeCallsAfter)
+	// 1 call for whitelisted reviewer + 1 for change summary
+	if claudeCallsAfter != 2 {
+		t.Errorf("expected 2 claude calls for whitelisted reviewer (review + summary), got %d", claudeCallsAfter)
 	}
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -5995,11 +5995,15 @@ type commitMsgCodeAgent struct {
 	result    AgentResult
 	err       error
 	prompts   []string
+	callCount int
 }
 
 func (m *commitMsgCodeAgent) Run(_ context.Context, _ CommandRunner, workDir, prompt string, _ *slog.Logger, _ bool) (AgentResult, error) {
+	m.callCount++
 	m.prompts = append(m.prompts, prompt)
-	if m.commitMsg != "" {
+	// Only write the commit message file on the first call (the review fix).
+	// Subsequent calls (e.g. change summary LLM) should not recreate it.
+	if m.commitMsg != "" && m.callCount == 1 {
 		// Simulate the agent writing the commit message file
 		if err := os.WriteFile(filepath.Join(workDir, commitMsgFile), []byte(m.commitMsg), 0o644); err != nil {
 			return AgentResult{}, err
@@ -6114,7 +6118,7 @@ func TestProcessReviewComments_AmendUsesCommitMsgFile(t *testing.T) {
 	runner := &changeSummaryRunner{
 		mockCommandRunner: &mockCommandRunner{},
 		headSHA:           "after-sha",
-		diffStat:          " pkg/agent/review.go | 5 +++--\n",
+		diffPatch:         "diff --git a/pkg/agent/review.go b/pkg/agent/review.go\n@@ -1 +1 @@\n-old\n+new\n",
 	}
 	wt := &fixedPathWorktreeManager{fixedPath: worktreeDir}
 
@@ -6451,7 +6455,7 @@ func TestTriageDedup_DeterministicFallbackWithMultiLineNone(t *testing.T) {
 
 func TestProcessReviewComments_PostsChangeSummaryAfterPush(t *testing.T) {
 	// After pushing a fix in response to review feedback, oompa should
-	// comment on the PR with a compare URL and a summary of the changes.
+	// comment on the PR with a compare URL and a semantic summary of the changes.
 	gh := &mockGitHubClient{
 		prComments: []ReviewComment{
 			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
@@ -6460,13 +6464,16 @@ func TestProcessReviewComments_PostsChangeSummaryAfterPush(t *testing.T) {
 	runner := &changeSummaryRunner{
 		mockCommandRunner: &mockCommandRunner{},
 		headSHA:           "abc123def456",
-		diffStat:          " pkg/agent/review.go | 5 +++--\n 1 file changed, 3 insertions(+), 2 deletions(-)\n",
+		diffPatch:         "diff --git a/pkg/agent/review.go b/pkg/agent/review.go\n--- a/pkg/agent/review.go\n+++ b/pkg/agent/review.go\n@@ -1,3 +1,5 @@\n+// Added validation\n func foo() {\n+\treturn nil\n }\n",
 	}
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+		results: []mockCodeAgentCall{
+			{result: AgentResult{Result: "Done"}},                                                 // review fix
+			{result: AgentResult{Result: "- Added validation logic to the review handler"}}, // change summary
+		},
 	}
 	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
 		IssueNumber:   42,
@@ -6498,9 +6505,9 @@ func TestProcessReviewComments_PostsChangeSummaryAfterPush(t *testing.T) {
 	if !strings.Contains(changeSummaryComment, "[Change](") {
 		t.Errorf("expected [Change](...) link in comment, got: %q", changeSummaryComment)
 	}
-	// Should contain file change info
-	if !strings.Contains(changeSummaryComment, "pkg/agent/review.go") {
-		t.Errorf("expected file path in summary, got: %q", changeSummaryComment)
+	// Should contain semantic summary from LLM (not raw file paths with stats)
+	if !strings.Contains(changeSummaryComment, "Added validation logic") {
+		t.Errorf("expected semantic summary in comment, got: %q", changeSummaryComment)
 	}
 	// Should contain bot marker
 	if !strings.Contains(changeSummaryComment, botMarker) {
@@ -6555,40 +6562,77 @@ func TestProcessReviewComments_NoChangeSummaryWhenNoPush(t *testing.T) {
 
 func TestBuildChangeSummary(t *testing.T) {
 	tests := []struct {
-		name      string
-		diffStat  string
-		runnerErr error // if set, runner returns this error instead of diffStat
-		want      []string // strings that should appear in the output
-		notWant   []string // strings that should NOT appear in the output
+		name        string
+		diff        string       // git diff output (full patch)
+		runnerErr   error        // if set, runner returns this error for git diff
+		llmResult   string       // LLM response text
+		llmErr      error        // if set, LLM call returns this error
+		want        []string     // strings that should appear in the output
+		notWant     []string     // strings that should NOT appear in the output
 	}{
 		{
-			name:     "single file changed",
-			diffStat: " pkg/agent/review.go | 5 +++--\n 1 file changed, 3 insertions(+), 2 deletions(-)\n",
-			want:     []string{"pkg/agent/review.go", "5 +++--"},
-			notWant:  []string{"file changed"},
+			name:      "LLM summarizes single file change",
+			diff:      "diff --git a/pkg/agent/review.go b/pkg/agent/review.go\n@@ -1,3 +1,5 @@\n+// Added validation\n func foo() {}\n",
+			llmResult: "- Added input validation to the review handler",
+			want:      []string{"Added input validation to the review handler"},
+			notWant:   []string{"review.go", "+++"},
 		},
 		{
-			name:     "multiple files changed",
-			diffStat: " pkg/agent/review.go | 10 +++++++---\n pkg/agent/loop.go   |  3 ++-\n 2 files changed, 9 insertions(+), 4 deletions(-)\n",
-			want:     []string{"pkg/agent/review.go", "pkg/agent/loop.go"},
-			notWant:  []string{"files changed"},
+			name:      "LLM summarizes multiple changes",
+			diff:      "diff --git a/review.go b/review.go\n@@ -1 +1 @@\n-old\n+new\ndiff --git a/loop.go b/loop.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmResult: "- Refactored review handler for clarity\n- Updated loop to handle edge cases",
+			want:      []string{"Refactored review handler", "Updated loop to handle edge cases"},
+			notWant:   []string{"review.go", "loop.go"},
 		},
 		{
-			name:     "empty diff stat",
-			diffStat: "",
-			want:     []string{"Updated code to address review feedback"},
+			name: "empty diff returns fallback",
+			diff: "",
+			want: []string{"Updated code to address review feedback"},
 		},
 		{
-			name:      "runner error returns fallback",
+			name:      "git diff error returns fallback",
 			runnerErr: fmt.Errorf("git diff failed"),
+			want:      []string{"Updated code to address review feedback"},
+		},
+		{
+			name:   "LLM error returns fallback",
+			diff:   "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmErr: fmt.Errorf("LLM unavailable"),
+			want:   []string{"Updated code to address review feedback"},
+		},
+		{
+			name:      "LLM returns empty result uses fallback",
+			diff:      "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmResult: "",
+			want:      []string{"Updated code to address review feedback"},
+		},
+		{
+			name:      "LLM output without bullet prefix gets normalized",
+			diff:      "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmResult: "Fixed the null pointer check",
+			want:      []string{"- Fixed the null pointer check"},
+		},
+		{
+			name:      "LLM returns diff artifacts uses fallback",
+			diff:      "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmResult: "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new",
+			want:      []string{"Updated code to address review feedback"},
+		},
+		{
+			name:      "LLM returns stat artifacts uses fallback",
+			diff:      "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n",
+			llmResult: "- foo.go | 2 files changed, 1 insertions(+), 1 deletions(-)",
 			want:      []string{"Updated code to address review feedback"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner := &mockCommandRunner{stdout: []byte(tt.diffStat), err: tt.runnerErr}
+			runner := &mockCommandRunner{stdout: []byte(tt.diff), err: tt.runnerErr}
 			agent := newTestAgent(&mockGitHubClient{}, runner, &mockWorktreeManager{})
+			agent.codeAgent = &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{result: AgentResult{Result: tt.llmResult}, err: tt.llmErr}},
+			}
 
 			result := agent.buildChangeSummary(context.Background(), "/tmp/worktree", "abc", "def")
 
@@ -6607,12 +6651,12 @@ func TestBuildChangeSummary(t *testing.T) {
 }
 
 // changeSummaryRunner simulates review feedback that results in uncommitted changes,
-// a successful amend+push, and provides a diff stat for the change summary.
+// a successful amend+push, and provides a diff patch for the change summary.
 type changeSummaryRunner struct {
 	*mockCommandRunner
-	headSHA   string // SHA to return for git rev-parse HEAD after the agent runs (post-push SHA)
-	diffStat  string // output of git diff --stat
-	revCount  int    // tracks how many times rev-parse HEAD was called
+	headSHA    string // SHA to return for git rev-parse HEAD after the agent runs (post-push SHA)
+	diffPatch  string // output of git diff (full patch)
+	revCount   int    // tracks how many times rev-parse HEAD was called
 	headBefore string // pre-agent SHA
 }
 
@@ -6646,9 +6690,9 @@ func (r *changeSummaryRunner) Run(ctx context.Context, workDir, name string, arg
 		return []byte(""), nil, nil
 	}
 
-	// git diff --stat: return file changes
+	// git diff: return full patch
 	if name == "git" && len(args) >= 1 && args[0] == "diff" {
-		return []byte(r.diffStat), nil, nil
+		return []byte(r.diffPatch), nil, nil
 	}
 
 	return nil, nil, nil

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -440,3 +440,19 @@ Instructions:
 
 	return prompt.String()
 }
+
+func buildChangeSummaryPrompt(diff string) string {
+	return fmt.Sprintf(`Summarize the following code diff as a concise bullet list. Each bullet should describe one logical change in a single sentence. Do not include file paths, stat numbers, or diff formatting. Focus on what was changed and why it matters.
+
+<diff>
+%s
+</diff>
+
+Rules:
+- One bullet per logical change (group related hunks)
+- Start each bullet with "- "
+- Be specific and semantic (e.g. "Converted truncateSubject to use rune-based slicing for multi-byte UTF-8 safety")
+- Do not mention file paths or line counts
+- Do not include any text outside the bullet list
+- Do NOT modify any files or run any commands`, diff)
+}

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -397,38 +397,82 @@ func (a *Agent) commentChangeSummary(ctx context.Context, work *IssueWork, befor
 	}
 }
 
-// buildChangeSummary returns a bullet-point summary of file changes between two SHAs.
+// buildChangeSummary returns a semantic bullet-point summary of changes between two SHAs.
+// It runs `git diff` to get the actual patch, passes it to the LLM for summarization,
+// and returns concise human-readable descriptions of each logical change.
+// Falls back to a generic message if the diff or LLM call fails.
 func (a *Agent) buildChangeSummary(ctx context.Context, worktreePath, beforeSHA, afterSHA string) string {
-	out, _, err := a.runner.Run(ctx, worktreePath, "git", "diff", "--stat", "--no-color", beforeSHA, afterSHA)
+	const fallback = "- Updated code to address review feedback"
+
+	out, _, err := a.runner.Run(ctx, worktreePath, "git", "diff", "--no-color", beforeSHA, afterSHA)
 	if err != nil {
-		return "- Updated code to address review feedback"
+		return fallback
 	}
 
-	trimmed := strings.TrimSpace(string(out))
-	if trimmed == "" {
-		return "- Updated code to address review feedback"
+	diff := strings.TrimSpace(string(out))
+	if diff == "" {
+		return fallback
 	}
 
-	lines := strings.Split(trimmed, "\n")
+	prompt := buildChangeSummaryPrompt(diff)
+	result, err := a.codeAgent.Run(ctx, a.runner, worktreePath, prompt, a.logger, false)
+	if err != nil {
+		a.logger.Warn("LLM summarization failed, using fallback", "error", err)
+		return fallback
+	}
 
+	summary := strings.TrimSpace(result.Result)
+	if summary == "" {
+		return fallback
+	}
+
+	// Reject LLM output that contains raw diff or stat artifacts — posting these
+	// would reproduce the original bug this change was meant to fix.
+	if containsDiffArtifacts(summary) {
+		a.logger.Warn("LLM summary contained diff/stat artifacts, using fallback")
+		return fallback
+	}
+
+	// Ensure each line is a bullet point; the LLM should produce them but be defensive.
+	lines := strings.Split(summary, "\n")
 	var bullets []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		// Each line looks like: "path/to/file.go | 5 ++---"
-		parts := strings.SplitN(line, "|", 2)
-		if len(parts) == 2 {
-			filePath := strings.TrimSpace(parts[0])
-			change := strings.TrimSpace(parts[1])
-			bullets = append(bullets, fmt.Sprintf("- `%s` (%s)", filePath, change))
+		if !strings.HasPrefix(line, "- ") {
+			line = "- " + line
 		}
+		bullets = append(bullets, line)
 	}
 
 	if len(bullets) == 0 {
-		return "- Updated code to address review feedback"
+		return fallback
 	}
 
 	return strings.Join(bullets, "\n")
+}
+
+// containsDiffArtifacts returns true if the text contains raw diff or stat
+// markers that indicate the LLM returned diff formatting instead of a
+// semantic summary.
+func containsDiffArtifacts(text string) bool {
+	lower := strings.ToLower(text)
+	artifacts := []string{
+		"diff --git",
+		"+++ ",
+		"--- a/",
+		"--- b/",
+		"@@ ",
+		" files changed",
+		" insertions(+)",
+		" deletions(-)",
+	}
+	for _, marker := range artifacts {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/testdata/fake-claude-review.sh
+++ b/test/e2e/testdata/fake-claude-review.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Stream stdin directly to marker file (avoids echo flag interpretation).
-cat > .oompa-stdin-marker
+# Stream stdin directly to a temp file (preserves trailing newlines, handles large inputs).
+cat > .oompa-stdin-received
+
+# If this is a change summary prompt (LLM summarization), just return
+# a summary result without modifying any files or the stdin marker.
+if grep -q "Summarize the following code diff" .oompa-stdin-received; then
+    rm -f .oompa-stdin-received
+    printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"- Addressed review feedback"}'
+    exit 0
+fi
+
+# Move to marker file for review prompt verification by tests.
+mv .oompa-stdin-received .oompa-stdin-marker
 
 # For review scenarios: make a small change to simulate addressing feedback.
 echo "review fix $(date +%s)" >> REVIEW-FIX.md


### PR DESCRIPTION
Fixes #248

## Summary

Replace the mechanical `git diff --stat` reformatting in `buildChangeSummary` with LLM-based semantic summarization. Change summary comments now describe *what* was changed in human-readable terms instead of showing raw file paths with `+`/`-` counts.

## Changes

- **`pkg/agent/review.go`**: Rewrote `buildChangeSummary` to run `git diff` (full patch), pass it to the LLM via `codeAgent.Run()`, and return semantic bullet points. Falls back to generic message on empty diff, LLM error, or empty LLM output.
- **`pkg/agent/prompt.go`**: Added `buildChangeSummaryPrompt()` that instructs the LLM to summarize a diff as concise semantic bullets without file paths or stat numbers.
- **`pkg/agent/loop_test.go`**: Updated `TestBuildChangeSummary` with 7 test cases covering LLM success, multiple changes, empty diff, git error, LLM error, empty LLM result, and bullet normalization. Updated `TestProcessReviewComments_PostsChangeSummaryAfterPush` to verify semantic content. Updated `changeSummaryRunner` and `commitMsgCodeAgent` for the new call pattern.
- **`pkg/agent/integration_test.go`**: Updated expected claude call counts in `TestIntegration_FullIssueLifecycle` and `TestIntegration_ReviewerWhitelist` to account for the additional LLM summarization call.
- **`test/e2e/testdata/fake-claude-review.sh`**: Updated to detect summarization prompts and return a summary result without creating file changes or commits.

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

Fixes #248

<!-- oompa-bot v:b593061 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced change summary generation to produce semantic, descriptive bullet points instead of file paths and statistics. Change summaries in pull request reviews now provide more meaningful descriptions of code modifications, improving clarity on what was altered and why.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->