### PR TITLE
docs: create oompa documentation site using mdBook

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,54 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mdBook
+        run: |
+          tag=$(curl -s https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r '.tag_name')
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${tag}/mdbook-${tag}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz
+          sudo mv mdbook /usr/local/bin/
+
+      - name: Build documentation
+        run: mdbook build
+        working-directory: docs
+
+      - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 
 # AgentReady reports
 .agentready/
+
+# mdBook build output
+docs/book/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,19 @@
+[book]
+title = "Oompa Documentation"
+authors = ["Enrique Llorente Pastora"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "book"
+
+[output.html]
+git-repository-url = "https://github.com/qinqon/oompa"
+edit-url-template = "https://github.com/qinqon/oompa/edit/main/docs/src/{path}"
+site-url = "/oompa/"
+
+[output.html.search]
+enable = true
+
+[output.html.playground]
+editable = false

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,32 @@
+# Introduction
+
+**Oompa** is an autonomous AI-powered code maintenance agent that uses [OpenCode](https://opencode.ai) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to implement fixes, address reviews, resolve merge conflicts, fix CI failures, and triage flaky tests -- all without human intervention beyond the final merge.
+
+## What It Does
+
+- **Resolve issues** -- picks up GitHub issues with a configurable label, implements fixes, and opens pull requests.
+- **Address reviews** -- reads reviewer comments and iterates on the code until reviewers are satisfied.
+- **Fix CI failures** -- detects failing checks, analyzes logs, and pushes fixes.
+- **Resolve merge conflicts** -- attempts an automatic rebase and falls back to the coding agent when that fails.
+- **Babysit PRs** -- monitors specific PRs for reviews, CI, conflicts, and rebase.
+- **Triage periodic CI** -- analyzes nightly/scheduled job failures and creates issues with root-cause analysis.
+
+## Safety First
+
+Oompa never merges; a human must approve and merge every PR. No force-pushes beyond `--force-with-lease` for rebase operations. On failure, issues are labeled `ai-failed` with a comment explaining the error so a human can decide next steps.
+
+## How It Works
+
+Oompa is a single long-running Go binary with a sequential polling loop. On each poll cycle it:
+
+1. **Cleans up** merged/closed PRs (removes worktrees, updates state)
+2. **Discovers** new issues with the configured label
+3. **Processes** review comments, CI failures, merge conflicts, and rebase requests
+
+The agent is stateless on disk -- on every startup it rebuilds state from GitHub by scanning labeled issues and matching PRs. All external interactions (GitHub API, coding agent CLI, git) are behind interfaces with mock implementations, so tests run without credentials or network access.
+
+## Next Steps
+
+- [Installation](getting-started/installation.md) -- get oompa running
+- [Quickstart](getting-started/quickstart.md) -- your first run
+- [Configuration](configuration/cli-flags.md) -- customize behavior

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,42 @@
+# Summary
+
+[Introduction](README.md)
+
+# Getting Started
+
+- [Installation](getting-started/installation.md)
+- [Authentication](getting-started/authentication.md)
+- [Quickstart](getting-started/quickstart.md)
+
+# Configuration
+
+- [CLI Flags](configuration/cli-flags.md)
+- [Config File](configuration/config-file.md)
+- [Inheritance](configuration/inheritance.md)
+- [Examples](configuration/examples.md)
+
+# Roles
+
+- [Issue Resolver](roles/issue-resolver.md)
+- [PR Babysitter](roles/pr-babysitter.md)
+- [Periodic Triage](roles/periodic-triage.md)
+
+# Features
+
+- [CI Investigation](features/ci-investigation.md)
+- [Flaky Issues](features/flaky-issues.md)
+- [Skip Comment](features/skip-comment.md)
+- [Conflict Resolution](features/conflict-resolution.md)
+- [Review Response](features/review-response.md)
+
+# Operations
+
+- [Systemd](operations/systemd.md)
+- [Kubernetes](operations/kubernetes.md)
+- [Monitoring](operations/monitoring.md)
+- [Troubleshooting](operations/troubleshooting.md)
+
+# Architecture
+
+- [Overview](architecture/overview.md)
+- [Contributing](architecture/contributing.md)

--- a/docs/src/architecture/contributing.md
+++ b/docs/src/architecture/contributing.md
@@ -1,0 +1,93 @@
+# Contributing
+
+Oompa uses spec-driven development. Every component has a corresponding specification that serves as the source of truth.
+
+## Specs
+
+| Spec | Drives |
+|------|--------|
+| `specs/architecture.md` | Overall structure, directory layout, main loop flow |
+| `specs/state.md` | `pkg/agent/state.go` + tests |
+| `specs/github-client.md` | `pkg/agent/github.go` + tests |
+| `specs/claude-runner.md` | `pkg/agent/claude.go` + tests |
+| `specs/worktree.md` | `pkg/agent/worktree.go` + tests |
+| `specs/prompts.md` | `pkg/agent/prompt.go` + tests |
+| `specs/loop.md` | `pkg/agent/loop.go` + tests |
+| `specs/config.md` | `cmd/oompa/main.go` + `pkg/agent/config.go` |
+| `specs/error-handling.md` | Error handling and safety constraints |
+| `specs/testing.md` | Mock types, test strategy, verification |
+| `specs/event.md` | Event system (emitter, server, client) |
+| `specs/tui.md` | TUI dashboard |
+
+## Rules
+
+1. **Spec first**: Before writing or modifying any file, read its corresponding spec
+2. **Interfaces match spec**: All interface definitions must match the spec exactly
+3. **Tests match spec**: Every test listed in a spec must be implemented
+4. **No unspecified features**: Do not add functionality not described in a spec
+5. **Spec changes require discussion**: If a spec seems wrong, flag it -- do not silently deviate
+
+## Build and Test
+
+```bash
+# Build
+go build -o oompa ./cmd/oompa
+
+# Run all tests
+go test ./...
+
+# Type-check a single package
+go vet ./pkg/agent/...
+
+# Run tests for a single file
+go test ./pkg/agent/ -run TestProcessNewIssues -v
+
+# Lint
+golangci-lint run ./pkg/agent/...
+
+# Static analysis
+staticcheck ./pkg/agent/...
+
+# Build documentation locally (requires mdBook)
+# Install: https://rust-lang.github.io/mdBook/guide/installation.html
+mdbook build docs/
+mdbook serve docs/   # live preview at http://localhost:3000
+```
+
+## Adding a New Reaction
+
+Follow the pattern in `pkg/agent/ci.go` (see `ProcessCIFailures`):
+
+1. Add the method to `Agent` in a new file (e.g., `pkg/agent/foo.go`)
+2. Gate it with `a.ShouldRunReaction("foo")` at the top
+3. Add the call to the main polling loop in `cmd/oompa/main.go`
+4. Add the reaction name to the `--reactions` flag documentation
+5. Write tests in `pkg/agent/loop_test.go` using the mock interfaces
+
+## Adding a New GitHub API Method
+
+See `pkg/agent/github.go` for reference implementations:
+
+1. Add the method signature to the `GitHubClient` interface
+2. Implement it on `*GoGitHubClient`
+3. Add the mock implementation to `MockGitHubClient` in `pkg/agent/loop_test.go`
+4. Write a test using `httptest.NewServer` in `pkg/agent/github_test.go`
+
+## Adding a New CLI Flag
+
+1. Add the field to `Config` in `pkg/agent/config.go`
+2. Add the flag binding in `cmd/oompa/main.go` (flag + env var fallback)
+3. Document it in the CLI flags reference
+
+## Implementation Order
+
+When implementing from scratch, follow dependency order:
+
+1. `go.mod` + `pkg/agent/types.go`
+2. `pkg/agent/state.go` + tests
+3. `pkg/agent/prompt.go` + tests
+4. `pkg/agent/claude.go` + tests
+5. `pkg/agent/github.go` + tests
+6. `pkg/agent/worktree.go` + tests
+7. `pkg/agent/loop.go` + tests
+8. `cmd/oompa/main.go`

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -1,0 +1,89 @@
+# Architecture Overview
+
+Oompa is a single long-running Go binary with a sequential polling loop.
+
+## Design Decisions
+
+- **Polling, not webhooks**: Avoids inbound connectivity requirements, NAT traversal, and webhook secret management. The agent runs behind firewalls and on developer machines without exposing ports. The trade-off is higher latency (bounded by `--poll-interval`) which is acceptable for code maintenance tasks that tolerate minutes of delay.
+
+- **Sequential, not parallel**: One issue at a time prevents race conditions on shared git state (worktrees, branches). A goroutine-per-issue model would require locking around git operations and make debugging harder. The `--max-workers` flag allows opt-in parallelism when the user accepts the complexity.
+
+- **Interfaces over mocks**: All external dependencies (GitHub API, Claude CLI, git) are behind Go interfaces. This enables deterministic unit tests without credentials, network access, or subprocess execution.
+
+- **Stateless on disk**: The agent rebuilds state from GitHub on every startup by scanning labeled issues and matching PRs. This eliminates state file corruption, migration, and backup concerns. The trade-off is a small startup cost from API calls.
+
+- **CLI subprocess, not SDK**: The coding agent is invoked via the CLI (`claude -p` or `opencode`) rather than an SDK. This decouples the agent from release cycles and authentication flows, and allows swapping agents via `--agent`.
+
+## Invariants
+
+- Oompa never merges -- it only creates or updates PRs. A human must approve and merge.
+- Force-pushes use `--force-with-lease` only for history-rewriting operations (rebase, squash).
+- Bot-posted comments are tagged with `<!-- oompa-bot -->` markers to prevent self-reply loops.
+
+## Directory Structure
+
+```
+cmd/oompa/
+  main.go              -- entry point, config parsing, subcommand dispatch, polling loop
+  status.go            -- `oompa status` subcommand (print-and-exit snapshot)
+  tui.go               -- `oompa tui` subcommand (live bubbletea dashboard)
+pkg/agent/
+  types.go             -- shared types (Issue, ReviewComment, PR, ClaudeResult, IssueWork)
+  config.go            -- Config struct
+  event.go             -- EventEmitter interface, Event/WorkerState types
+  eventserver.go       -- SocketEventServer (Unix socket server)
+  eventclient.go       -- EventClient (connects to daemon socket for status/tui)
+  github.go            -- GitHubClient interface + go-github implementation
+  claude.go            -- CommandRunner interface + coding agent CLI invocation
+  worktree.go          -- git worktree management
+  state.go             -- in-memory state rebuilt from GitHub on startup
+  prompt.go            -- prompt templates
+  loop.go              -- Agent struct, NewAgent, CleanupDone, BootstrapWatchedPRs
+  issues.go            -- ProcessNewIssues
+  review.go            -- ProcessReviewComments
+  ci.go                -- ProcessCIFailures
+  conflicts.go         -- ProcessConflicts, conflict resolution
+  triage.go            -- ProcessTriageJobs, periodic CI investigation
+  git_ops.go           -- git push, amend, squash, rebase helpers
+  loop_test.go         -- integration tests with all interfaces mocked
+specs/
+  *.md                 -- design specifications for each component
+```
+
+## Main Loop
+
+```
+STARTUP: parse config -> rebuild state from GitHub -> signal handler
+
+LOOP (every poll-interval):
+  1. Cleanup: for each active PR
+     -> get PR state via GitHub API
+     -> if MERGED/CLOSED: remove worktree, remove from state
+
+  2. New Issues: list issues with label via GitHub API
+     -> skip if already in state
+     -> git fetch + git worktree add -b ai/issue-N
+     -> invoke coding agent
+     -> push branch, create PR via GitHub API
+     -> update in-memory state
+
+  3. Reactions: for each active PR in state
+     -> review comments: fetch new comments, invoke agent
+     -> CI failures: check runs, classify, fix or report
+     -> conflicts: detect and resolve via rebase
+     -> rebase: update base branch
+```
+
+## Dependencies
+
+- `github.com/google/go-github/v84` -- GitHub API client (behind `GitHubClient` interface)
+- Go standard library for everything else
+
+## Error Strategy
+
+The error strategy prioritizes human visibility over automatic recovery:
+
+- **Agent failure**: Label issue `ai-failed`, post comment with error, skip
+- **GitHub API failure**: Log and skip, retry on next poll cycle
+- **Process restart**: State rebuilt from GitHub on startup
+- **Self-reply prevention**: Bot comments tagged with `<!-- oompa-bot -->` markers

--- a/docs/src/configuration/cli-flags.md
+++ b/docs/src/configuration/cli-flags.md
@@ -1,0 +1,71 @@
+# CLI Flags
+
+Every flag has a corresponding environment variable. Flags take precedence over environment variables.
+
+## Core
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--repo` | `OOMPA_REPO` | -- | GitHub repo as `owner/repo` (required) |
+| `--agent` | `OOMPA_AGENT` | `claudecode` | Coding agent backend: `claudecode` or `opencode` |
+| `--agent-model` | `OOMPA_AGENT_MODEL` | -- | Model override for OpenCode (e.g. `google-vertex-anthropic/claude-opus-4-6@default`) |
+| `--label` | `OOMPA_LABEL` | `good-for-ai` | Issue label to watch |
+| `--clone-dir` | `OOMPA_CLONE_DIR` | `/tmp/oompa-work` | Working directory for clones and worktrees |
+| `--poll-interval` | `OOMPA_POLL_INTERVAL` | `2m` | How often to poll GitHub |
+
+## Logging
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--log-level` | `OOMPA_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `--log-file` | `OOMPA_LOG_FILE` | stderr | Write logs to a file instead of stderr |
+
+## Git Identity
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--signed-off-by` | `OOMPA_SIGNED_OFF_BY` | auto-detected | `Signed-off-by` line for commits |
+| `--assisted-by` | `OOMPA_ASSISTED_BY` | auto-detected | `Assisted-by` trailer for AI-assisted commits (auto-detected from `--agent`) |
+| `--git-author-name` | `GIT_AUTHOR_NAME` | auto-detected | Git commit author name |
+| `--git-author-email` | `GIT_AUTHOR_EMAIL` | auto-detected | Git commit author email |
+
+## GitHub Authentication
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| -- | `GITHUB_TOKEN` | -- | GitHub personal access token (falls back to `gh auth token`) |
+| `--github-app-id` | `GITHUB_APP_ID` | -- | GitHub App ID |
+| `--github-app-private-key` | `GITHUB_APP_PRIVATE_KEY_PATH` | -- | Path to GitHub App private key PEM file |
+| `--github-app-installation-id` | `GITHUB_APP_INSTALLATION_ID` | -- | GitHub App installation ID |
+| `--github-user` | `GITHUB_USER` | auto-detected | GitHub username (e.g. `myapp[bot]`) |
+
+## Behavior
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--reviewers` | `OOMPA_REVIEWERS` | all | Comma-separated allowlist of reviewers to respond to |
+| `--fork` | `OOMPA_FORK` | -- | Fork repo as `owner/repo` for pushing branches |
+| `--watch-prs` | `OOMPA_WATCH_PRS` | -- | Comma-separated PR numbers to monitor (bypasses issue discovery) |
+| `--reactions` | `OOMPA_REACTIONS` | all | Comma-separated list: `reviews`, `ci`, `conflicts`, `rebase` |
+| `--skip-comment` | `OOMPA_SKIP_COMMENTS` | none | Comma-separated comment categories to suppress |
+| `--only-assigned` | `OOMPA_ONLY_ASSIGNED` | `false` | Only process issues assigned to the agent user |
+| `--dry-run` | -- | `false` | Log actions without executing them |
+| `--one-shot` | -- | `false` | Run one poll cycle and exit |
+| `--max-workers` | `OOMPA_MAX_WORKERS` | `1` | Maximum parallel agent invocations |
+| `--exit-on-new-version` | `OOMPA_EXIT_ON_NEW_VERSION` | -- | Exit when a new release is available (`owner/repo`) |
+
+## CI and Flaky Tests
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--create-flaky-issues` | `OOMPA_CREATE_FLAKY_ISSUES` | `false` | Create issues for unrelated CI failures (opt-in) |
+| `--flaky-label` | `OOMPA_FLAKY_LABEL` | `flaky-test` | Label to apply to flaky CI issues |
+| `--triage-jobs` | `OOMPA_TRIAGE_JOBS` | -- | Comma-separated CI job URLs to monitor for periodic job triage |
+| `--triage-lookback` | `OOMPA_TRIAGE_LOOKBACK` | `0` (latest only) | Time window to check for failed triage runs (e.g. `24h`, `12h`) |
+
+## Notes
+
+- `GITHUB_TOKEN` is optional -- if not set, oompa falls back to `gh auth token`.
+- When all three `--github-app-*` flags are provided, the agent uses App auth instead of PAT auth.
+- `--reactions` controls which processing phases run. An empty list disables all reactions (useful for report-only mode).
+- `--skip-comment` categories: `ci-unrelated`, `ci-infrastructure`, `ci-related`, `conflict`, `rebase`, `flaky`, `issue-in-progress`.

--- a/docs/src/configuration/config-file.md
+++ b/docs/src/configuration/config-file.md
@@ -1,0 +1,99 @@
+# Config File
+
+For managing multiple repositories or running different roles per project, oompa supports a YAML configuration file.
+
+## Usage
+
+```bash
+oompa --config config.yaml
+```
+
+## Format
+
+The config file defines global settings and a list of projects. Each project can have multiple roles (issue resolvers, PR watchers, triage jobs).
+
+```yaml
+# Global settings (apply to all projects unless overridden)
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+poll-interval: 2m
+log-level: debug
+exit-on-new-version: qinqon/oompa
+
+projects:
+  - repo: myorg/myrepo
+    # Project-level settings override global
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514
+
+    # Issue resolver role
+    issues:
+      - label: good-for-ai
+        only-assigned: true
+
+    # PR babysitter role
+    prs:
+      - watch: [123, 456]
+        reactions: [ci, conflicts, rebase]
+
+    # Periodic triage role
+    triage:
+      - jobs:
+          - https://prow.example.com/nightly
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+        create-flaky-issues: true
+        flaky-label: ci-flake
+```
+
+## Project Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repo` | string | GitHub repo as `owner/repo` (required) |
+| `fork` | string | Fork repo as `owner/repo` for pushing branches |
+| `agent-model` | string | Model override for this project |
+| `reviewers` | list | Allowlist of reviewers to respond to |
+| `create-flaky-issues` | bool | Create issues for unrelated CI failures |
+| `flaky-label` | string | Label for flaky CI issues |
+| `rebase-interval` | duration | Minimum time between rebases (default: `4h`) |
+| `issues` | list | Issue resolver role configurations |
+| `prs` | list | PR babysitter role configurations |
+| `triage` | list | Periodic triage role configurations |
+
+## Issue Role Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | string | Issue label to watch |
+| `only-assigned` | bool | Only process issues assigned to the agent |
+| `reviewers` | list | Overrides project-level reviewers |
+
+## PR Role Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `watch` | list | PR numbers to monitor |
+| `reactions` | list | Reactions to run: `reviews`, `ci`, `conflicts`, `rebase` |
+| `skip-comment` | list | Comment categories to suppress |
+| `reviewers` | list | Overrides project-level reviewers |
+| `rebase-interval` | duration | Overrides project-level rebase interval |
+
+## Triage Role Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jobs` | list | CI job URLs to monitor |
+| `workflow` | string | GHA workflow file name (e.g. `test.yml`) |
+| `lanes` | list | Glob patterns for matrix job filtering |
+| `schedule` | string | Schedule as `HH:MM Timezone` |
+| `lookback` | duration | Time window for failed runs |
+| `create-flaky-issues` | bool | Create issues for flaky failures |
+| `flaky-label` | string | Label for flaky issues |
+
+A triage entry must have either `jobs` or (`workflow` + `lanes`), not both.
+
+## Multi-Project Execution
+
+Each project/role runs as an independent goroutine with its own Agent and structured logger. This means a single oompa process can manage multiple repositories simultaneously.
+
+See [Inheritance](inheritance.md) for how settings cascade and [Examples](examples.md) for common patterns.

--- a/docs/src/configuration/examples.md
+++ b/docs/src/configuration/examples.md
@@ -1,0 +1,148 @@
+# Configuration Examples
+
+## Single Repository (CLI Only)
+
+No config file needed -- just use CLI flags:
+
+```bash
+./oompa \
+  --agent opencode \
+  --agent-model google-vertex-anthropic/claude-opus-4-6@default \
+  --repo myorg/myrepo \
+  --poll-interval 2m \
+  --log-level info
+```
+
+## Multi-Project Config File
+
+Manage multiple repositories from a single oompa process:
+
+```yaml
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+poll-interval: 2m
+log-level: debug
+exit-on-new-version: qinqon/oompa
+
+projects:
+  - repo: myorg/frontend
+    issues:
+      - label: good-for-ai
+        reviewers: [alice, bob]
+
+  - repo: myorg/backend
+    fork: myuser/backend
+    issues:
+      - label: good-for-ai
+        only-assigned: true
+    prs:
+      - watch: [42, 55]
+        reactions: [ci, conflicts, rebase]
+```
+
+## PR Babysitter With Fork
+
+Monitor PRs in a repo where you push to a fork:
+
+```bash
+./oompa \
+  --repo upstream/repo \
+  --fork myuser/repo \
+  --watch-prs 123,456 \
+  --reactions ci,conflicts,rebase \
+  --poll-interval 2m
+```
+
+Or in YAML:
+
+```yaml
+projects:
+  - repo: upstream/repo
+    fork: myuser/repo
+    prs:
+      - watch: [123, 456]
+        reactions: [ci, conflicts, rebase]
+```
+
+## Cost-Optimized Setup
+
+Use a cheaper model for report-only roles, and the full model for issue resolution:
+
+```yaml
+agent: opencode
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+
+projects:
+  - repo: myorg/myrepo
+    # Sonnet for PR babysitting (cheaper)
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514
+    prs:
+      - watch: [100, 200]
+        reactions: [ci, conflicts, rebase]
+
+  - repo: myorg/myrepo
+    # Opus for issue resolution (full power)
+    issues:
+      - label: good-for-ai
+```
+
+## Periodic CI Triage
+
+### Prow Jobs
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    create-flaky-issues: true
+    flaky-label: kind/ci-flake
+    triage:
+      - jobs:
+          - https://prow.example.com/view/gs/bucket/logs/periodic-e2e-job/
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+```
+
+### GitHub Actions Workflows (Lane-Level)
+
+Filter specific matrix lanes within a workflow:
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    flaky-label: kind/ci-flake
+    triage:
+      - workflow: test.yml
+        lanes:
+          - "e2e (live-migration, noHA, local,*"
+          - "e2e (live-migration, noHA, shared,*"
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+```
+
+## Suppressing Comment Categories
+
+Reduce noise by suppressing specific comment types:
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    prs:
+      - watch: [123]
+        reactions: [ci, conflicts, rebase]
+        skip-comment: [ci-unrelated, ci-infrastructure]
+```
+
+Available categories: `ci-unrelated`, `ci-infrastructure`, `ci-related`, `conflict`, `rebase`, `flaky`, `issue-in-progress`.
+
+## GitHub App Authentication
+
+```bash
+export GITHUB_APP_ID="123456"
+export GITHUB_APP_PRIVATE_KEY_PATH="/path/to/private-key.pem"
+export GITHUB_APP_INSTALLATION_ID="78901234"
+
+./oompa \
+  --agent opencode \
+  --agent-model google-vertex-anthropic/claude-opus-4-6@default \
+  --repo myorg/myrepo
+```

--- a/docs/src/configuration/inheritance.md
+++ b/docs/src/configuration/inheritance.md
@@ -1,0 +1,80 @@
+# Inheritance
+
+Oompa uses two-tier inheritance for configuration: **global** settings flow down to **project** level, which flow down to **role** level.
+
+## Hierarchy
+
+```
+Global Settings
+  └─ Project Settings (override global)
+       └─ Role Settings (override project)
+```
+
+## How It Works
+
+1. **Global settings** are defined at the top level of the YAML config file
+2. **Project settings** override global settings for all roles in that project
+3. **Role settings** override project settings for that specific role
+
+## Example
+
+```yaml
+# Global: all projects use Opus by default
+agent-model: google-vertex-anthropic/claude-opus-4-6@default
+
+projects:
+  - repo: myorg/expensive-repo
+    # Project: override to Sonnet (cheaper) for all roles
+    agent-model: google-vertex-anthropic/claude-sonnet-4-20250514
+    reviewers: [alice, bob]
+
+    prs:
+      - watch: [100]
+        reactions: [ci, conflicts]
+        # Role: inherits agent-model from project (Sonnet)
+        # Role: inherits reviewers from project ([alice, bob])
+
+      - watch: [200]
+        # Role: override reviewers for this specific PR group
+        reviewers: [alice]
+
+  - repo: myorg/critical-repo
+    # Project: inherits agent-model from global (Opus)
+    issues:
+      - label: good-for-ai
+        # Role: inherits agent-model from global (Opus)
+```
+
+## Inheritable Fields
+
+| Field | Global | Project | Role |
+|-------|--------|---------|------|
+| `agent` | Y | - | - |
+| `agent-model` | Y | Y | - |
+| `poll-interval` | Y | - | - |
+| `log-level` | Y | - | - |
+| `reviewers` | - | Y | Y |
+| `create-flaky-issues` | - | Y | Y |
+| `flaky-label` | - | Y | Y |
+| `rebase-interval` | - | Y | Y |
+| `skip-comment` | - | - | Y |
+| `reactions` | - | - | Y |
+
+## Rebase Interval
+
+The `rebase-interval` field controls the minimum time between rebases for a PR. It defaults to `4h` when not specified at either level.
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    rebase-interval: 24h    # project default: at most once per day
+    prs:
+      - watch: [100]
+        reactions: [ci, conflicts, rebase]
+        # inherits rebase-interval: 24h from project
+
+      - watch: [200]
+        rebase-interval: 12h  # override: twice per day for this group
+```
+
+Non-positive values (zero or negative) are rejected at config load time.

--- a/docs/src/features/ci-investigation.md
+++ b/docs/src/features/ci-investigation.md
@@ -1,0 +1,57 @@
+# CI Investigation
+
+Oompa detects failing CI checks on pull requests and uses the coding agent to investigate and fix them.
+
+## How It Works
+
+1. On each poll cycle, oompa checks for failing CI check runs on tracked PRs
+2. The coding agent receives the failure details, the PR diff, and commit history
+3. The agent classifies the failure as **related** or **unrelated** to the PR changes
+
+### Related Failures
+
+When the failure is caused by the PR:
+
+- The agent analyzes the failure and implements a fix
+- For **multi-commit PRs**: a fixup commit is created targeting the commit that introduced the issue
+- For **single-commit PRs**: changes are staged but not committed (oompa amends the existing commit)
+- Lint and tests are run to verify the fix
+
+### Unrelated Failures
+
+When the failure is not caused by the PR (flaky test, infrastructure issue):
+
+- The agent outputs `UNRELATED` with an explanation
+- A comment is posted on the PR (unless suppressed with `--skip-comment`)
+- If `--create-flaky-issues` is enabled, an issue is created for the flaky test
+
+## Classification Rules
+
+The agent applies strict classification criteria:
+
+- Failures in code the PR did not touch are treated as **unrelated**
+- Changes to test expectations require verification that the new behavior is correct
+- Minimal, targeted fixes are preferred over broad refactoring
+
+## Configuration
+
+Enable CI investigation with the `ci` reaction:
+
+```bash
+./oompa --repo myorg/myrepo --watch-prs 123 --reactions ci
+```
+
+Suppress comment categories:
+
+```bash
+./oompa --repo myorg/myrepo --watch-prs 123 --reactions ci \
+  --skip-comment ci-unrelated,ci-infrastructure
+```
+
+## Comment Suppression
+
+| Category | Description |
+|----------|-------------|
+| `ci-unrelated` | Suppress comments for failures unrelated to PR changes |
+| `ci-infrastructure` | Suppress comments for infrastructure failures |
+| `ci-related` | Suppress comments for failures related to PR changes |

--- a/docs/src/features/conflict-resolution.md
+++ b/docs/src/features/conflict-resolution.md
@@ -1,0 +1,59 @@
+# Conflict Resolution
+
+Oompa detects merge conflicts on tracked PRs and resolves them automatically.
+
+## How It Works
+
+1. On each poll cycle, oompa checks if tracked PRs have merge conflicts
+2. First, an automatic `git rebase` is attempted
+3. If the rebase has conflicts, the coding agent is invoked to resolve them
+4. The agent resolves conflicts within the rebase flow (not by creating new commits)
+5. After resolution, oompa force-pushes with `--force-with-lease`
+
+## Resolution Strategy
+
+The coding agent follows a strict resolution protocol:
+
+1. Fetch latest changes and rebase onto the default branch
+2. For each conflicting commit:
+   - Resolve conflicts in the affected files
+   - Run `git add <resolved-files>`
+   - Run `git rebase --continue`
+3. The original commit structure is preserved
+4. Lint and tests are run to verify the resolved code
+
+The agent never runs `git rebase --abort` or creates standalone merge commits.
+
+## Configuration
+
+Enable conflict resolution with the `conflicts` reaction:
+
+```bash
+./oompa --repo myorg/myrepo --watch-prs 123 --reactions conflicts
+```
+
+To suppress conflict-related PR comments:
+
+```bash
+./oompa --repo myorg/myrepo --watch-prs 123 --reactions conflicts \
+  --skip-comment conflict
+```
+
+## Rebase Interval
+
+To avoid excessive rebasing, use the `rebase-interval` setting (default: 4 hours):
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    rebase-interval: 24h
+    prs:
+      - watch: [123]
+        reactions: [conflicts, rebase]
+```
+
+## Safety
+
+- Force-pushes use `--force-with-lease` only for history-rewriting operations
+- The original commit structure is preserved -- no squashing during conflict resolution
+- If resolution fails, the issue is logged and skipped until the next cycle

--- a/docs/src/features/flaky-issues.md
+++ b/docs/src/features/flaky-issues.md
@@ -1,0 +1,47 @@
+# Flaky Issues
+
+When oompa detects CI failures unrelated to a PR's changes, it can create GitHub issues to track these flaky tests.
+
+## How It Works
+
+1. During CI investigation, the agent classifies a failure as **unrelated** to the PR
+2. If `--create-flaky-issues` is enabled, oompa creates a GitHub issue with:
+   - The failing test name and error details
+   - Root-cause analysis from the coding agent
+   - A link to the CI run
+3. Issues are deduplicated -- if an issue already exists for the same failure, a new one is not created
+
+## Configuration
+
+**CLI:**
+
+```bash
+./oompa \
+  --repo myorg/myrepo \
+  --create-flaky-issues \
+  --flaky-label kind/ci-flake
+```
+
+**YAML config file:**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    create-flaky-issues: true
+    flaky-label: kind/ci-flake
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--create-flaky-issues` | `false` | Enable flaky issue creation (opt-in) |
+| `--flaky-label` | `flaky-test` | Label to apply to created issues |
+
+## Deduplication
+
+Oompa checks existing open issues with the flaky label before creating a new one. If a matching issue already exists (same test name or failure signature), the existing issue is updated rather than creating a duplicate.
+
+## Periodic Triage Integration
+
+Flaky issue creation also works with the [periodic triage](../roles/periodic-triage.md) role, where it tracks failures from scheduled CI jobs rather than PR-triggered CI.

--- a/docs/src/features/review-response.md
+++ b/docs/src/features/review-response.md
@@ -1,0 +1,61 @@
+# Review Response
+
+Oompa monitors tracked PRs for new review comments and uses the coding agent to address them.
+
+## How It Works
+
+1. On each poll cycle, oompa fetches new review comments on tracked PRs
+2. Comments are filtered through the reviewers allowlist
+3. An `:eyes:` reaction is added to each comment before processing
+4. The coding agent evaluates each comment independently using the `/ce-resolve-pr-feedback` skill
+5. For valid issues: code changes are made (left uncommitted for oompa to handle)
+6. For invalid suggestions: a reply is posted with specific rationale
+7. Addressed review threads are resolved via GraphQL
+
+## Reviewer Allowlist
+
+By default, oompa responds to all reviewers. Use `--reviewers` to restrict to specific users:
+
+```bash
+./oompa --repo myorg/myrepo --reviewers alice,bob,coderabbitai[bot]
+```
+
+Bot comments (from oompa itself) are always filtered out to prevent self-reply loops.
+
+## Comment Processing
+
+Each comment is evaluated independently:
+
+| Classification | Action |
+|---------------|--------|
+| Bug fix | Fix the code, post confirmation reply |
+| Valid improvement | Implement the change, post confirmation reply |
+| Incorrect | Decline with specific rationale |
+| Style preference | Evaluate and decide per project conventions |
+
+## Cursor Advancement
+
+The comment cursor advances to the max ID of all fetched comments (including filtered ones). This prevents re-fetching bot-posted or already-replied comments.
+
+Special cases:
+- When changes were detected but push failed, the cursor does **not** advance (comments are retried next cycle)
+- When no actionable comments remain after filtering, the cursor still advances past filtered items
+
+## Configuration
+
+Enable review response with the `reviews` reaction:
+
+```bash
+./oompa --repo myorg/myrepo --watch-prs 123 --reactions reviews
+```
+
+In YAML:
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    reviewers: [alice, bob]
+    prs:
+      - watch: [123]
+        reactions: [reviews]
+```

--- a/docs/src/features/skip-comment.md
+++ b/docs/src/features/skip-comment.md
@@ -1,0 +1,47 @@
+# Skip Comment
+
+The `--skip-comment` flag allows you to suppress specific categories of PR comments that oompa would normally post.
+
+## Motivation
+
+In some workflows, certain comment types add noise without actionable value. For example, when babysitting PRs on a large project, you might not want a comment every time an unrelated CI failure is detected.
+
+## Usage
+
+**CLI:**
+
+```bash
+./oompa --repo myorg/myrepo --skip-comment ci-unrelated,ci-infrastructure
+```
+
+**YAML config file:**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    prs:
+      - watch: [123]
+        skip-comment: [ci-unrelated, ci-infrastructure]
+```
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| `ci-unrelated` | CI failures unrelated to PR changes |
+| `ci-infrastructure` | CI infrastructure failures (network, OOM, timeouts) |
+| `ci-related` | CI failures related to PR changes |
+| `conflict` | Merge conflict notifications |
+| `rebase` | Rebase notifications |
+| `flaky` | Flaky test notifications |
+| `issue-in-progress` | Notifications about issue processing in progress |
+
+## Behavior
+
+When a comment category is suppressed:
+
+- The underlying action still happens (e.g., CI is still investigated, conflicts are still resolved)
+- Only the PR comment is skipped
+- Structured logs still record the event
+
+This means you get the benefits of automation without the PR comment noise.

--- a/docs/src/getting-started/authentication.md
+++ b/docs/src/getting-started/authentication.md
@@ -1,0 +1,89 @@
+# Authentication
+
+Oompa requires authentication with both GitHub and an AI provider (Vertex AI or Anthropic API).
+
+## GitHub Authentication
+
+You have three options for GitHub authentication, listed from simplest to most robust.
+
+### Option 1: `gh` CLI (Recommended for Development)
+
+The simplest approach -- oompa falls back to `gh auth token` when no `GITHUB_TOKEN` is set:
+
+```bash
+gh auth login
+gh auth setup-git
+```
+
+### Option 2: Personal Access Token
+
+Set `GITHUB_TOKEN` with a token that has `repo` scope:
+
+```bash
+export GITHUB_TOKEN="ghp_..."
+```
+
+### Option 3: GitHub App (Recommended for Production)
+
+GitHub Apps provide fine-grained permissions and don't consume a user's rate limit.
+
+**Setup:**
+
+1. Create a GitHub App in your org settings:
+   `https://github.com/organizations/<org>/settings/apps/new`
+
+2. Disable webhooks (oompa uses polling, not webhooks)
+
+3. Grant repository permissions:
+   - Actions: Read
+   - Checks: Read
+   - Contents: Read and Write
+   - Issues: Read and Write
+   - Metadata: Read
+   - Pull requests: Read and Write
+
+4. Generate a private key (PEM file)
+
+5. Install the app on the target repository
+
+6. Get the installation ID:
+   ```bash
+   gh api /orgs/<org>/installations \
+     --jq '.installations[] | select(.app_slug | contains("<app-slug>")) | .id'
+   ```
+
+7. Configure oompa:
+   ```bash
+   export GITHUB_APP_ID="123456"
+   export GITHUB_APP_PRIVATE_KEY_PATH="/path/to/private-key.pem"
+   export GITHUB_APP_INSTALLATION_ID="78901234"
+   ```
+
+When all three `--github-app-*` flags are provided, the agent uses App auth instead of PAT auth. Installation tokens are automatically refreshed before each poll cycle.
+
+The agent pushes branches directly to the upstream repository and authenticates as `<app-slug>[bot]`.
+
+## AI Provider Authentication
+
+### Vertex AI (Google Cloud)
+
+```bash
+gcloud auth application-default login
+export CLOUD_ML_REGION="us-east5"
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+```
+
+For service accounts (production), use a credentials JSON file:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+export GOOGLE_CLOUD_PROJECT="my-gcp-project"
+export CLOUD_ML_REGION="us-east5"
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+```
+
+### Anthropic API (Direct)
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,0 +1,52 @@
+# Installation
+
+## Prerequisites
+
+- Go 1.26+
+- A coding agent CLI on `PATH`: either [OpenCode](https://opencode.ai) (recommended) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+- Provider credentials configured (e.g. `gcloud auth application-default login` for Vertex AI, or `ANTHROPIC_API_KEY` for direct API)
+- GitHub authentication: either `gh auth login` (recommended), a personal access token (PAT) with repo scope, or a GitHub App
+- `gh` CLI installed and configured as a git credential helper (`gh auth setup-git`)
+- [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) for CI investigation, review handling, and commit creation
+
+## Install the Coding Agent Plugin
+
+**OpenCode:**
+
+```bash
+bunx @every-env/compound-plugin install compound-engineering --to opencode
+```
+
+**Claude Code:**
+
+```
+/plugin install compound-engineering
+```
+
+## Binary Download
+
+Download the latest release binary from GitHub:
+
+```bash
+gh release download --repo qinqon/oompa --pattern 'oompa-linux-amd64'
+chmod +x oompa-linux-amd64
+sudo mv oompa-linux-amd64 /usr/local/bin/oompa
+```
+
+## Build From Source
+
+```bash
+git clone https://github.com/qinqon/oompa.git
+cd oompa
+go build -o oompa ./cmd/oompa
+```
+
+## Container Image
+
+A container image is published to GitHub Container Registry on every push to `main`:
+
+```bash
+podman pull ghcr.io/qinqon/oompa:latest
+```
+
+The image includes Go, `gh` CLI, Claude Code CLI, and git -- everything needed to run oompa in a container environment. See [Kubernetes deployment](../operations/kubernetes.md) for production use.

--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart
+
+This guide walks you through your first oompa run in single-repo mode.
+
+## 1. Authenticate
+
+```bash
+gh auth login
+gh auth setup-git
+gcloud auth application-default login
+```
+
+## 2. Build
+
+```bash
+go build -o oompa ./cmd/oompa
+```
+
+## 3. Label an Issue
+
+On your GitHub repository, add the `good-for-ai` label to an issue you want oompa to pick up. The issue should contain a clear description of the bug or feature to implement.
+
+## 4. Run
+
+**With OpenCode (recommended):**
+
+```bash
+./oompa \
+  --agent opencode \
+  --agent-model google-vertex-anthropic/claude-opus-4-6@default \
+  --repo myorg/myrepo
+```
+
+**With Claude Code:**
+
+```bash
+export CLAUDE_CODE_USE_VERTEX=1
+export CLOUD_ML_REGION="us-east5"
+export ANTHROPIC_VERTEX_PROJECT_ID="my-gcp-project"
+
+./oompa --repo myorg/myrepo
+```
+
+## 5. What Happens
+
+Oompa will:
+
+1. Clone the repository to `/tmp/oompa-work` (configurable with `--clone-dir`)
+2. Scan for issues with the `good-for-ai` label
+3. Create a git worktree on a branch named `ai/issue-<number>`
+4. Invoke the coding agent to implement the fix
+5. Push the branch and create a pull request
+6. Continue polling every 2 minutes for new issues, review comments, CI failures, and merge conflicts
+
+## 6. Dry Run
+
+To see what oompa would do without making changes:
+
+```bash
+./oompa --repo myorg/myrepo --dry-run --one-shot
+```
+
+`--dry-run` logs actions without executing them. `--one-shot` runs a single poll cycle and exits.
+
+## Next Steps
+
+- [CLI Flags](../configuration/cli-flags.md) -- full flag reference
+- [Config File](../configuration/config-file.md) -- multi-project configuration
+- [Roles](../roles/issue-resolver.md) -- different operating modes

--- a/docs/src/operations/kubernetes.md
+++ b/docs/src/operations/kubernetes.md
@@ -1,0 +1,124 @@
+# Kubernetes
+
+Oompa can be deployed as a Kubernetes Deployment using the container image published to GitHub Container Registry.
+
+## Container Image
+
+```
+ghcr.io/qinqon/oompa:latest
+```
+
+The image includes Go, `gh` CLI, Claude Code CLI, and git. It runs as a non-root user (UID 1000) and is compatible with OpenShift's random UID assignment.
+
+## Example Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oompa
+  namespace: oompa
+  labels:
+    app: oompa
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: oompa
+  template:
+    metadata:
+      labels:
+        app: oompa
+    spec:
+      containers:
+        - name: oompa
+          image: ghcr.io/qinqon/oompa:latest
+          args:
+            - --repo=myorg/myrepo
+            - --clone-dir=/work
+            - --log-level=debug
+            - --poll-interval=2m
+          env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oompa-github
+                  key: app-id
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oompa-github
+                  key: installation-id
+            - name: GITHUB_APP_PRIVATE_KEY_PATH
+              value: /secrets/github/app.pem
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/gcp/credentials.json
+            - name: CLOUD_ML_REGION
+              value: us-east5
+            - name: ANTHROPIC_VERTEX_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oompa-gcp
+                  key: project-id
+          volumeMounts:
+            - name: github-app-key
+              mountPath: /secrets/github
+              readOnly: true
+            - name: gcp-credentials
+              mountPath: /secrets/gcp
+              readOnly: true
+            - name: work
+              mountPath: /work
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+      volumes:
+        - name: github-app-key
+          secret:
+            secretName: github-app-key
+        - name: gcp-credentials
+          secret:
+            secretName: gcp-credentials
+        - name: work
+          emptyDir: {}
+```
+
+## Secrets
+
+Create the required secrets:
+
+```bash
+# GitHub App private key
+kubectl create secret generic github-app-key \
+  --from-file=app.pem=/path/to/private-key.pem \
+  -n oompa
+
+# GCP credentials
+kubectl create secret generic gcp-credentials \
+  --from-file=credentials.json=/path/to/credentials.json \
+  -n oompa
+
+# GitHub App IDs
+kubectl create secret generic oompa-github \
+  --from-literal=app-id=123456 \
+  --from-literal=installation-id=78901234 \
+  -n oompa
+
+# GCP project
+kubectl create secret generic oompa-gcp \
+  --from-literal=project-id=my-gcp-project \
+  -n oompa
+```
+
+## Design Notes
+
+- `strategy.type: Recreate` ensures only one instance runs at a time (oompa uses sequential processing)
+- `emptyDir` for `/work` is sufficient since oompa rebuilds state from GitHub on startup
+- The container runs as a non-root user and supports OpenShift's random UID assignment
+- Git credentials are configured system-wide in the container using the `GH_TOKEN` environment variable

--- a/docs/src/operations/monitoring.md
+++ b/docs/src/operations/monitoring.md
@@ -1,0 +1,79 @@
+# Monitoring
+
+Oompa uses Go's `slog` for structured logging, making it easy to parse and filter logs in production.
+
+## Log Levels
+
+Set the log level with `--log-level`:
+
+| Level | Description |
+|-------|-------------|
+| `debug` | Detailed operational info (API calls, git commands, agent invocations) |
+| `info` | Standard operational events (issues processed, PRs created, reactions triggered) |
+| `warn` | Non-critical issues (skipped items, rate limits approaching) |
+| `error` | Failures requiring attention (API errors, agent failures) |
+
+## Log Output
+
+By default, logs go to stderr. Use `--log-file` to write to a file:
+
+```bash
+./oompa --repo myorg/myrepo --log-file /var/log/oompa/agent.log
+```
+
+## Structured Log Fields
+
+Logs include structured fields for filtering:
+
+```
+time=2025-01-15T10:30:00Z level=INFO msg="processing issue" repo=myorg/myrepo issue=42 branch=ai/issue-42
+time=2025-01-15T10:31:00Z level=INFO msg="PR created" repo=myorg/myrepo issue=42 pr=100
+time=2025-01-15T10:32:00Z level=ERROR msg="agent failed" repo=myorg/myrepo issue=43 error="exit code 1"
+```
+
+## Filtering Logs
+
+With `jq` (when using JSON output):
+
+```bash
+journalctl --user -u oompa-issue-resolver -o cat | jq 'select(.level == "ERROR")'
+```
+
+With `grep` (when using text output):
+
+```bash
+journalctl --user -u oompa-issue-resolver | grep "level=ERROR"
+```
+
+## Health Monitoring
+
+### Systemd
+
+Check service health:
+
+```bash
+systemctl --user status oompa-issue-resolver
+journalctl --user -u oompa-issue-resolver --since "1 hour ago"
+```
+
+### Kubernetes
+
+Monitor the pod:
+
+```bash
+kubectl logs -f deployment/oompa -n oompa
+kubectl get pods -n oompa -w
+```
+
+## Auto-Update
+
+Use `--exit-on-new-version=qinqon/oompa` to make oompa exit when a new release is available. Combined with systemd's `Restart=always`, this provides automatic binary updates:
+
+1. Oompa detects a new release during polling
+2. It exits cleanly
+3. Systemd restarts the service
+4. `ExecStartPre` downloads the new binary
+
+## Multi-Project Logging
+
+When running multiple projects from a YAML config file, each project/role runs as an independent goroutine with its own structured logger. Log entries include the `repo` field to distinguish between projects.

--- a/docs/src/operations/systemd.md
+++ b/docs/src/operations/systemd.md
@@ -1,0 +1,129 @@
+# Systemd
+
+Oompa can run as a systemd user service that downloads the latest release binary on each (re)start.
+
+## Credentials File
+
+Store provider credentials in `~/.config/oompa/env`:
+
+```bash
+# For Vertex AI (used by both OpenCode and Claude Code)
+CLOUD_ML_REGION=us-east5
+ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+GOOGLE_CLOUD_PROJECT=my-gcp-project
+
+# GITHUB_TOKEN is optional -- oompa falls back to `gh auth token`
+```
+
+## Issue Resolver Service
+
+`~/.config/systemd/user/oompa-issue-resolver.service`:
+
+```ini
+[Unit]
+Description=Oompa Issue Resolver - myorg/myrepo
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=%h/.config/oompa/env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+RuntimeDirectory=oompa-resolver
+ExecStartPre=/bin/bash -c 'gh release download --repo qinqon/oompa --pattern oompa-linux-amd64 --dir %t/oompa-resolver --clobber && chmod +x %t/oompa-resolver/oompa-linux-amd64'
+ExecStart=%t/oompa-resolver/oompa-linux-amd64 --exit-on-new-version=qinqon/oompa --repo myorg/myrepo --poll-interval 2m --log-level info
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+## PR Babysitter Service
+
+`~/.config/systemd/user/oompa-pr-babysitter.service`:
+
+```ini
+[Unit]
+Description=Oompa PR Babysitter - myorg/myrepo
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=%h/.config/oompa/env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+RuntimeDirectory=oompa-babysitter
+ExecStartPre=/bin/bash -c 'gh release download --repo qinqon/oompa --pattern oompa-linux-amd64 --dir %t/oompa-babysitter --clobber && chmod +x %t/oompa-babysitter/oompa-linux-amd64'
+ExecStart=%t/oompa-babysitter/oompa-linux-amd64 --exit-on-new-version=qinqon/oompa --repo myorg/myrepo --watch-prs 123,456 --reactions ci,conflicts,rebase --fork myuser/myrepo --poll-interval 2m --log-level info
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+## Periodic CI Triage (Timer)
+
+For one-shot workflows, use a `Type=oneshot` service paired with a systemd timer.
+
+`~/.config/systemd/user/oompa-periodic-triage.service`:
+
+```ini
+[Unit]
+Description=Oompa Periodic CI Triage - myorg/myrepo
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/oompa/env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+RuntimeDirectory=oompa-periodic-triage
+ExecStartPre=/bin/bash -c 'gh release download --repo qinqon/oompa --pattern oompa-linux-amd64 --dir %t/oompa-periodic-triage --clobber && chmod +x %t/oompa-periodic-triage/oompa-linux-amd64'
+ExecStart=%t/oompa-periodic-triage/oompa-linux-amd64 --repo myorg/myrepo --triage-jobs https://prow.example.com/view/gs/bucket/logs/periodic-e2e-job/ --create-flaky-issues --one-shot --log-level info
+```
+
+`~/.config/systemd/user/oompa-periodic-triage.timer`:
+
+```ini
+[Unit]
+Description=Run Oompa Periodic CI Triage daily at 9 AM
+
+[Timer]
+OnCalendar=*-*-* 09:00:00 Europe/Madrid
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable the timer (not the service):
+
+```bash
+systemctl --user enable --now oompa-periodic-triage.timer
+```
+
+## How It Works
+
+- `ExecStartPre` downloads the latest release binary before each start
+- `--exit-on-new-version` makes the agent exit when it detects a newer release during polling
+- `Restart=always` restarts the service on exit, triggering `ExecStartPre` to download the new binary
+- `RuntimeDirectory=` gives each unit its own directory under `/run/user/<uid>/`
+- `Persistent=true` on timers ensures missed runs are caught up on next boot
+- The timer's `OnCalendar` supports IANA timezones (e.g. `Europe/Madrid`, `US/Eastern`)
+
+## Managing Services
+
+```bash
+# Enable and start
+systemctl --user enable --now oompa-issue-resolver
+
+# Check status
+systemctl --user status oompa-issue-resolver
+
+# View logs
+journalctl --user -u oompa-issue-resolver -f
+
+# Restart
+systemctl --user restart oompa-issue-resolver
+```

--- a/docs/src/operations/troubleshooting.md
+++ b/docs/src/operations/troubleshooting.md
@@ -1,0 +1,108 @@
+# Troubleshooting
+
+## Common Issues
+
+### "GITHUB_TOKEN not set" or Authentication Failures
+
+**Symptom:** Oompa fails to authenticate with GitHub.
+
+**Solutions:**
+1. Run `gh auth login` and `gh auth setup-git`
+2. Or set `GITHUB_TOKEN` environment variable
+3. Or configure all three GitHub App flags (`--github-app-id`, `--github-app-private-key`, `--github-app-installation-id`)
+
+### Agent Fails to Run
+
+**Symptom:** The coding agent (OpenCode or Claude Code) fails to start.
+
+**Solutions:**
+1. Verify the agent is on `PATH`: `which opencode` or `which claude`
+2. Check provider credentials: `gcloud auth application-default print-access-token`
+3. Verify the compound-engineering plugin is installed
+4. Check `--agent-model` is valid for your provider
+
+### Issue Labeled `ai-failed`
+
+**Symptom:** An issue gets the `ai-failed` label with an error comment.
+
+**Resolution:**
+1. Read the error comment on the issue for details
+2. Fix any blockers (unclear requirements, missing context)
+3. Remove the `ai-failed` label
+4. Re-add `good-for-ai` (or your configured label)
+
+Oompa will pick up the issue on the next poll cycle.
+
+### PR Stuck in Conflict Loop
+
+**Symptom:** A PR keeps getting rebased but conflicts keep recurring.
+
+**Solutions:**
+1. Increase `rebase-interval` to reduce frequency
+2. Check if the base branch has frequent conflicting changes
+3. Consider manually resolving the conflicts
+
+### Worktree Errors
+
+**Symptom:** Git worktree operations fail.
+
+**Solutions:**
+1. Check disk space in `--clone-dir`
+2. Clean up stale worktrees: `git worktree prune`
+3. Verify the clone directory is writable
+
+### Rate Limiting
+
+**Symptom:** GitHub API errors with 403 status.
+
+**Solutions:**
+1. Increase `--poll-interval` to reduce API call frequency
+2. Switch to GitHub App auth (higher rate limits than PAT)
+3. Check `X-RateLimit-Remaining` in debug logs
+
+### Self-Reply Loop
+
+**Symptom:** Oompa keeps responding to its own comments.
+
+**Prevention:** Bot-posted comments are tagged with `<!-- oompa-bot -->` markers. If you see self-replies, check that the marker is present in the comment template.
+
+## Debugging
+
+### Enable Debug Logging
+
+```bash
+./oompa --repo myorg/myrepo --log-level debug
+```
+
+### Dry Run
+
+Test what oompa would do without making changes:
+
+```bash
+./oompa --repo myorg/myrepo --dry-run --one-shot
+```
+
+### Single Poll Cycle
+
+Run one iteration and exit:
+
+```bash
+./oompa --repo myorg/myrepo --one-shot
+```
+
+### Check State
+
+Oompa is stateless on disk -- it rebuilds state from GitHub on startup. To see what oompa tracks, enable debug logging and look for state-related messages:
+
+```bash
+./oompa --repo myorg/myrepo --log-level debug --one-shot 2>&1 | grep "state"
+```
+
+## Getting Help
+
+If you encounter an issue not covered here, [open a GitHub issue](https://github.com/qinqon/oompa/issues/new) with:
+
+1. The oompa version (`oompa --version` or commit hash)
+2. Debug-level logs (with any tokens/secrets redacted)
+3. The configuration you are using
+4. Steps to reproduce the issue

--- a/docs/src/roles/issue-resolver.md
+++ b/docs/src/roles/issue-resolver.md
@@ -1,0 +1,66 @@
+# Issue Resolver
+
+The issue resolver is oompa's primary role: it picks up GitHub issues, implements fixes using a coding agent, and opens pull requests.
+
+## How It Works
+
+1. Oompa scans the repository for issues with the configured label (default: `good-for-ai`)
+2. For each new issue, it creates a git worktree on a branch named `ai/issue-<number>`
+3. The coding agent is invoked with a prompt containing the issue title, body, and project conventions
+4. After the agent finishes, oompa pushes the branch and creates a pull request
+5. The PR links back to the original issue
+
+## Configuration
+
+**CLI:**
+
+```bash
+./oompa \
+  --repo myorg/myrepo \
+  --label good-for-ai \
+  --agent opencode \
+  --agent-model google-vertex-anthropic/claude-opus-4-6@default
+```
+
+**YAML config file:**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    issues:
+      - label: good-for-ai
+        only-assigned: true
+        reviewers: [alice, bob]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--label` | `good-for-ai` | Issue label to watch |
+| `--only-assigned` | `false` | Only process issues assigned to the agent user |
+| `--reviewers` | all | Allowlist of reviewers to respond to on created PRs |
+
+## Lifecycle
+
+Once a PR is created, the issue resolver also handles:
+
+- **Review comments** -- reviewer feedback is addressed by the coding agent
+- **CI failures** -- failing checks are investigated and fixed
+- **Merge conflicts** -- automatic rebase with conflict resolution
+
+These behaviors are controlled by `--reactions`. See [Features](../features/ci-investigation.md) for details.
+
+## Failure Handling
+
+If the coding agent fails to implement a fix:
+
+1. The issue is labeled `ai-failed`
+2. A comment is posted explaining the error
+3. The issue is skipped on subsequent poll cycles
+
+To retry: remove the `ai-failed` label and re-add `good-for-ai`.
+
+## Skipping Already-Tracked Issues
+
+Issues already in oompa's state are skipped. If a PR was created but its number wasn't recorded (e.g., due to a crash), oompa re-checks for the PR on the next cycle.

--- a/docs/src/roles/periodic-triage.md
+++ b/docs/src/roles/periodic-triage.md
@@ -1,0 +1,87 @@
+# Periodic Triage
+
+The periodic triage role analyzes failures from scheduled CI jobs (nightly builds, periodic e2e tests) and creates issues with root-cause analysis.
+
+## How It Works
+
+1. Oompa monitors specified CI job URLs or GitHub Actions workflows
+2. On each triage cycle, it fetches recent failed runs within the lookback window
+3. For each failure, the coding agent analyzes logs and classifies the root cause
+4. Issues are created with the analysis, deduplicating against existing issues
+
+## Configuration
+
+**CLI (one-shot):**
+
+```bash
+./oompa \
+  --repo myorg/myrepo \
+  --triage-jobs https://prow.example.com/view/gs/bucket/logs/periodic-e2e-job/ \
+  --triage-lookback 24h \
+  --create-flaky-issues \
+  --one-shot
+```
+
+**YAML config file (Prow jobs):**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    create-flaky-issues: true
+    flaky-label: kind/ci-flake
+    triage:
+      - jobs:
+          - https://prow.example.com/view/gs/bucket/logs/periodic-e2e-job/
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+```
+
+**YAML config file (GitHub Actions lane-level):**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    flaky-label: kind/ci-flake
+    triage:
+      - workflow: test.yml
+        lanes:
+          - "e2e (live-migration, noHA, local,*"
+          - "e2e (live-migration, noHA, shared,*"
+        schedule: "09:00 Europe/Madrid"
+        lookback: 24h
+```
+
+## Triage Modes
+
+### Prow Job URLs
+
+Specify full URLs to Prow job pages. Oompa fetches and analyzes all failed runs within the lookback window.
+
+### GitHub Actions Workflows (Lane-Level)
+
+For GitHub Actions, use `workflow` + `lanes` to monitor specific matrix lanes within a high-volume workflow:
+
+- `workflow`: GHA workflow file name relative to the repo (e.g., `test.yml`)
+- `lanes`: Glob patterns matched against job names (supports trailing `*` wildcard)
+
+This avoids triaging all 42+ jobs in a matrix workflow when you only care about specific lanes.
+
+**Behavior:**
+- Runs with `conclusion=success` are skipped (no API call needed)
+- Only matching lanes with `conclusion=failure` are reported
+- Logs are fetched per-lane, not per-workflow
+- State dedup keys are per-lane (e.g., `runID:laneName`)
+
+## Validation
+
+A triage entry must have either `jobs` or (`workflow` + `lanes`), not both and not neither. `workflow` without `lanes` is invalid. `lanes` without `workflow` is invalid.
+
+## Scheduling
+
+For scheduled runs, use a systemd timer or cron job with `--one-shot`:
+
+```bash
+./oompa --repo myorg/myrepo --triage-jobs ... --one-shot
+```
+
+See [Systemd](../operations/systemd.md) for a complete timer setup.

--- a/docs/src/roles/pr-babysitter.md
+++ b/docs/src/roles/pr-babysitter.md
@@ -1,0 +1,76 @@
+# PR Babysitter
+
+The PR babysitter monitors specific pull requests for reviews, CI failures, merge conflicts, and rebase needs. Use this role when you have existing PRs that need ongoing maintenance.
+
+## How It Works
+
+1. Oompa bootstraps state for the specified PR numbers
+2. On each poll cycle, it checks each PR for:
+   - New review comments that need a response
+   - CI failures that need investigation or fixing
+   - Merge conflicts that need resolution
+   - Rebase needs (outdated base branch)
+3. For each detected issue, the appropriate reaction is triggered
+
+## Configuration
+
+**CLI:**
+
+```bash
+./oompa \
+  --repo myorg/myrepo \
+  --watch-prs 123,456 \
+  --reactions ci,conflicts,rebase \
+  --poll-interval 2m
+```
+
+**With a fork** (push branches to your fork instead of upstream):
+
+```bash
+./oompa \
+  --repo upstream/repo \
+  --fork myuser/repo \
+  --watch-prs 123,456 \
+  --reactions ci,conflicts,rebase
+```
+
+**YAML config file:**
+
+```yaml
+projects:
+  - repo: myorg/myrepo
+    prs:
+      - watch: [123, 456]
+        reactions: [ci, conflicts, rebase]
+        skip-comment: [ci-unrelated, ci-infrastructure]
+```
+
+## Reactions
+
+Control which maintenance tasks run with `--reactions`:
+
+| Reaction | Description |
+|----------|-------------|
+| `reviews` | Respond to reviewer comments |
+| `ci` | Investigate and fix CI failures |
+| `conflicts` | Resolve merge conflicts |
+| `rebase` | Rebase onto the latest base branch |
+
+Default: all reactions are enabled. An empty list disables all reactions (useful for report-only mode).
+
+## Bootstrap Behavior
+
+When `--watch-prs` is set:
+
+- `BootstrapWatchedPRs` runs instead of `ProcessNewIssues`
+- Open PRs are added to state
+- Merged or closed PRs are skipped
+- Already-tracked PRs are not duplicated
+
+## Cleanup
+
+PRs that are merged or closed are automatically cleaned up:
+
+- The associated worktree is removed
+- The PR is removed from state
+- This happens in the `CleanupDone` phase at the start of each poll cycle


### PR DESCRIPTION
Fixes #127

## Summary

Create a documentation site for oompa using mdBook, deployed to GitHub Pages via GitHub Actions.

## Changes

- Add `docs/book.toml` -- mdBook configuration with search, edit links, and GitHub repository URL
- Add `docs/src/SUMMARY.md` -- chapter structure with 6 sections and 20 pages
- Add `docs/src/README.md` -- introduction and overview
- Add getting started guides: installation (binary, source, container), authentication (gh CLI, PAT, GitHub App), quickstart
- Add configuration reference: complete CLI flags table, YAML config file format, two-tier inheritance, common examples
- Add role descriptions: issue resolver, PR babysitter, periodic triage
- Add feature documentation: CI investigation, flaky issues, skip-comment, conflict resolution, review response
- Add operations guides: systemd services/timers, Kubernetes deployment, monitoring/logging, troubleshooting
- Add architecture: design decisions, directory structure, main loop flow, contributing guide
- Add `.github/workflows/docs.yaml` -- GitHub Actions workflow to build mdBook on PRs and deploy to Pages on push to main
- Add `docs/book/` to `.gitignore` for local builds

## Testing

- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [x] Manual testing (if applicable)

Documentation-only change -- no Go code modified. Content was extracted and expanded from the existing README.md, config.example.yaml, specs/, and deploy/ directory.

## Related Issues

Fixes #127

---
*🤖 Generated by [oompa](https://github.com/qinqon/oompa). Use `/oompa` to talk with me.* <!-- oompa-bot v:a80f19d -->