### PR TITLE
bug: comment cursor recovery skips unprocessed review comments posted after last review cycle

### DIFF
--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -38,8 +38,9 @@ type mockGitHubClient struct {
 	workflowRuns    []WorkflowRun // workflow runs to return from ListWorkflowRuns
 	prReviews      []PRReview // reviews to return from GetPRReviews
 	headCommitDate time.Time  // date to return from GetPRHeadCommitDate
-	recentCommits  int        // number of recent commits returned by CountCommitsSince
-	countCommitsErr error     // error to return from CountCommitsSince
+	recentCommits   int             // number of recent commits returned by CountCommitsSince
+	countCommitsErr error           // error to return from CountCommitsSince
+	hasEyesReaction map[int64]map[string]bool // commentID -> user -> has eyes reaction
 
 	listIssuesCalled bool // tracks whether ListLabeledIssues was called
 	listIssuesErr    error
@@ -134,7 +135,12 @@ func (m *mockGitHubClient) GetPRHeadSHA(_ context.Context, _, _ string, _ int) (
 	return "abc123", nil
 }
 
-func (m *mockGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, _ int64, _, _ string) (bool, error) {
+func (m *mockGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, commentID int64, reaction, user string) (bool, error) {
+	if reaction == "eyes" && m.hasEyesReaction != nil {
+		if byUser, ok := m.hasEyesReaction[commentID]; ok {
+			return byUser[user], nil
+		}
+	}
 	return false, nil
 }
 

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 )
 
@@ -60,40 +61,86 @@ func recoverLastRebaseTime(ctx context.Context, gh GitHubClient, cfg Config, wor
 
 // recoverCommentCursors recovers the comment cursors (LastCommentID, LastReviewID,
 // LastIssueCommentID) from GitHub by fetching all existing comments/reviews and
-// setting each cursor to the max ID. This prevents re-processing old comments
-// after a restart (e.g., --exit-on-new-version).
+// setting each cursor to the max ID among comments that show evidence of prior
+// processing. This prevents both re-processing old comments after a restart AND
+// skipping unprocessed comments that arrived after the last processing cycle.
+//
+// Processing evidence differs by cursor type:
+//
+// LastCommentID (PR review comments): bot-posted, bot-replied-to, contains
+// bot marker, or has an eyes reaction from the bot.
+//
+// LastReviewID (PR reviews): bot-posted or contains bot marker. The agent
+// never creates PR reviews in practice, so this cursor typically recovers
+// to 0 — all reviews are re-fetched once and the cursor advances on the
+// first poll cycle after filtering.
+//
+// LastIssueCommentID (issue comments): bot-posted or contains bot marker.
+//
+// Comments from external reviewers that have NOT been processed remain above
+// the cursor so they get picked up in the next review cycle.
 func recoverCommentCursors(ctx context.Context, gh GitHubClient, cfg Config, work *IssueWork, prNumber int, logger *slog.Logger) {
-	// Recover LastCommentID from PR review comments
+	// Recover LastCommentID from PR review comments.
+	// Only advance past comments that show evidence of processing:
+	// bot-posted, bot-replied-to, containing bot marker, or having eyes reaction.
 	comments, err := gh.GetPRReviewComments(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
 	if err != nil {
 		logger.Warn("failed to get PR review comments for cursor recovery", "pr", prNumber, "error", err)
 	} else {
+		// Build a set of comment IDs that the bot has replied to.
+		botRepliedTo := make(map[int64]bool)
 		for _, c := range comments {
-			if c.ID > work.LastCommentID {
+			if c.User == cfg.GitHubUser && c.InReplyToID != 0 {
+				botRepliedTo[c.InReplyToID] = true
+			}
+		}
+
+		for _, c := range comments {
+			processed := c.User == cfg.GitHubUser ||
+				botRepliedTo[c.ID] ||
+				strings.Contains(c.Body, botMarker)
+			if !processed {
+				// Check for eyes reaction from bot — the definitive processing marker.
+				// This catches comments that were processed (eyes added) but got no
+				// bot reply (e.g., agent pushed changes without replying individually).
+				if hasEyes, eyesErr := gh.HasPRCommentReaction(ctx, cfg.Owner, cfg.Repo, c.ID, "eyes", cfg.GitHubUser); eyesErr != nil {
+					logger.Warn("failed to check eyes reaction for cursor recovery", "pr", prNumber, "comment", c.ID, "error", eyesErr)
+				} else if hasEyes {
+					processed = true
+				}
+			}
+			if processed && c.ID > work.LastCommentID {
 				work.LastCommentID = c.ID
 			}
 		}
 	}
 
-	// Recover LastReviewID from PR reviews
+	// Recover LastReviewID from PR reviews.
+	// Only advance past reviews from the bot user or containing the bot marker.
+	// The agent never creates PR reviews, so this cursor typically recovers to 0.
+	// All reviews are re-fetched once at startup; ProcessReviewComments filters
+	// them and advances the cursor on the first poll cycle.
 	reviews, err := gh.GetPRReviews(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
 	if err != nil {
 		logger.Warn("failed to get PR reviews for cursor recovery", "pr", prNumber, "error", err)
 	} else {
 		for _, r := range reviews {
-			if r.ID > work.LastReviewID {
+			processed := r.User == cfg.GitHubUser || strings.Contains(r.Body, botMarker)
+			if processed && r.ID > work.LastReviewID {
 				work.LastReviewID = r.ID
 			}
 		}
 	}
 
-	// Recover LastIssueCommentID from PR conversation comments (Issues API)
+	// Recover LastIssueCommentID from PR conversation comments (Issues API).
+	// Only advance past comments from the bot user or containing the bot marker.
 	issueComments, err := gh.GetIssueComments(ctx, cfg.Owner, cfg.Repo, prNumber, 0)
 	if err != nil {
 		logger.Warn("failed to get issue comments for cursor recovery", "pr", prNumber, "error", err)
 	} else {
 		for _, c := range issueComments {
-			if c.ID > work.LastIssueCommentID {
+			processed := c.User == cfg.GitHubUser || strings.Contains(c.Body, botMarker)
+			if processed && c.ID > work.LastIssueCommentID {
 				work.LastIssueCommentID = c.ID
 			}
 		}

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -33,17 +33,21 @@ func TestBuildStateFromGitHub_RecoversPRState(t *testing.T) {
 		prs:    []PR{{Number: 100, State: "open", Head: "ai/issue-42"}},
 		prComments: []ReviewComment{
 			{ID: 10, User: "alice", Body: "looks good"},
+			// Bot reply to alice's comment — proves alice's comment was processed
+			{ID: 15, User: "oompa-bot", Body: "fixed", InReplyToID: 10},
 			{ID: 20, User: "bob", Body: "fix this"},
+			// Bot reply to bob's comment
+			{ID: 25, User: "oompa-bot", Body: "done", InReplyToID: 20},
 		},
 		prReviews: []PRReview{
 			{ID: 5, User: "carol", State: "CHANGES_REQUESTED", Body: "needs work"},
-			{ID: 15, User: "dave", State: "APPROVED", Body: "lgtm"},
+			{ID: 15, User: "oompa-bot", State: "COMMENTED", Body: "addressed <!-- oompa-bot -->"},
 		},
 		issueComments: []ReviewComment{
-			{ID: 30, User: "eve", Body: "/oompa fix tests"},
+			{ID: 30, User: "oompa-bot", Body: "Working on it <!-- oompa-bot -->"},
 		},
 	}
-	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai"}
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", GitHubUser: "oompa-bot"}
 
 	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
 
@@ -57,14 +61,16 @@ func TestBuildStateFromGitHub_RecoversPRState(t *testing.T) {
 	if work.Status != "pr-open" {
 		t.Errorf("expected status 'pr-open', got %q", work.Status)
 	}
-	// Comment cursors should be recovered to max existing IDs to prevent
-	// re-processing old comments after a restart.
-	if work.LastCommentID != 20 {
-		t.Errorf("expected LastCommentID 20, got %d", work.LastCommentID)
+	// Comment cursors should recover to max ID among processed comments only.
+	// Bot replies (ID 25) are the highest processed review comment.
+	if work.LastCommentID != 25 {
+		t.Errorf("expected LastCommentID 25, got %d", work.LastCommentID)
 	}
+	// Bot review (ID 15) is the highest processed review.
 	if work.LastReviewID != 15 {
 		t.Errorf("expected LastReviewID 15, got %d", work.LastReviewID)
 	}
+	// Bot issue comment (ID 30) is the highest processed issue comment.
 	if work.LastIssueCommentID != 30 {
 		t.Errorf("expected LastIssueCommentID 30, got %d", work.LastIssueCommentID)
 	}
@@ -214,19 +220,21 @@ func TestBuildStateFromGitHub_WatchPRsRecoversCursors(t *testing.T) {
 		},
 		prComments: []ReviewComment{
 			{ID: 100, User: "alice", Body: "fix this"},
-			{ID: 200, User: "bob", Body: "also this"},
+			{ID: 150, User: "oompa-bot", Body: "fixed", InReplyToID: 100},
+			{ID: 200, User: "oompa-bot", Body: "done", InReplyToID: 0},
 		},
 		prReviews: []PRReview{
-			{ID: 50, User: "carol", State: "CHANGES_REQUESTED", Body: "needs work"},
+			{ID: 50, User: "oompa-bot", State: "COMMENTED", Body: "addressed <!-- oompa-bot -->"},
 		},
 		issueComments: []ReviewComment{
-			{ID: 300, User: "eve", Body: "/oompa fix tests"},
+			{ID: 300, User: "oompa-bot", Body: "Working on it <!-- oompa-bot -->"},
 		},
 	}
 	cfg := Config{
-		Owner:    "owner",
-		Repo:     "repo",
-		WatchPRs: []int{500},
+		Owner:      "owner",
+		Repo:       "repo",
+		WatchPRs:   []int{500},
+		GitHubUser: "oompa-bot",
 	}
 
 	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
@@ -235,6 +243,7 @@ func TestBuildStateFromGitHub_WatchPRsRecoversCursors(t *testing.T) {
 	if !ok {
 		t.Fatal("expected watched PR 500 in state")
 	}
+	// Cursors recover to max ID among bot-posted/replied comments only.
 	if work.LastCommentID != 200 {
 		t.Errorf("expected LastCommentID 200, got %d", work.LastCommentID)
 	}
@@ -268,5 +277,130 @@ func TestBuildStateFromGitHub_RecoversCursorsNoComments(t *testing.T) {
 	}
 	if work.LastIssueCommentID != 0 {
 		t.Errorf("expected LastIssueCommentID 0, got %d", work.LastIssueCommentID)
+	}
+}
+
+func TestBuildStateFromGitHub_CursorRecoverySkipsUnprocessedComments(t *testing.T) {
+	// Regression test for #251: cursor recovery must NOT advance past unprocessed
+	// review comments. When a second reviewer posts comments after the bot's last
+	// processing cycle, those comments should remain above the cursor.
+	//
+	// Scenario: Bot processed alice's comment (ID 10, replied with ID 15),
+	// then copilot posted two new comments (ID 20, 30) that were never processed.
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 50, Title: "Feature", Labels: []string{"good-for-ai"}}},
+		prs:    []PR{{Number: 250, State: "open", Head: "ai/issue-50"}},
+		prComments: []ReviewComment{
+			{ID: 10, User: "alice", Body: "fix the type"},
+			{ID: 15, User: "oompa-bot", Body: "fixed", InReplyToID: 10},
+			// Copilot's comments arrived after bot's last cycle — never processed
+			{ID: 20, User: "copilot[bot]", Body: "consider using a constant here"},
+			{ID: 30, User: "copilot[bot]", Body: "this could be simplified"},
+		},
+		prReviews: []PRReview{
+			{ID: 5, User: "alice", State: "CHANGES_REQUESTED", Body: "needs work"},
+			// Copilot review arrived after bot's last cycle — never processed
+			{ID: 25, User: "copilot[bot]", State: "COMMENTED", Body: "minor suggestions"},
+		},
+		issueComments: []ReviewComment{
+			{ID: 40, User: "oompa-bot", Body: "Working on it <!-- oompa-bot -->"},
+			// External comment arrived after bot's last cycle
+			{ID: 50, User: "dave", Body: "/oompa please also fix the tests"},
+		},
+	}
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", GitHubUser: "oompa-bot"}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 50)]
+	if !ok {
+		t.Fatal("expected issue 50 in state")
+	}
+
+	// LastCommentID should be 15 (bot's reply), NOT 30 (copilot's unprocessed comment).
+	// This ensures copilot's comments (ID 20, 30) will be fetched on the next poll
+	// cycle since they have ID > 15.
+	if work.LastCommentID != 15 {
+		t.Errorf("expected LastCommentID 15 (bot reply), got %d — unprocessed comments were incorrectly skipped", work.LastCommentID)
+	}
+
+	// LastReviewID should be 0 — alice's review (ID 5) was not posted by the bot
+	// and copilot's review (ID 25) was never processed. No bot-posted reviews exist.
+	if work.LastReviewID != 0 {
+		t.Errorf("expected LastReviewID 0, got %d — unprocessed reviews were incorrectly skipped", work.LastReviewID)
+	}
+
+	// LastIssueCommentID should be 40 (bot's comment), NOT 50 (dave's unprocessed comment).
+	if work.LastIssueCommentID != 40 {
+		t.Errorf("expected LastIssueCommentID 40 (bot comment), got %d — unprocessed issue comments were incorrectly skipped", work.LastIssueCommentID)
+	}
+}
+
+func TestBuildStateFromGitHub_CursorRecoveryWithEyesReaction(t *testing.T) {
+	// When a review comment has an eyes reaction from the bot (but no bot reply),
+	// it should still be considered processed. This handles the case where the agent
+	// added eyes, ran, and pushed changes without posting an individual reply.
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 60, Title: "Bug fix", Labels: []string{"good-for-ai"}}},
+		prs:    []PR{{Number: 300, State: "open", Head: "ai/issue-60"}},
+		prComments: []ReviewComment{
+			// Comment that was processed (eyes reaction) but got no bot reply
+			{ID: 10, User: "alice", Body: "fix the type"},
+			// Comment that was NOT processed (no eyes, no reply)
+			{ID: 20, User: "bob", Body: "also fix this"},
+		},
+		hasEyesReaction: map[int64]map[string]bool{10: {"oompa-bot": true}},
+	}
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", GitHubUser: "oompa-bot"}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 60)]
+	if !ok {
+		t.Fatal("expected issue 60 in state")
+	}
+
+	// LastCommentID should be 10 (alice's comment with eyes reaction), NOT 20 (unprocessed).
+	if work.LastCommentID != 10 {
+		t.Errorf("expected LastCommentID 10 (comment with eyes reaction), got %d", work.LastCommentID)
+	}
+}
+
+func TestBuildStateFromGitHub_CursorRecoveryAllUnprocessed(t *testing.T) {
+	// When no comments have been processed (fresh PR, all from external reviewers),
+	// cursors should stay at 0 so all comments get processed.
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 70, Title: "New PR", Labels: []string{"good-for-ai"}}},
+		prs:    []PR{{Number: 400, State: "open", Head: "ai/issue-70"}},
+		prComments: []ReviewComment{
+			{ID: 10, User: "alice", Body: "looks wrong"},
+			{ID: 20, User: "bob", Body: "fix this"},
+		},
+		prReviews: []PRReview{
+			{ID: 5, User: "carol", State: "CHANGES_REQUESTED", Body: "needs work"},
+		},
+		issueComments: []ReviewComment{
+			{ID: 30, User: "eve", Body: "/oompa fix tests"},
+		},
+	}
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", GitHubUser: "oompa-bot"}
+
+	state := BuildStateFromGitHub(context.Background(), gh, cfg, "/tmp/clone", slog.Default())
+
+	work, ok := state.ActiveIssues[IssueKey("owner", "repo", 70)]
+	if !ok {
+		t.Fatal("expected issue 70 in state")
+	}
+
+	// All comments are from external users with no processing evidence.
+	// Cursors should be 0 so everything gets processed.
+	if work.LastCommentID != 0 {
+		t.Errorf("expected LastCommentID 0 (no processed comments), got %d", work.LastCommentID)
+	}
+	if work.LastReviewID != 0 {
+		t.Errorf("expected LastReviewID 0 (no processed reviews), got %d", work.LastReviewID)
+	}
+	if work.LastIssueCommentID != 0 {
+		t.Errorf("expected LastIssueCommentID 0 (no processed issue comments), got %d", work.LastIssueCommentID)
 	}
 }


### PR DESCRIPTION
Fixes #251

## Summary

Fix cursor recovery to only advance past comments that show evidence of prior processing, preventing unprocessed review comments from being silently skipped after a restart.

## Changes

- `recoverCommentCursors` in `state.go` now only advances cursors past comments that are:
  - Posted by the bot user (replies or bot-generated comments)
  - Replied to by the bot user (tracked via `InReplyToID`)
  - Have an eyes reaction from the bot (checked via `HasPRCommentReaction`)
  - Contain the bot marker (`<!-- oompa-bot`) in their body
- Updated `mockGitHubClient.HasPRCommentReaction` in `loop_test.go` to support configurable eyes reaction responses via `hasEyesReaction` map
- Updated existing cursor recovery tests to use bot-posted comments for processed comment evidence
- Added regression test `TestBuildStateFromGitHub_CursorRecoverySkipsUnprocessedComments` reproducing the exact #251 scenario (copilot comments arriving after bot's last cycle)
- Added `TestBuildStateFromGitHub_CursorRecoveryWithEyesReaction` testing the eyes-reaction fallback path
- Added `TestBuildStateFromGitHub_CursorRecoveryAllUnprocessed` verifying cursors stay at 0 when no comments have been processed

## Testing

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Manual testing (if applicable)

## Related Issues

- Fixes #251 -- cursor recovery skips unprocessed review comments posted after last review cycle
- Related to #244 -- the original re-processing bug
- Related to #245 -- the PR that introduced cursor recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor tracking for GitHub comments and reviews to ensure the bot accurately identifies which items have been processed.
  * Added support for recognizing "eyes" reactions as evidence of processed comments.
  * Fixed state recovery to prevent re-processing or skipping GitHub artifacts during bot restarts.

* **Tests**
  * Enhanced test coverage for cursor recovery behavior with new regression tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->