### PR TITLE
bug: issue fixer retries creating PRs for issues that already have an open PR

### DIFF
--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -216,10 +216,10 @@ func (g *GoGitHubClient) RemoveLabel(ctx context.Context, owner, repo string, is
 }
 
 // maxClosedPRPages bounds the scan of closed PRs in listPRsByHead. When
-// GitHub ignores the head filter (fork repo named differently than the base
-// repo) the closed list is the repo's entire PR history, newest first. Five
-// pages of 100 are enough to spot a recently merged or rejected fix PR
-// without walking thousands of historical PRs on every poll.
+// GitHub ignores the head filter the closed list is the repo's entire PR
+// history, most recently updated first. Five pages of 100 are enough to spot
+// a recently merged or rejected fix PR without walking thousands of
+// historical PRs on every poll.
 const maxClosedPRPages = 5
 
 func (g *GoGitHubClient) ListPRsByHead(ctx context.Context, owner, repo, headOwner, branch string) ([]PR, error) {
@@ -242,30 +242,32 @@ func (g *GoGitHubClient) ListPRsByHead(ctx context.Context, owner, repo, headOwn
 	return g.listPRsByHead(ctx, owner, repo, branch, branch)
 }
 
-// listPRsByHead returns PRs whose head ref is exactly branch, open PRs first.
-// Because the head filter may be silently ignored by GitHub (see
-// ListPRsByHead), every state is paginated and verified client-side:
-// open PRs are scanned fully (the open set is small on any repo), closed
-// PRs only through the newest maxClosedPRPages pages.
+// listPRsByHead returns PRs whose head ref is exactly branch. Because the
+// head filter may be silently ignored by GitHub (see ListPRsByHead), results
+// are paginated and verified client-side. Open PRs are scanned fully (the
+// open set is small on any repo) and short-circuit the closed scan — an open
+// match already decides the caller's outcome. Closed PRs are scanned most
+// recently updated first, through at most maxClosedPRPages pages, which keeps
+// recently merged or rejected fix PRs visible regardless of creation date.
 func (g *GoGitHubClient) listPRsByHead(ctx context.Context, owner, repo, head, branch string) ([]PR, error) {
 	openPRs, err := g.listPRsByHeadState(ctx, owner, repo, head, branch, "open", 0)
 	if err != nil {
 		return nil, err
 	}
-	closedPRs, err := g.listPRsByHeadState(ctx, owner, repo, head, branch, "closed", maxClosedPRPages)
-	if err != nil {
-		return nil, err
+	if len(openPRs) > 0 {
+		return openPRs, nil
 	}
-	return append(openPRs, closedPRs...), nil
+	return g.listPRsByHeadState(ctx, owner, repo, head, branch, "closed", maxClosedPRPages)
 }
 
 // listPRsByHeadState lists PRs in the given state whose head ref is exactly
-// branch, paginated newest first. maxPages == 0 means no page limit.
+// branch, paginated most recently updated first. maxPages == 0 means no page
+// limit.
 func (g *GoGitHubClient) listPRsByHeadState(ctx context.Context, owner, repo, head, branch, state string, maxPages int) ([]PR, error) {
 	opts := &github.PullRequestListOptions{
 		Head:      head,
 		State:     state,
-		Sort:      "created",
+		Sort:      "updated",
 		Direction: "desc",
 		ListOptions: github.ListOptions{
 			PerPage: 100,

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -215,6 +215,13 @@ func (g *GoGitHubClient) RemoveLabel(ctx context.Context, owner, repo string, is
 	return nil
 }
 
+// maxClosedPRPages bounds the scan of closed PRs in listPRsByHead. When
+// GitHub ignores the head filter (fork repo named differently than the base
+// repo) the closed list is the repo's entire PR history, newest first. Five
+// pages of 100 are enough to spot a recently merged or rejected fix PR
+// without walking thousands of historical PRs on every poll.
+const maxClosedPRPages = 5
+
 func (g *GoGitHubClient) ListPRsByHead(ctx context.Context, owner, repo, headOwner, branch string) ([]PR, error) {
 	head := branch
 	if headOwner != "" {
@@ -235,31 +242,62 @@ func (g *GoGitHubClient) ListPRsByHead(ctx context.Context, owner, repo, headOwn
 	return g.listPRsByHead(ctx, owner, repo, branch, branch)
 }
 
+// listPRsByHead returns PRs whose head ref is exactly branch, open PRs first.
+// Because the head filter may be silently ignored by GitHub (see
+// ListPRsByHead), every state is paginated and verified client-side:
+// open PRs are scanned fully (the open set is small on any repo), closed
+// PRs only through the newest maxClosedPRPages pages.
 func (g *GoGitHubClient) listPRsByHead(ctx context.Context, owner, repo, head, branch string) ([]PR, error) {
-	opts := &github.PullRequestListOptions{
-		Head:  head,
-		State: "all",
-	}
-
-	ghPRs, _, err := g.client.PullRequests.List(ctx, owner, repo, opts)
+	openPRs, err := g.listPRsByHeadState(ctx, owner, repo, head, branch, "open", 0)
 	if err != nil {
-		return nil, fmt.Errorf("listing PRs: %w", err)
+		return nil, err
+	}
+	closedPRs, err := g.listPRsByHeadState(ctx, owner, repo, head, branch, "closed", maxClosedPRPages)
+	if err != nil {
+		return nil, err
+	}
+	return append(openPRs, closedPRs...), nil
+}
+
+// listPRsByHeadState lists PRs in the given state whose head ref is exactly
+// branch, paginated newest first. maxPages == 0 means no page limit.
+func (g *GoGitHubClient) listPRsByHeadState(ctx context.Context, owner, repo, head, branch, state string, maxPages int) ([]PR, error) {
+	opts := &github.PullRequestListOptions{
+		Head:      head,
+		State:     state,
+		Sort:      "created",
+		Direction: "desc",
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
 	}
 
 	var prs []PR
-	for _, p := range ghPRs {
-		// Verify the head ref actually matches — the GitHub API may ignore
-		// the head filter when the branch doesn't exist on the upstream repo
-		if p.GetHead().GetRef() != branch {
-			continue
+	for page := 1; ; page++ {
+		ghPRs, resp, err := g.client.PullRequests.List(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing %s PRs: %w", state, err)
 		}
-		prs = append(prs, PR{
-			Number: p.GetNumber(),
-			Title:  p.GetTitle(),
-			State:  p.GetState(),
-			Merged: p.GetMerged(),
-			Head:   p.GetHead().GetRef(),
-		})
+		for _, p := range ghPRs {
+			// Verify the head ref actually matches — the GitHub API may ignore
+			// the head filter when the branch doesn't exist on the upstream repo
+			if p.GetHead().GetRef() != branch {
+				continue
+			}
+			prs = append(prs, PR{
+				Number: p.GetNumber(),
+				Title:  p.GetTitle(),
+				State:  p.GetState(),
+				// The list endpoint never populates the merged boolean,
+				// only merged_at — derive Merged from it.
+				Merged: p.GetMerged() || p.MergedAt != nil,
+				Head:   p.GetHead().GetRef(),
+			})
+		}
+		if resp.NextPage == 0 || (maxPages > 0 && page >= maxPages) {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 	return prs, nil
 }
@@ -479,25 +517,35 @@ func (g *GoGitHubClient) CreatePR(ctx context.Context, owner, repo, title, body,
 }
 
 func (g *GoGitHubClient) HasLinkedPR(ctx context.Context, owner, repo string, issueNumber int) (bool, error) {
-	events, _, err := g.client.Issues.ListIssueTimeline(ctx, owner, repo, issueNumber, nil)
-	if err != nil {
-		return false, fmt.Errorf("listing issue timeline: %w", err)
-	}
+	// Every label, assignment, comment and rename is a timeline event, so
+	// cross-references easily land beyond the first page on active issues —
+	// paginate through all of them.
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		events, resp, err := g.client.Issues.ListIssueTimeline(ctx, owner, repo, issueNumber, opts)
+		if err != nil {
+			return false, fmt.Errorf("listing issue timeline: %w", err)
+		}
 
-	for _, e := range events {
-		if e.GetEvent() != "cross-referenced" {
-			continue
+		for _, e := range events {
+			if e.GetEvent() != "cross-referenced" {
+				continue
+			}
+			src := e.GetSource()
+			if src == nil || src.GetIssue() == nil {
+				continue
+			}
+			// GitHub's timeline returns PRs as issues with a PullRequestLinks field
+			if src.GetIssue().IsPullRequest() && src.GetIssue().GetState() == "open" {
+				return true, nil
+			}
 		}
-		src := e.GetSource()
-		if src == nil || src.GetIssue() == nil {
-			continue
+
+		if resp.NextPage == 0 {
+			return false, nil
 		}
-		// GitHub's timeline returns PRs as issues with a PullRequestLinks field
-		if src.GetIssue().IsPullRequest() && src.GetIssue().GetState() == "open" {
-			return true, nil
-		}
+		opts.Page = resp.NextPage
 	}
-	return false, nil
 }
 
 func (g *GoGitHubClient) GetPR(ctx context.Context, owner, repo string, prNumber int) (PR, error) {

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -276,9 +276,11 @@ func TestRemoveLabel(t *testing.T) {
 }
 
 func TestListPRsByHead(t *testing.T) {
+	var closedRequests int
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v3/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("state") != "open" {
+			closedRequests++
 			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
 			return
 		}
@@ -306,6 +308,9 @@ func TestListPRsByHead(t *testing.T) {
 	}
 	if prs[0].Head != "ai/issue-42" {
 		t.Errorf("expected head 'ai/issue-42', got %q", prs[0].Head)
+	}
+	if closedRequests != 0 {
+		t.Errorf("open match should short-circuit the closed scan, got %d closed requests", closedRequests)
 	}
 }
 
@@ -414,6 +419,14 @@ func TestListPRsByHead_CapsClosedPRScan(t *testing.T) {
 		if q.Get("state") != "closed" {
 			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
 			return
+		}
+		// Recently merged PRs must sort near the front even when created long
+		// ago, or the page cap would hide them.
+		if got := q.Get("sort"); got != "updated" {
+			t.Errorf("expected sort=updated, got %q", got)
+		}
+		if got := q.Get("direction"); got != "desc" {
+			t.Errorf("expected direction=desc, got %q", got)
 		}
 		closedRequests++
 		// Endless pages of non-matching closed PRs

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -278,6 +278,10 @@ func TestRemoveLabel(t *testing.T) {
 func TestListPRsByHead(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v3/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != "open" {
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
+			return
+		}
 		prs := []*github.PullRequest{
 			{
 				Number: new(100),
@@ -302,6 +306,139 @@ func TestListPRsByHead(t *testing.T) {
 	}
 	if prs[0].Head != "ai/issue-42" {
 		t.Errorf("expected head 'ai/issue-42', got %q", prs[0].Head)
+	}
+}
+
+func TestListPRsByHead_PaginatesOpenPRs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if got := q.Get("per_page"); got != "100" {
+			t.Errorf("expected per_page=100, got %q", got)
+		}
+		if q.Get("state") != "open" {
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
+			return
+		}
+		if page := q.Get("page"); page == "" || page == "1" {
+			// Page 1: only non-matching PRs (simulates GitHub ignoring the head filter)
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			prs := []*github.PullRequest{
+				{
+					Number: new(1),
+					State:  new("open"),
+					Head:   &github.PullRequestBranch{Ref: new("some/other-branch")},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		// Page 2: the matching PR
+		prs := []*github.PullRequest{
+			{
+				Number: new(100),
+				State:  new("open"),
+				Head:   &github.PullRequestBranch{Ref: new("ai/issue-42")},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(prs)
+	})
+
+	gh := setupTestClient(t, mux)
+	prs, err := gh.ListPRsByHead(context.Background(), "owner", "repo", "qinqon", "ai/issue-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR found on page 2, got %d", len(prs))
+	}
+	if prs[0].Number != 100 {
+		t.Errorf("expected PR 100, got %d", prs[0].Number)
+	}
+}
+
+func TestListPRsByHead_FindsClosedPRAcrossPages(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("state") != "closed" {
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
+			return
+		}
+		if page := q.Get("page"); page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			prs := []*github.PullRequest{
+				{
+					Number: new(1),
+					State:  new("closed"),
+					Head:   &github.PullRequestBranch{Ref: new("some/other-branch")},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		// Page 2: the matching merged PR. The list endpoint only exposes
+		// merged_at, never the merged boolean.
+		prs := []*github.PullRequest{
+			{
+				Number:   new(100),
+				State:    new("closed"),
+				MergedAt: &github.Timestamp{Time: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+				Head:     &github.PullRequestBranch{Ref: new("ai/issue-42")},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(prs)
+	})
+
+	gh := setupTestClient(t, mux)
+	prs, err := gh.ListPRsByHead(context.Background(), "owner", "repo", "qinqon", "ai/issue-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR found on closed page 2, got %d", len(prs))
+	}
+	if prs[0].Number != 100 {
+		t.Errorf("expected PR 100, got %d", prs[0].Number)
+	}
+	if !prs[0].Merged {
+		t.Error("expected Merged=true derived from merged_at")
+	}
+}
+
+func TestListPRsByHead_CapsClosedPRScan(t *testing.T) {
+	var closedRequests int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("state") != "closed" {
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
+			return
+		}
+		closedRequests++
+		// Endless pages of non-matching closed PRs
+		w.Header().Set("Link", `<`+r.URL.Path+`?page=`+fmt.Sprint(closedRequests+1)+`>; rel="next"`)
+		prs := []*github.PullRequest{
+			{
+				Number: new(closedRequests),
+				State:  new("closed"),
+				Head:   &github.PullRequestBranch{Ref: new("some/other-branch")},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(prs)
+	})
+
+	gh := setupTestClient(t, mux)
+	// Empty headOwner: no fallback retry, so the closed scan runs exactly once.
+	prs, err := gh.ListPRsByHead(context.Background(), "owner", "repo", "", "ai/issue-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(prs) != 0 {
+		t.Fatalf("expected no matching PRs, got %d", len(prs))
+	}
+	if closedRequests != maxClosedPRPages {
+		t.Errorf("expected closed scan to stop at %d pages, got %d", maxClosedPRPages, closedRequests)
 	}
 }
 
@@ -383,6 +520,50 @@ func TestHasLinkedPR_NoLinkedPRs(t *testing.T) {
 	}
 	if linked {
 		t.Error("expected HasLinkedPR to return false when no linked PRs")
+	}
+}
+
+func TestHasLinkedPR_PaginatesTimeline(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/issues/42/timeline", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("per_page"); got != "100" {
+			t.Errorf("expected per_page=100, got %q", got)
+		}
+		if page := r.URL.Query().Get("page"); page == "" || page == "1" {
+			// Page 1: only non-PR activity (labels, comments, ...)
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			events := []map[string]any{
+				{"event": "labeled"},
+				{"event": "commented"},
+				{"event": "assigned"},
+			}
+			_ = json.NewEncoder(w).Encode(events)
+			return
+		}
+		// Page 2: the cross-referenced open PR
+		events := []map[string]any{
+			{
+				"event": "cross-referenced",
+				"source": map[string]any{
+					"type": "issue",
+					"issue": map[string]any{
+						"number":       99,
+						"state":        "open",
+						"pull_request": map[string]any{"url": "https://api.github.com/repos/owner/repo/pulls/99"},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(events)
+	})
+
+	gh := setupTestClient(t, mux)
+	linked, err := gh.HasLinkedPR(context.Background(), "owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !linked {
+		t.Error("expected HasLinkedPR to find the cross-referenced PR on page 2")
 	}
 }
 

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -66,9 +66,15 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 
 		branchName := issueBranchName(issue.Number)
 
-		// Check if a PR already exists for this issue (open, closed, or merged)
+		// Check if a PR already exists for this issue (open, closed, or merged).
+		// Fail closed on error: without PR visibility we risk opening a
+		// duplicate — defer the issue to the next poll cycle instead.
 		prs, err := a.gh.ListPRsByHead(ctx, a.cfg.Owner, a.cfg.Repo, a.cfg.GitHubHeadOwner, branchName)
-		if err == nil && len(prs) > 0 {
+		if err != nil {
+			a.logger.Warn("failed to list PRs for issue, deferring to next poll", "issue", issue.Number, "error", err)
+			continue
+		}
+		if len(prs) > 0 {
 			// Find the first open PR, or check if any was merged
 			openPR, hasMerged := classifyPRs(prs)
 			if openPR != nil {
@@ -90,9 +96,12 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			// PR was closed (rejected) — fall through to allow retry
 		}
 
-		// Check if any open PR already references this issue (e.g., created by a human)
+		// Check if any open PR already references this issue (e.g., created by
+		// a human). Fail closed on error: defer to the next poll cycle rather
+		// than risk creating a duplicate PR.
 		if linked, err := a.gh.HasLinkedPR(ctx, a.cfg.Owner, a.cfg.Repo, issue.Number); err != nil {
-			a.logger.Warn("failed to check for linked PRs", "issue", issue.Number, "error", err)
+			a.logger.Warn("failed to check for linked PRs, deferring to next poll", "issue", issue.Number, "error", err)
+			continue
 		} else if linked {
 			a.logger.Info("skipping issue with existing linked PR", "issue", issue.Number)
 			continue

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -30,6 +30,9 @@ type mockGitHubClient struct {
 	prHeadSHAs      []string         // returns these in sequence; if empty returns "abc123"
 	prsAfterNCalls  int              // only return PRs after this many ListPRsByHead calls
 	prsCallCount    int
+	listPRsErr      error // error to return from ListPRsByHead
+	linkedPR        bool  // return value for HasLinkedPR
+	linkedPRErr     error // error to return from HasLinkedPR
 	mergeableState  string        // mergeable state to return from GetPRMergeable (default: "clean")
 	prBehind        bool          // whether IsPRBehind returns true
 	createdIssues   []Issue       // tracks issues created via CreateIssue
@@ -93,6 +96,9 @@ func (m *mockGitHubClient) RemoveLabel(_ context.Context, _, _ string, _ int, la
 
 func (m *mockGitHubClient) ListPRsByHead(_ context.Context, _, _, _, _ string) ([]PR, error) {
 	m.prsCallCount++
+	if m.listPRsErr != nil {
+		return nil, m.listPRsErr
+	}
 	if m.prsAfterNCalls > 0 && m.prsCallCount <= m.prsAfterNCalls {
 		return nil, nil
 	}
@@ -175,7 +181,10 @@ func (m *mockGitHubClient) CreatePR(_ context.Context, _, _, _, _, _, _ string) 
 }
 
 func (m *mockGitHubClient) HasLinkedPR(_ context.Context, _, _ string, _ int) (bool, error) {
-	return false, nil
+	if m.linkedPRErr != nil {
+		return false, m.linkedPRErr
+	}
+	return m.linkedPR, nil
 }
 
 func (m *mockGitHubClient) GetPR(_ context.Context, _, _ string, prNumber int) (PR, error) {
@@ -410,6 +419,97 @@ func TestProcessNewIssues_SkipsWhenPRExists(t *testing.T) {
 	}
 	if work.Status != "pr-open" {
 		t.Errorf("expected status 'pr-open', got %q", work.Status)
+	}
+}
+
+func TestProcessNewIssues_SkipsLinkedPR(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues:   []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+		linkedPR: true, // an open PR (e.g. human-created) already references the issue
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.ProcessNewIssues(context.Background())
+
+	if len(runner.calls) != 0 {
+		t.Error("should not invoke claude when a linked PR exists")
+	}
+	if len(wt.createdBranches) != 0 {
+		t.Error("should not create worktree when a linked PR exists")
+	}
+	if len(gh.addedComments) != 0 {
+		t.Errorf("should not comment on issue with linked PR, got %v", gh.addedComments)
+	}
+	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
+		t.Error("issue with linked PR should not be tracked")
+	}
+}
+
+func TestProcessNewIssues_DefersOnListPRsError(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues:     []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+		listPRsErr: &mockError{msg: "boom"},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.ProcessNewIssues(context.Background())
+
+	if len(runner.calls) != 0 {
+		t.Error("should not invoke claude when PR listing fails")
+	}
+	if len(wt.createdBranches) != 0 {
+		t.Error("should not create worktree when PR listing fails")
+	}
+	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
+		t.Error("deferred issue should not be tracked so the next poll retries it")
+	}
+}
+
+func TestProcessNewIssues_DefersOnLinkedPRCheckError(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues:      []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+		linkedPRErr: &mockError{msg: "boom"},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.ProcessNewIssues(context.Background())
+
+	if len(runner.calls) != 0 {
+		t.Error("should not invoke claude when linked PR check fails")
+	}
+	if len(wt.createdBranches) != 0 {
+		t.Error("should not create worktree when linked PR check fails")
+	}
+	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
+		t.Error("deferred issue should not be tracked so the next poll retries it")
+	}
+}
+
+func TestProcessNewIssues_SkipsMergedPR(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+		prs:    []PR{{Number: 100, State: "closed", Merged: true, Head: "ai/issue-42"}},
+	}
+	runner := &mockCommandRunner{}
+	wt := &mockWorktreeManager{}
+
+	agent := newTestAgent(gh, runner, wt)
+	agent.ProcessNewIssues(context.Background())
+
+	if len(runner.calls) != 0 {
+		t.Error("should not invoke claude when the fix PR was merged")
+	}
+	if len(wt.createdBranches) != 0 {
+		t.Error("should not create worktree when the fix PR was merged")
+	}
+	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
+		t.Error("issue with merged PR should not be tracked")
 	}
 }
 

--- a/specs/github-client.md
+++ b/specs/github-client.md
@@ -44,17 +44,20 @@ type GitHubClient interface {
 from opening duplicate PRs (issue #264), so both must see the *complete*
 picture, not just the first API page:
 
-- `ListPRsByHead` cannot trust GitHub's `head` filter: it is silently ignored
-  when the fork repo has a different name than the base repo, in which case
-  the response is the repo's entire PR list. Results are therefore always
-  verified client-side (`head.ref == branch`) and queried per state,
-  sorted `created`/`desc`:
+- `ListPRsByHead` cannot trust GitHub's `head` filter, which misbehaves in two
+  distinct ways: the `owner:branch` form matches nothing when the fork repo
+  has a different name than the base repo (hence the bare-`branch` fallback),
+  and the bare form may be ignored entirely (e.g. when the branch cannot be
+  resolved on the upstream repo), returning the repo's unfiltered PR list.
+  Results are therefore always verified client-side (`head.ref == branch`)
+  and queried per state, sorted `updated`/`desc`:
   - `state=open`: paginated fully (`PerPage: 100`) — the open set is small on
-    any repo.
-  - `state=closed`: paginated up to `maxClosedPRPages` (5) pages — enough to
-    spot a recently merged or rejected fix PR without walking thousands of
+    any repo. A match here short-circuits the closed scan, because an open PR
+    already decides the caller's outcome.
+  - `state=closed`: paginated up to `maxClosedPRPages` (5) pages — sorting by
+    most recent update keeps recently merged or rejected fix PRs inside the
+    window regardless of when they were created, without walking thousands of
     historical PRs on every poll.
-  - Open PRs are returned before closed ones.
   - `Merged` is derived from `merged_at != nil` because the *list* endpoint
     never populates the `merged` boolean (only the *get* endpoint does).
 - `HasLinkedPR` paginates the issue timeline fully (`PerPage: 100`). Every

--- a/specs/github-client.md
+++ b/specs/github-client.md
@@ -13,7 +13,8 @@ type GitHubClient interface {
     AddIssueComment(ctx context.Context, owner, repo string, issueNumber int, body string) error
     AddLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error
     RemoveLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error
-    ListPRsByHead(ctx context.Context, owner, repo, branch string) ([]PR, error)
+    ListPRsByHead(ctx context.Context, owner, repo, headOwner, branch string) ([]PR, error)
+    HasLinkedPR(ctx context.Context, owner, repo string, issueNumber int) (bool, error)
     AddPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error
     GetPR(ctx context.Context, owner, repo string, prNumber int) (PR, error)
 }
@@ -30,11 +31,36 @@ type GitHubClient interface {
 | `AddIssueComment` | `client.Issues.CreateComment()` |
 | `AddLabel` | `client.Issues.AddLabelsToIssue()` |
 | `RemoveLabel` | `client.Issues.RemoveLabelForIssue()` |
-| `ListPRsByHead` | `client.PullRequests.List()` with `Head: branch` (no owner prefix — works for same-repo and fork PRs) |
+| `ListPRsByHead` | `client.PullRequests.List()` with `Head: headOwner:branch` (falls back to bare `branch` when the fork repo name differs from the base repo). See "Duplicate-PR guard queries" below. |
+| `HasLinkedPR` | `client.Issues.ListIssueTimeline()`, true when any `cross-referenced` event points to an **open** PR. See "Duplicate-PR guard queries" below. |
 | `AddPRCommentReaction` | `client.Reactions.CreatePullRequestCommentReaction()` |
 | `GetPR` | `client.PullRequests.Get()`, returns `PR{Number, Title, State, Merged, Head}` |
 | `GetAuthenticatedUser` | `client.Users.Get("")`, returns name + email with login/noreply fallbacks |
 | `CreateIssue` | `client.Issues.Create()`, creates a new issue with title, body, and labels |
+
+## Duplicate-PR Guard Queries
+
+`ListPRsByHead` and `HasLinkedPR` are the guards that prevent the issue fixer
+from opening duplicate PRs (issue #264), so both must see the *complete*
+picture, not just the first API page:
+
+- `ListPRsByHead` cannot trust GitHub's `head` filter: it is silently ignored
+  when the fork repo has a different name than the base repo, in which case
+  the response is the repo's entire PR list. Results are therefore always
+  verified client-side (`head.ref == branch`) and queried per state,
+  sorted `created`/`desc`:
+  - `state=open`: paginated fully (`PerPage: 100`) — the open set is small on
+    any repo.
+  - `state=closed`: paginated up to `maxClosedPRPages` (5) pages — enough to
+    spot a recently merged or rejected fix PR without walking thousands of
+    historical PRs on every poll.
+  - Open PRs are returned before closed ones.
+  - `Merged` is derived from `merged_at != nil` because the *list* endpoint
+    never populates the `merged` boolean (only the *get* endpoint does).
+- `HasLinkedPR` paginates the issue timeline fully (`PerPage: 100`). Every
+  label, assignment, comment and rename is a timeline event, so
+  `cross-referenced` events easily land beyond the first page on active
+  issues. Returns early on the first open cross-referenced PR.
 
 ## Additional Methods (on concrete type, not interface)
 
@@ -58,6 +84,13 @@ Use `net/http/httptest` with canned JSON responses. Point go-github client at te
 - `TestAddIssueComment` -- verifies request body
 - `TestAddLabel` / `TestRemoveLabel`
 - `TestListPRsByHead` -- filters by branch
+- `TestListPRsByHead_PaginatesOpenPRs` -- follows Link headers across open-PR pages
+- `TestListPRsByHead_FindsClosedPRAcrossPages` -- finds a merged PR (via `merged_at`) beyond page 1 of the closed scan
+- `TestListPRsByHead_CapsClosedPRScan` -- stops after `maxClosedPRPages` pages of closed PRs
+- `TestHasLinkedPR_FindsOpenPR` -- true for an open cross-referenced PR
+- `TestHasLinkedPR_IgnoresClosedPR` -- false when the only cross-referenced PR is closed
+- `TestHasLinkedPR_NoLinkedPRs` -- false when no cross-references exist
+- `TestHasLinkedPR_PaginatesTimeline` -- finds a cross-referenced PR beyond the first timeline page
 - `TestGetAuthenticatedUser_WithNameAndEmail` -- returns name and email
 - `TestGetAuthenticatedUser_FallbackToLogin` -- falls back to login and noreply email
 - `TestCreateIssue` -- creates an issue and returns its number

--- a/specs/loop.md
+++ b/specs/loop.md
@@ -31,6 +31,10 @@ When `--watch-prs` is set, `BootstrapWatchedPRs` runs instead of `ProcessNewIssu
 
 ### ProcessNewIssues behavior
 - Skips issues already in state (unless `prNumber == 0` and status is `implementing`, in which case it re-checks for the PR)
+- Duplicate-PR guards, evaluated before any work starts:
+  - `ListPRsByHead` on the `ai/issue-N` branch: an open PR is tracked as `pr-open` and skipped; a merged PR is skipped for good; a closed unmerged PR falls through to allow a retry
+  - `HasLinkedPR`: skips the issue when any open PR (e.g. human-created) cross-references it
+  - Both guards **fail closed**: on GitHub API error the issue is deferred to the next poll cycle (see specs/error-handling.md), never processed blindly
 - Cleans up stale worktrees/branches before creating new ones
 - After Claude finishes, the agent pushes the branch and creates the PR (Claude does NOT push or create PRs)
 
@@ -57,6 +61,10 @@ All interfaces mocked:
 - `TestProcessReviewComments_NoNewComments` -- no action taken
 - `TestProcessReviewComments_AddressesHumanComments` -- runs agent call, updates lastCommentID, verifies no agent-posted replies (skill owns replies)
 - `TestProcessNewIssues_RechecksForPR` -- re-checks for PR when prNumber is 0
+- `TestProcessNewIssues_SkipsLinkedPR` -- issue with an open cross-referenced PR is not processed
+- `TestProcessNewIssues_DefersOnListPRsError` -- ListPRsByHead failure defers the issue (no Claude run, no PR)
+- `TestProcessNewIssues_DefersOnLinkedPRCheckError` -- HasLinkedPR failure defers the issue (no Claude run, no PR)
+- `TestProcessNewIssues_SkipsMergedPR` -- issue whose fix PR was merged is not re-processed
 - `TestProcessReviewComments_SkipsNonWhitelistedUsers` -- skips comments from users not in whitelist
 - `TestProcessReviewComments_AllowsAllWhenWhitelistEmpty` -- allows all when whitelist is empty
 - `TestCleanupDone_MergedPR` -- removes worktree, deletes from state

--- a/test/e2e/fakegithub.go
+++ b/test/e2e/fakegithub.go
@@ -628,8 +628,21 @@ func (fg *FakeGitHub) handleListPRs(w http.ResponseWriter, r *http.Request) {
 	defer fg.mu.Unlock()
 
 	headFilter := r.URL.Query().Get("head")
+	stateFilter := r.URL.Query().Get("state")
 	var result []fakePRJSON
 	for _, pr := range fg.prs {
+		switch stateFilter {
+		case "", "all":
+			// no state filtering
+		case "open":
+			if pr.State != "open" {
+				continue
+			}
+		default: // "closed" (merged PRs are closed too)
+			if pr.State == "open" {
+				continue
+			}
+		}
 		if headFilter != "" {
 			// headFilter can be "owner:branch" or just "branch"
 			branchName := headFilter

--- a/test/e2e/fakegithub.go
+++ b/test/e2e/fakegithub.go
@@ -629,16 +629,20 @@ func (fg *FakeGitHub) handleListPRs(w http.ResponseWriter, r *http.Request) {
 
 	headFilter := r.URL.Query().Get("head")
 	stateFilter := r.URL.Query().Get("state")
+	switch stateFilter {
+	case "", "all", "open", "closed":
+	default:
+		http.Error(w, "invalid state filter: "+stateFilter, http.StatusBadRequest)
+		return
+	}
 	var result []fakePRJSON
 	for _, pr := range fg.prs {
 		switch stateFilter {
-		case "", "all":
-			// no state filtering
 		case "open":
 			if pr.State != "open" {
 				continue
 			}
-		default: // "closed" (merged PRs are closed too)
+		case "closed": // merged PRs are closed too
 			if pr.State == "open" {
 				continue
 			}


### PR DESCRIPTION
## Summary

The issue fixer kept opening duplicate fix PRs for issues that already had one (#264). Both duplicate-PR guards in `ProcessNewIssues` were blind past the first API page — confirming the pagination suspicion — and had two additional holes: merged PRs misclassified as retryable, and guards failing open on API errors.

## Changes

- **`HasLinkedPR` paginates the issue timeline** (was: first 30 events only). Every label/comment/assignment is a timeline event, so `cross-referenced` events pointing at existing fix PRs easily fell beyond page 1 on active issues — exactly the July 8 case where the agent's own analysis mentioned the existing fix PRs yet it still created a new one.
- **`ListPRsByHead` paginates and splits the query per state**: open PRs scanned fully (small set on any repo), closed PRs capped at the newest 5×100 (sorted `created`/`desc`). GitHub silently ignores the `head` filter when the fork repo name differs from the base repo, so the previous single unpaginated call let the agent's own PR from a previous cycle fall off page 1 on busy repos. The cap avoids walking thousands of historical PRs on every poll.
- **`Merged` derived from `merged_at`** for list results — the list endpoint never populates the `merged` boolean, so merged fix PRs took the "closed → retry" path and completed issues were reprocessed.
- **Both guards now fail closed**: on GitHub API error the issue is deferred to the next poll cycle (per `specs/error-handling.md`) instead of falling through to create a PR.
- Specs updated: `specs/github-client.md` now documents `HasLinkedPR`, the `headOwner` parameter, and the pagination contract of both guards; `specs/loop.md` documents the guard sequence and new tests.
- e2e `FakeGitHub.handleListPRs` now honors the `state` query param.

Not included (product decision, discussed as follow-up): stop retrying after a fix PR is closed unless explicitly re-triggered.

## Testing

- [x] `go test ./...` passes (also with `-race`)
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` and `go fix` clean
- [ ] Manual testing (if applicable)

New tests: `TestListPRsByHead_PaginatesOpenPRs`, `TestListPRsByHead_FindsClosedPRAcrossPages` (merged_at derivation), `TestListPRsByHead_CapsClosedPRScan`, `TestHasLinkedPR_PaginatesTimeline`, `TestProcessNewIssues_SkipsLinkedPR` (first test ever exercising the linked-PR skip at loop level), `TestProcessNewIssues_DefersOnListPRsError`, `TestProcessNewIssues_DefersOnLinkedPRCheckError`, `TestProcessNewIssues_SkipsMergedPR`.

## Related Issues

Fixes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR detection so matching pull requests are found more reliably, including across multiple pages of results.
  * Added support for checking whether an issue already has a linked pull request, reducing duplicate work.
  * When GitHub lookups fail, the system now safely defers processing instead of continuing with incomplete information.
  * Better handles merged pull requests when determining issue status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->