### PR TITLE
fix: phase 1 unslop — correctness fixes

### DIFF
--- a/cmd/oompa/main.go
+++ b/cmd/oompa/main.go
@@ -394,7 +394,6 @@ func setupAuth(cfg *agent.Config, logger *slog.Logger) (ghClient *agent.GoGitHub
 			logger.Error("failed to get initial installation token", "error", err)
 			os.Exit(1)
 		}
-		cfg.GitHubToken = token
 		os.Setenv("GH_TOKEN", token)
 
 		logger.Info("authenticated as GitHub App", "login", appAuth.Login, "signed-off-by", cfg.SignedOffBy)
@@ -415,7 +414,6 @@ func setupAuth(cfg *agent.Config, logger *slog.Logger) (ghClient *agent.GoGitHub
 			logger.Error("GITHUB_TOKEN is required, or run 'gh auth login' (or configure GitHub App auth with --github-app-id, --github-app-private-key/GITHUB_APP_PRIVATE_KEY, --github-app-installation-id)")
 			os.Exit(1) //nolint:gocritic // exitAfterDefer: intentional early exit in CLI startup
 		}
-		cfg.GitHubToken = token
 		os.Setenv("GH_TOKEN", token)
 
 		var err error

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -18,6 +18,8 @@ type ClaudeCodeAgent struct{}
 // Run invokes Claude Code in headless mode with streaming output and parses the result.
 // If resume is true, --continue is passed to resume the most recent session in workDir.
 // The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
+// On invocation failure the partial stream output is still parsed so any cost
+// it reports can be billed against session budgets alongside the error.
 func (c *ClaudeCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, resume bool) (AgentResult, error) {
 	args := []string{"-p", "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions"}
@@ -37,7 +39,10 @@ func (c *ClaudeCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir
 	}
 
 	if err != nil {
-		return AgentResult{}, fmt.Errorf("claude invocation failed: %w (stderr: %s)", err, string(stderr))
+		// Best-effort cost salvage: a run that failed after emitting its
+		// result event still consumed tokens.
+		salvaged, _ := parseStreamResult(stdout)
+		return AgentResult{CostUSD: salvaged.CostUSD}, fmt.Errorf("claude invocation failed: %w (stderr: %s)", err, string(stderr))
 	}
 
 	return parseStreamResult(stdout)

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -189,3 +189,25 @@ type mockError struct {
 }
 
 func (e *mockError) Error() string { return e.msg }
+
+func TestClaudeCodeAgent_SalvagesCostOnInvocationFailure(t *testing.T) {
+	// A run can fail (non-zero exit) after emitting its result event; the
+	// tokens are billed regardless, so the cost must survive the error.
+	runner := &mockCommandRunner{
+		stdout: streamResultJSON(AgentResult{Result: "partial", CostUSD: 0.42}),
+		err:    &mockError{msg: "exit status 1"},
+		stderr: []byte("crashed after result"),
+	}
+	agent := &ClaudeCodeAgent{}
+
+	result, err := agent.Run(context.Background(), runner, "/tmp/work", "fix the bug", nil, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result.CostUSD != 0.42 {
+		t.Errorf("expected salvaged cost 0.42, got %f", result.CostUSD)
+	}
+	if result.Result != "" {
+		t.Errorf("expected cost-only salvage on failure, got result text %q", result.Result)
+	}
+}

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	SignedOffBy        string
 	AssistedBy         string        // Assisted-by trailer value for commits (e.g. "oompa with claude-opus-4-6 <https://github.com/qinqon/oompa>")
 	GitHubUser         string        // authenticated GitHub username (for reaction checks)
-	GitHubToken        string        // GitHub token (passed to the coding agent for gh CLI access)
 	GitHubHeadOwner    string        // owner for PR head filtering (fork owner for PAT, repo owner for App)
 	ForkOwner          string        // owner of the fork repo for pushing (empty = push to upstream)
 	ForkRepo           string        // name of the fork repo (empty = same as Repo)

--- a/pkg/agent/conflicts.go
+++ b/pkg/agent/conflicts.go
@@ -19,6 +19,18 @@ const (
 	rebaseMinInterval = 4 * time.Hour
 )
 
+// rebaseSuccessComment builds the human-visible comment for a successful
+// rebase push. The commit reference is omitted when the head SHA could not
+// be resolved, and the actual default branch name is used instead of a
+// hardcoded "main".
+func (a *Agent) rebaseSuccessComment(headSHA, suffix string) string {
+	subject := "Rebased"
+	if headSHA != "" {
+		subject = "Rebased commit " + shortSHA(headSHA)
+	}
+	return fmt.Sprintf("%s on %s and pushed%s.\n\n%s", subject, a.defaultBranch(), suffix, a.botComment())
+}
+
 // ProcessConflicts checks for merge conflicts (dirty mergeable_state) and tries to resolve them.
 // For simple rebases when a PR is just behind the base branch, use ProcessRebase instead.
 func (a *Agent) ProcessConflicts(ctx context.Context) {
@@ -58,7 +70,12 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		}
 
 		// Check if we already posted a conflict comment for the current HEAD
-		headSHA, _ := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			// Without the SHA, comment-marker dedup below is skipped, so a
+			// repeat comment is possible — but proceeding beats stalling.
+			a.logger.Warn("failed to get PR head SHA", "pr", work.PRNumber, "error", err)
+		}
 		if headSHA != "" && a.hasExistingBotComment(ctx, work.PRNumber, "rebase") && a.hasExistingBotComment(ctx, work.PRNumber, shortSHA(headSHA)) {
 			continue
 		}
@@ -92,7 +109,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 				})
 				if !a.ShouldSkipComment("conflict") {
 					_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-						fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), a.botComment()))
+						a.rebaseSuccessComment(headSHA, ""))
 				}
 			}
 			continue
@@ -207,7 +224,12 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 			continue
 		}
 
-		headSHA, _ := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		headSHA, err := a.gh.GetPRHeadSHA(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber)
+		if err != nil {
+			// Without the SHA, comment-marker dedup below is skipped, so a
+			// repeat comment is possible — but proceeding beats stalling.
+			a.logger.Warn("failed to get PR head SHA", "pr", work.PRNumber, "error", err)
+		}
 		if headSHA != "" && a.hasExistingBotComment(ctx, work.PRNumber, "rebase") && a.hasExistingBotComment(ctx, work.PRNumber, shortSHA(headSHA)) {
 			continue
 		}
@@ -256,7 +278,7 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 			})
 			if !a.ShouldSkipComment("rebase") {
 				_ = a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, work.PRNumber,
-					fmt.Sprintf("Rebased commit %s on main and pushed.\n\n%s", shortSHA(headSHA), a.botComment()))
+					a.rebaseSuccessComment(headSHA, ""))
 			}
 		}
 	}
@@ -346,7 +368,7 @@ func (a *Agent) resolveConflictsSequential(ctx context.Context, tasks []conflict
 			})
 			if !a.ShouldSkipComment("conflict") {
 				if err := a.gh.AddIssueComment(ctx, a.cfg.Owner, a.cfg.Repo, task.work.PRNumber,
-					fmt.Sprintf("Rebased commit %s on main and pushed (conflicts resolved).\n\n%s", shortSHA(task.headSHA), a.botComment())); err != nil {
+					a.rebaseSuccessComment(task.headSHA, " (conflicts resolved)")); err != nil {
 					a.logger.Error("failed to log success to github", "pr", task.work.PRNumber, "error", err)
 				}
 			}

--- a/pkg/agent/conflicts.go
+++ b/pkg/agent/conflicts.go
@@ -286,7 +286,10 @@ func (a *Agent) resolveConflictsSequential(ctx context.Context, tasks []conflict
 		commitCountBefore := len(commitsBefore)
 
 		prompt := buildConflictResolutionPrompt(*task.work, a.originDefaultBranch())
-		_, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
+		result, err := a.codeAgent.Run(ctx, a.runner, task.work.WorktreePath, prompt, a.logger, true)
+		// Track cumulative cost even on failure — failed invocations still
+		// consume tokens and count against the per-PR session budget.
+		task.work.SessionCostUSD += result.CostUSD
 		if err != nil {
 			a.logger.Error("agent failed to resolve conflicts", "pr", task.work.PRNumber, "error", err)
 			a.emit(Event{

--- a/pkg/agent/etag.go
+++ b/pkg/agent/etag.go
@@ -2,9 +2,21 @@ package agent
 
 import (
 	"bytes"
+	"container/list"
 	"io"
 	"net/http"
 	"sync"
+)
+
+const (
+	// maxCacheEntries bounds the number of cached responses. The daemon runs
+	// for weeks and every paginated URL is a distinct cache key, so an
+	// unbounded map grows forever. Least-recently-used entries are evicted.
+	maxCacheEntries = 512
+
+	// maxCachedBodyBytes skips caching oversized response bodies (e.g. log
+	// payloads) that would dominate memory for little conditional-GET win.
+	maxCachedBodyBytes = 1 << 20 // 1 MiB
 )
 
 type cacheEntry struct {
@@ -12,12 +24,14 @@ type cacheEntry struct {
 	body       []byte
 	header     http.Header
 	statusCode int
+	elem       *list.Element // position in the LRU order list; value is the cache key
 }
 
 type CachingTransport struct {
 	base  http.RoundTripper
 	mu    sync.Mutex
 	cache map[string]*cacheEntry
+	order *list.List // LRU order: front = most recently used
 }
 
 func NewCachingTransport(base http.RoundTripper) *CachingTransport {
@@ -27,6 +41,32 @@ func NewCachingTransport(base http.RoundTripper) *CachingTransport {
 	return &CachingTransport{
 		base:  base,
 		cache: make(map[string]*cacheEntry),
+		order: list.New(),
+	}
+}
+
+// touch marks a cached entry as most recently used. Callers must hold t.mu.
+func (t *CachingTransport) touch(entry *cacheEntry) {
+	t.order.MoveToFront(entry.elem)
+}
+
+// store inserts or updates a cache entry, evicting the least-recently-used
+// entry when the cache is full. Callers must hold t.mu.
+func (t *CachingTransport) store(key string, entry *cacheEntry) {
+	if existing, ok := t.cache[key]; ok {
+		entry.elem = existing.elem
+		t.cache[key] = entry
+		t.order.MoveToFront(entry.elem)
+		return
+	}
+	entry.elem = t.order.PushFront(key)
+	t.cache[key] = entry
+	if len(t.cache) > maxCacheEntries {
+		oldest := t.order.Back()
+		if oldest != nil {
+			t.order.Remove(oldest)
+			delete(t.cache, oldest.Value.(string))
+		}
 	}
 }
 
@@ -53,6 +93,9 @@ func (t *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	if resp.StatusCode == http.StatusNotModified && ok {
 		resp.Body.Close()
+		t.mu.Lock()
+		t.touch(entry)
+		t.mu.Unlock()
 		return &http.Response{
 			StatusCode: entry.statusCode,
 			Header:     entry.header.Clone(),
@@ -69,14 +112,16 @@ func (t *CachingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 			return nil, readErr
 		}
 
-		t.mu.Lock()
-		t.cache[key] = &cacheEntry{
-			etag:       etag,
-			body:       body,
-			header:     resp.Header.Clone(),
-			statusCode: resp.StatusCode,
+		if len(body) <= maxCachedBodyBytes {
+			t.mu.Lock()
+			t.store(key, &cacheEntry{
+				etag:       etag,
+				body:       body,
+				header:     resp.Header.Clone(),
+				statusCode: resp.StatusCode,
+			})
+			t.mu.Unlock()
 		}
-		t.mu.Unlock()
 
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 	}

--- a/pkg/agent/etag_test.go
+++ b/pkg/agent/etag_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -220,4 +222,78 @@ func TestCachingTransport_ConcurrentAccess(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+func TestCachingTransport_EvictsLeastRecentlyUsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"e-`+r.URL.Path+`"`)
+		_, _ = w.Write([]byte(`{"path":"` + r.URL.Path + `"}`))
+	}))
+	defer server.Close()
+
+	transport := NewCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	get := func(path string) {
+		resp, err := client.Get(server.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+
+	// Fill the cache to capacity, then touch the first entry to make it
+	// recently used, and insert one more to force an eviction.
+	for i := range maxCacheEntries {
+		get(fmt.Sprintf("/item-%d", i))
+	}
+	get("/item-0") // touch: /item-0 becomes most recently used
+	get("/one-more")
+
+	transport.mu.Lock()
+	size := len(transport.cache)
+	_, item0Alive := transport.cache[server.URL+"/item-0"]
+	_, item1Alive := transport.cache[server.URL+"/item-1"]
+	transport.mu.Unlock()
+
+	if size != maxCacheEntries {
+		t.Fatalf("expected cache bounded at %d entries, got %d", maxCacheEntries, size)
+	}
+	if !item0Alive {
+		t.Error("expected recently-touched /item-0 to survive eviction")
+	}
+	if item1Alive {
+		t.Error("expected least-recently-used /item-1 to be evicted")
+	}
+}
+
+func TestCachingTransport_OversizedBodyNotCached(t *testing.T) {
+	big := bytes.Repeat([]byte("x"), maxCachedBodyBytes+1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"big"`)
+		_, _ = w.Write(big)
+	}))
+	defer server.Close()
+
+	transport := NewCachingTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL + "/big")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if len(body) != len(big) {
+		t.Fatalf("expected full %d-byte body passthrough, got %d", len(big), len(body))
+	}
+
+	transport.mu.Lock()
+	_, ok := transport.cache[server.URL+"/big"]
+	transport.mu.Unlock()
+	if ok {
+		t.Fatal("oversized body should not be cached")
+	}
 }

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -381,7 +381,6 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			ForkOwner:    projForkOwner,
 			ForkRepo:     projForkRepo,
 			// These are inherited from the global config (set by main from auth)
-			GitHubToken:      globalCfg.GitHubToken,
 			GitHubUser:       globalCfg.GitHubUser,
 			GitHubHeadOwner:  globalCfg.GitHubHeadOwner,
 			GitAuthorName:    globalCfg.GitAuthorName,

--- a/pkg/agent/fileconfig.go
+++ b/pkg/agent/fileconfig.go
@@ -371,7 +371,6 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		baseCfg := Config{
 			Owner:        owner,
 			Repo:         repo,
-			CloneDir:     fmt.Sprintf("%s/%s/%s", baseCloneDir, owner, repo),
 			PollInterval: pollInterval,
 			LogLevel:     logLevel,
 			DryRun:       fc.DryRun || globalCfg.DryRun,
@@ -403,10 +402,28 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 			baseCfg.GitHubHeadOwner = projForkOwner
 		}
 
+		// Each role entry gets its own clone directory. Role goroutines run
+		// concurrently and each builds its own worktree manager whose mutex
+		// only serializes its own git operations — a shared .git across
+		// goroutines would race (including destructive recovery like
+		// re-cloning). Per-role forks also get their own "fork" remote this
+		// way instead of clashing in one clone. Entries of the same role are
+		// disambiguated by position (prs, prs-2, ...).
+		roleCounts := map[string]int{}
+		roleCloneDir := func(role string) string {
+			roleCounts[role]++
+			slug := role
+			if n := roleCounts[role]; n > 1 {
+				slug = fmt.Sprintf("%s-%d", role, n)
+			}
+			return fmt.Sprintf("%s/%s/%s/%s", baseCloneDir, owner, repo, slug)
+		}
+
 		// PRs role entries
 		for _, pr := range p.PRs {
 			cfg := baseCfg
 			cfg.Role = "prs"
+			cfg.CloneDir = roleCloneDir("prs")
 			cfg.WatchPRs = pr.Watch
 			cfg.Reactions = stringsOr(pr.Reactions, projReactions)
 			cfg.SkipComments = stringsOr(pr.SkipComment, projSkipComment)
@@ -423,6 +440,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		for _, issue := range p.Issues {
 			cfg := baseCfg
 			cfg.Role = "issues"
+			cfg.CloneDir = roleCloneDir("issues")
 			cfg.Label = stringOr(issue.Label, projLabel)
 			cfg.OnlyAssigned = boolOr(issue.OnlyAssigned, projOnlyAssigned)
 			cfg.SkipFix = boolOr(issue.SkipFix, projSkipFix)
@@ -445,6 +463,7 @@ func BuildRoleEntries(fc *FileConfig, baseCloneDir string, globalCfg Config) []R
 		for _, triage := range p.Triage {
 			cfg := baseCfg
 			cfg.Role = "triage"
+			cfg.CloneDir = roleCloneDir("triage")
 			cfg.TriageJobs = triage.Jobs
 			cfg.TriageWorkflow = triage.Workflow
 			cfg.TriageLanePatterns = triage.Lanes

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -230,12 +230,16 @@ func TestBuildRoleEntries_MultipleProjectsAndRoles(t *testing.T) {
 	if entries[2].Config.Owner != "org2" || entries[2].Config.Repo != "repo2" {
 		t.Error("entry 2 has wrong owner/repo")
 	}
-	// Check clone dirs are per-project
-	if entries[0].Config.CloneDir != "/tmp/work/org1/repo1" {
+	// Check clone dirs are per role entry — concurrent role goroutines must
+	// never share a .git directory.
+	if entries[0].Config.CloneDir != "/tmp/work/org1/repo1/prs" {
 		t.Errorf("unexpected clone dir %q", entries[0].Config.CloneDir)
 	}
-	if entries[1].Config.CloneDir != "/tmp/work/org2/repo2" {
+	if entries[1].Config.CloneDir != "/tmp/work/org2/repo2/issues" {
 		t.Errorf("unexpected clone dir %q", entries[1].Config.CloneDir)
+	}
+	if entries[2].Config.CloneDir != "/tmp/work/org2/repo2/triage" {
+		t.Errorf("unexpected clone dir %q", entries[2].Config.CloneDir)
 	}
 	// Check triage entry has schedule and Config.Role
 	if entries[2].Schedule != "09:00 UTC" {
@@ -1346,5 +1350,49 @@ func TestBuildRoleEntries_TriageWorkflowLanes(t *testing.T) {
 	// TriageJobs should be empty (workflow+lanes mode, not jobs mode)
 	if len(te.Config.TriageJobs) != 0 {
 		t.Errorf("expected empty TriageJobs, got %v", te.Config.TriageJobs)
+	}
+}
+
+func TestBuildRoleEntries_CloneDirsAreUniquePerEntry(t *testing.T) {
+	// Concurrent role goroutines each build their own worktree manager whose
+	// mutex only guards its own instance, so two entries sharing one clone
+	// dir would run unserialized git operations on the same .git.
+	fc := &FileConfig{
+		Projects: []ProjectConfig{
+			{
+				Repo: "org/repo",
+				PRs: []PRsRoleConfig{
+					{Watch: []int{1}},
+					{Watch: []int{2}},
+				},
+				Issues: []IssuesRoleConfig{{Label: "ai"}},
+				Triage: []TriageRoleConfig{{Jobs: []string{"https://ci.example.com/job"}}},
+			},
+		},
+	}
+
+	entries := BuildRoleEntries(fc, "/tmp/work", Config{Agent: "claudecode"})
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	seen := map[string]string{}
+	for _, e := range entries {
+		dir := e.Config.CloneDir
+		if dir == "" {
+			t.Fatalf("entry %s has empty clone dir", e.Role)
+		}
+		if prev, dup := seen[dir]; dup {
+			t.Errorf("clone dir %q shared by %s and %s entries", dir, prev, e.Role)
+		}
+		seen[dir] = e.Role
+	}
+
+	// Same-role entries are disambiguated by position.
+	if entries[0].Config.CloneDir != "/tmp/work/org/repo/prs" {
+		t.Errorf("unexpected first prs clone dir %q", entries[0].Config.CloneDir)
+	}
+	if entries[1].Config.CloneDir != "/tmp/work/org/repo/prs-2" {
+		t.Errorf("unexpected second prs clone dir %q", entries[1].Config.CloneDir)
 	}
 }

--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -283,6 +283,10 @@ func truncateSubject(subject string, maxLen int) string {
 
 // gitSquashCommits squashes all commits since the origin default branch into a single commit.
 func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issueNumber int, issueTitle string) error {
+	if a.cfg.DryRun {
+		a.logger.Info("[dry-run] would squash commits", "worktree", worktreePath, "issue", issueNumber)
+		return nil
+	}
 	// Get all commit messages since origin default branch
 	logOut, _, err := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%B")
 	if err != nil {
@@ -332,6 +336,10 @@ func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issue
 
 // deleteRemoteBranch removes a branch from the push remote.
 func (a *Agent) deleteRemoteBranch(ctx context.Context, worktreePath, branchName string) {
+	if a.cfg.DryRun {
+		a.logger.Info("[dry-run] would delete remote branch", "branch", branchName)
+		return
+	}
 	pushRemote := a.pushRemote()
 	_, stderr, err := a.runner.Run(ctx, worktreePath, "git", "push", pushRemote, "--delete", branchName)
 	if err != nil {

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -391,6 +391,20 @@ func (g *GoGitHubClient) GetCommitStatuses(ctx context.Context, owner, repo, ref
 	return runs, nil
 }
 
+// maxCILogBytes caps CI log payloads fetched for LLM analysis. Logs are
+// tail-truncated because failures appear at the end; the cap keeps enough
+// context for investigation while avoiding excessively large prompts.
+const maxCILogBytes = 50000
+
+// truncateLogTail returns the last maxCILogBytes of a log, with a truncation
+// marker prepended when the log was cut.
+func truncateLogTail(log string) string {
+	if len(log) <= maxCILogBytes {
+		return log
+	}
+	return "...(truncated)...\n" + log[len(log)-maxCILogBytes:]
+}
+
 func (g *GoGitHubClient) GetCheckRunLog(ctx context.Context, owner, repo string, checkRunID int64) (string, error) {
 	// The check run ID is the same as the job ID for GitHub Actions
 	_, resp, err := g.client.Actions.GetWorkflowJobLogs(ctx, owner, repo, checkRunID, 4)
@@ -404,14 +418,7 @@ func (g *GoGitHubClient) GetCheckRunLog(ctx context.Context, owner, repo string,
 		return "", fmt.Errorf("reading job logs: %w", err)
 	}
 
-	log := string(data)
-	// Truncate to last 50000 chars to keep enough context for investigation
-	// while avoiding excessively large prompts
-	const maxLogSize = 50000
-	if len(log) > maxLogSize {
-		log = "...(truncated)...\n" + log[len(log)-maxLogSize:]
-	}
-	return log, nil
+	return truncateLogTail(string(data)), nil
 }
 
 func (g *GoGitHubClient) HasPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction, user string) (bool, error) {
@@ -793,5 +800,5 @@ func (g *GoGitHubClient) GetWorkflowJobLogs(ctx context.Context, owner, repo str
 		return "", fmt.Errorf("reading log: %w", err)
 	}
 
-	return string(body), nil
+	return truncateLogTail(string(body)), nil
 }

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -788,10 +788,14 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 		t.Errorf("expected 3 CI fix attempts, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 77)].CIFixAttempts)
 	}
 
-	// Fourth attempt — should be blocked, comment posted
+	// Fourth attempt — should be blocked, no agent call, no comment
 	runner.mu.Lock()
 	callsBefore := len(runner.calls)
 	runner.mu.Unlock()
+
+	gh.mu.Lock()
+	commentsBefore := len(gh.postedComments)
+	gh.mu.Unlock()
 
 	agent.ProcessCIFailures(ctx)
 
@@ -808,17 +812,14 @@ func TestIntegration_CIFailureFixAndRetryLimit(t *testing.T) {
 		t.Error("should not invoke claude after max retries")
 	}
 
+	// The max-retries guard skips silently (log-only); it must not post
+	// any comment on the blocked cycle.
 	gh.mu.Lock()
-	hasComment := false
-	for _, c := range gh.postedComments {
-		if strings.Contains(c, "3 fix attempts") {
-			hasComment = true
-		}
-	}
+	commentsAfter := len(gh.postedComments)
 	gh.mu.Unlock()
 
-	if hasComment {
-		t.Error("should not post comment about exhausted CI fix attempts")
+	if commentsAfter != commentsBefore {
+		t.Errorf("expected no new comments on the blocked cycle, got %d new", commentsAfter-commentsBefore)
 	}
 
 	// CI passes — verify no further action is taken

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -196,7 +196,10 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			Action:   fmt.Sprintf("Agent implementing issue #%d", task.issue.Number),
 		})
 		prompt := buildImplementationPrompt(task.issue, a.cfg.SignedOffBy, a.cfg.AssistedBy)
-		_, err := a.codeAgent.Run(ctx, a.runner, task.worktreePath, prompt, a.logger, false)
+		result, err := a.codeAgent.Run(ctx, a.runner, task.worktreePath, prompt, a.logger, false)
+		// Track cumulative cost even on failure — failed invocations still
+		// consume tokens and count against the per-PR session budget.
+		task.work.SessionCostUSD += result.CostUSD
 		if err != nil {
 			a.logger.Error("agent failed", "issue", task.issue.Number, "error", err)
 			a.markIssueFailed(ctx, task.issue.Number, task.work)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -89,6 +88,9 @@ func (a *Agent) SetTokenFunc(fn func(context.Context) (string, error)) {
 
 // RefreshToken updates the GitHub token if a token function is set.
 // Call this before each poll cycle to ensure the token is fresh.
+// The fresh token is propagated to subprocesses via the runner's
+// environment (GH_TOKEN); the process-wide environment is never
+// mutated here because multiple role goroutines refresh concurrently.
 func (a *Agent) RefreshToken(ctx context.Context) error {
 	if a.tokenFunc == nil {
 		return nil
@@ -97,8 +99,6 @@ func (a *Agent) RefreshToken(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("refreshing GitHub token: %w", err)
 	}
-	a.cfg.GitHubToken = token
-	os.Setenv("GH_TOKEN", token)
 
 	// Update the runner's GH_TOKEN environment variable
 	if execRunner, ok := a.runner.(*ExecRunner); ok {

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -150,19 +150,20 @@ func parseOpencodeResult(stdout []byte) (AgentResult, error) {
 				foundFinalStep = true
 			}
 		case "error":
-			// Return error if OpenCode reported one
+			// Return error if OpenCode reported one, keeping the cost
+			// accumulated so far — the failed run still billed those steps.
 			if event.Error != nil {
 				msg := event.Error.Name
 				if event.Error.Data != nil && event.Error.Data.Message != "" {
 					msg = event.Error.Data.Message
 				}
-				return AgentResult{}, fmt.Errorf("opencode error: %s", msg)
+				return AgentResult{CostUSD: totalCost}, fmt.Errorf("opencode error: %s", msg)
 			}
 		}
 	}
 
 	if !foundFinalStep {
-		return AgentResult{}, fmt.Errorf("no final step_finish event (reason=stop) found in OpenCode output (stdout: %s)", string(stdout))
+		return AgentResult{CostUSD: totalCost}, fmt.Errorf("no final step_finish event (reason=stop) found in OpenCode output (stdout: %s)", string(stdout))
 	}
 
 	// Join accumulated text
@@ -180,6 +181,9 @@ func parseOpencodeResult(stdout []byte) (AgentResult, error) {
 // Run invokes OpenCode CLI with JSON output and parses the result.
 // If resume is true, --continue is passed to resume the most recent session in workDir.
 // The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
+// On invocation failure the partial stream output is still parsed so any cost
+// it reports (OpenCode bills per step) can be billed against session budgets
+// alongside the error.
 func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, resume bool) (AgentResult, error) {
 	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
@@ -202,7 +206,10 @@ func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, 
 	}
 
 	if err != nil {
-		return AgentResult{}, fmt.Errorf("opencode invocation failed: %w (stderr: %s)", err, string(stderr))
+		// Best-effort cost salvage: sum the step costs emitted before the
+		// failure — the failed run still billed those steps.
+		salvaged, _ := parseOpencodeResult(stdout)
+		return AgentResult{CostUSD: salvaged.CostUSD}, fmt.Errorf("opencode invocation failed: %w (stderr: %s)", err, string(stderr))
 	}
 
 	return parseOpencodeResult(stdout)

--- a/pkg/agent/opencode_test.go
+++ b/pkg/agent/opencode_test.go
@@ -209,3 +209,55 @@ func TestOpenCodeAgent_Run_Failure(t *testing.T) {
 		t.Errorf("expected stderr in error message, got: %v", err)
 	}
 }
+
+// TestOpenCodeAgent_ParseResult_CostKeptOnErrorEvent verifies that step costs
+// accumulated before an error event survive into the failed result.
+func TestOpenCodeAgent_ParseResult_CostKeptOnErrorEvent(t *testing.T) {
+	stdout := `{"type":"step_finish","timestamp":1767036064100,"sessionID":"ses_XXX","part":{"type":"step-finish","reason":"tool-calls","cost":0.003}}
+{"type":"error","timestamp":1767036064400,"sessionID":"ses_XXX","error":{"name":"CommandFailed","data":{"message":"command not found"}}}
+`
+	result, err := parseOpencodeResult([]byte(stdout))
+	if err == nil {
+		t.Fatal("expected error from error event")
+	}
+	if result.CostUSD != 0.003 {
+		t.Errorf("expected salvaged cost 0.003, got %f", result.CostUSD)
+	}
+}
+
+// TestOpenCodeAgent_ParseResult_CostKeptOnMissingFinalStep verifies that step
+// costs survive when the stream is truncated before the final step_finish.
+func TestOpenCodeAgent_ParseResult_CostKeptOnMissingFinalStep(t *testing.T) {
+	stdout := `{"type":"step_finish","timestamp":1767036064100,"sessionID":"ses_XXX","part":{"type":"step-finish","reason":"tool-calls","cost":0.001}}
+{"type":"step_finish","timestamp":1767036064200,"sessionID":"ses_XXX","part":{"type":"step-finish","reason":"tool-calls","cost":0.002}}
+`
+	result, err := parseOpencodeResult([]byte(stdout))
+	if err == nil {
+		t.Fatal("expected error for missing final step")
+	}
+	if result.CostUSD != 0.003 {
+		t.Errorf("expected salvaged cost 0.003, got %f", result.CostUSD)
+	}
+}
+
+// TestOpenCodeAgent_Run_SalvagesCostOnInvocationFailure verifies that a
+// non-zero exit still bills the steps that completed before the failure.
+func TestOpenCodeAgent_Run_SalvagesCostOnInvocationFailure(t *testing.T) {
+	stdout := `{"type":"step_finish","timestamp":1767036064100,"sessionID":"ses_XXX","part":{"type":"step-finish","reason":"tool-calls","cost":0.005}}
+{"type":"step_finish","timestamp":1767036064200,"sessionID":"ses_XXX","part":{"type":"step-finish","reason":"tool-calls","cost":0.005}}
+`
+	runner := &mockCommandRunner{
+		stdout: []byte(stdout),
+		err:    &mockError{msg: "exit status 1"},
+		stderr: []byte("killed"),
+	}
+	agent := &OpenCodeAgent{}
+
+	result, err := agent.Run(context.Background(), runner, "/tmp/work", "task", nil, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result.CostUSD != 0.01 {
+		t.Errorf("expected salvaged cost 0.01, got %f", result.CostUSD)
+	}
+}

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -398,7 +398,7 @@ func (a *Agent) commentChangeSummary(ctx context.Context, work *IssueWork, befor
 		return
 	}
 
-	summary := a.buildChangeSummary(ctx, work.WorktreePath, beforeSHA, afterSHA)
+	summary := a.buildChangeSummary(ctx, work, beforeSHA, afterSHA)
 
 	compareURL := fmt.Sprintf("https://github.com/%s/%s/compare/%s..%s",
 		a.cfg.Owner, a.cfg.Repo, beforeSHA, afterSHA)
@@ -414,10 +414,11 @@ func (a *Agent) commentChangeSummary(ctx context.Context, work *IssueWork, befor
 // It runs `git diff` to get the actual patch, passes it to the LLM for summarization,
 // and returns concise human-readable descriptions of each logical change.
 // Falls back to a generic message if the diff or LLM call fails.
-func (a *Agent) buildChangeSummary(ctx context.Context, worktreePath, beforeSHA, afterSHA string) string {
+// The LLM invocation cost is accumulated into the work item's session budget.
+func (a *Agent) buildChangeSummary(ctx context.Context, work *IssueWork, beforeSHA, afterSHA string) string {
 	const fallback = "- Updated code to address review feedback"
 
-	out, _, err := a.runner.Run(ctx, worktreePath, "git", "diff", "--no-color", beforeSHA, afterSHA)
+	out, _, err := a.runner.Run(ctx, work.WorktreePath, "git", "diff", "--no-color", beforeSHA, afterSHA)
 	if err != nil {
 		return fallback
 	}
@@ -428,7 +429,10 @@ func (a *Agent) buildChangeSummary(ctx context.Context, worktreePath, beforeSHA,
 	}
 
 	prompt := buildChangeSummaryPrompt(diff)
-	result, err := a.codeAgent.Run(ctx, a.runner, worktreePath, prompt, a.logger, false)
+	result, err := a.codeAgent.Run(ctx, a.runner, work.WorktreePath, prompt, a.logger, false)
+	// Track cumulative cost even on failure — failed invocations still
+	// consume tokens and count against the per-PR session budget.
+	work.SessionCostUSD += result.CostUSD
 	if err != nil {
 		a.logger.Warn("LLM summarization failed, using fallback", "error", err)
 		return fallback

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -1532,7 +1532,7 @@ func TestBuildChangeSummary(t *testing.T) {
 				results: []mockCodeAgentCall{{result: AgentResult{Result: tt.llmResult}, err: tt.llmErr}},
 			}
 
-			result := agent.buildChangeSummary(context.Background(), "/tmp/worktree", "abc", "def")
+			result := agent.buildChangeSummary(context.Background(), &IssueWork{WorktreePath: "/tmp/worktree"}, "abc", "def")
 
 			for _, s := range tt.want {
 				if !strings.Contains(result, s) {

--- a/pkg/agent/worktree.go
+++ b/pkg/agent/worktree.go
@@ -194,10 +194,27 @@ func (g *GitWorktreeManager) SyncWorktree(ctx context.Context, worktreePath stri
 
 	// Pull latest from the push remote, rebasing to preserve external contributions
 	pushRemote := g.PushRemote()
-	_, _, err = g.runner.Run(ctx, worktreePath, "git", "pull", "--rebase", pushRemote, branch)
+	_, stderr, err = g.runner.Run(ctx, worktreePath, "git", "pull", "--rebase", pushRemote, branch)
 	if err != nil {
-		// Branch may not exist on the push remote yet, that's OK
-		return nil
+		if strings.Contains(strings.ToLower(string(stderr)), "couldn't find remote ref") {
+			// Branch doesn't exist on the push remote yet (never pushed, or
+			// deleted after merge) — nothing to sync.
+			return nil
+		}
+		// The pull can conflict (worktrees are created from the origin default
+		// branch, so a PR branch based on an older default conflicts at sync
+		// time) or trip over leftover local state from an interrupted run.
+		// Swallowing the error here used to hand downstream flows a
+		// rebase-in-progress worktree. Instead, abort the rebase and hard-reset
+		// to the remote branch: the remote is the source of truth for a PR
+		// branch, and conflict handling needs the worktree at that state to
+		// reproduce the conflict in the right direction (branch onto default).
+		g.runner.Run(ctx, worktreePath, "git", "rebase", "--abort") //nolint:errcheck // best-effort
+		_, resetStderr, resetErr := g.runner.Run(ctx, worktreePath, "git", "reset", "--hard", pushRemote+"/"+branch)
+		if resetErr != nil {
+			return fmt.Errorf("git pull --rebase %s %s: %w (stderr: %s); recovery reset failed (stderr: %s)",
+				pushRemote, branch, err, string(stderr), string(resetStderr))
+		}
 	}
 	return nil
 }

--- a/pkg/agent/worktree_test.go
+++ b/pkg/agent/worktree_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -451,4 +453,86 @@ func (r *worktreeHealthRunner) Run(ctx context.Context, workDir, name string, ar
 	}
 
 	return nil, nil, nil
+}
+
+// syncPullFailRunner fails `git pull --rebase` with a scripted stderr and
+// optionally fails the recovery `git reset --hard`.
+type syncPullFailRunner struct {
+	mockCommandRunner
+	pullStderr  string
+	failReset   bool
+	resetStderr string
+}
+
+func (r *syncPullFailRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	stdout, stderr, err = r.mockCommandRunner.Run(ctx, workDir, name, args...)
+	if name == "git" && len(args) > 0 {
+		switch args[0] {
+		case "pull":
+			return nil, []byte(r.pullStderr), fmt.Errorf("exit status 1")
+		case "reset":
+			if r.failReset {
+				return nil, []byte(r.resetStderr), fmt.Errorf("exit status 128")
+			}
+		case "rev-parse":
+			return []byte("ai/issue-42\n"), nil, nil
+		}
+	}
+	return stdout, stderr, err
+}
+
+func TestSyncWorktree_PullConflictResetsToRemote(t *testing.T) {
+	runner := &syncPullFailRunner{pullStderr: "CONFLICT (content): Merge conflict in main.go\nerror: could not apply abc123"}
+	mgr := NewGitWorktreeManager(runner, "/tmp/repo", "https://github.com/owner/repo.git", "")
+
+	err := mgr.SyncWorktree(context.Background(), "/tmp/repo/worktrees/ai/issue-42")
+	if err != nil {
+		t.Fatalf("expected recovery via reset, got error: %v", err)
+	}
+
+	// Calls: fetch, rev-parse, pull (fails), rebase --abort, reset --hard origin/ai/issue-42
+	if len(runner.calls) != 5 {
+		t.Fatalf("expected 5 calls (fetch, rev-parse, pull, abort, reset), got %d: %v", len(runner.calls), runner.calls)
+	}
+	if runner.calls[3].Args[0] != "rebase" || runner.calls[3].Args[1] != "--abort" {
+		t.Errorf("expected 'git rebase --abort' after failed pull, got %v", runner.calls[3].Args)
+	}
+	expectedReset := []string{"reset", "--hard", "origin/ai/issue-42"}
+	for i, arg := range expectedReset {
+		if i >= len(runner.calls[4].Args) || runner.calls[4].Args[i] != arg {
+			t.Fatalf("expected reset call %v, got %v", expectedReset, runner.calls[4].Args)
+		}
+	}
+}
+
+func TestSyncWorktree_MissingRemoteRefIsOK(t *testing.T) {
+	runner := &syncPullFailRunner{pullStderr: "fatal: couldn't find remote ref ai/issue-42"}
+	mgr := NewGitWorktreeManager(runner, "/tmp/repo", "https://github.com/owner/repo.git", "")
+
+	err := mgr.SyncWorktree(context.Background(), "/tmp/repo/worktrees/ai/issue-42")
+	if err != nil {
+		t.Fatalf("expected nil for missing remote ref, got: %v", err)
+	}
+
+	// No recovery commands after the failed pull: fetch, rev-parse, pull only.
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected 3 calls (no recovery for missing ref), got %d: %v", len(runner.calls), runner.calls)
+	}
+}
+
+func TestSyncWorktree_PullFailureAndResetFailureErrors(t *testing.T) {
+	runner := &syncPullFailRunner{
+		pullStderr:  "error: could not apply abc123",
+		failReset:   true,
+		resetStderr: "fatal: ambiguous argument 'origin/ai/issue-42'",
+	}
+	mgr := NewGitWorktreeManager(runner, "/tmp/repo", "https://github.com/owner/repo.git", "")
+
+	err := mgr.SyncWorktree(context.Background(), "/tmp/repo/worktrees/ai/issue-42")
+	if err == nil {
+		t.Fatal("expected error when both pull and recovery reset fail")
+	}
+	if !strings.Contains(err.Error(), "recovery reset failed") {
+		t.Errorf("expected error to mention failed recovery, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Phase 1 of the unslop series (follows #269): correctness fixes found during the deep review, done **before** any restructuring so they land as small, individually revertable commits under the existing test net. Headline: the multi-project git race (roles of one project shared a clone dir while each held only its own mutex — including `os.RemoveAll` recovery paths), and the session-cost budget that missed 5 of 8 LLM invocations.

## Changes

One commit per fix:

- **Concurrency**: stop mutating process-wide env (`os.Setenv("GH_TOKEN")`) from concurrent poll cycles; token propagation now flows only through the per-runner env that actually reaches subprocesses. Delete write-only `Config.GitHubToken`.
- **Concurrency (P0)**: per-role-entry clone dirs (`<base>/<owner>/<repo>/<role>`) — role goroutines never share a `.git`. Also fixes per-role fork overrides clashing on the single `fork` remote. One-time re-clone on upgrade; a shared per-repo git gateway restores single-clone efficiency in the architecture phase.
- **Cost budget**: issue implementation, conflict resolution, and change-summary invocations now count against `MaxPRSessionCost` (previously only 3 of 8 call sites did). Triage invocations stay untracked deliberately — they aren't PR-scoped.
- **Dry-run**: `gitSquashCommits` (real local history rewrite) and `deleteRemoteBranch` (real remote deletion) now honor `--dry-run` like their guarded siblings.
- **SyncWorktree**: pull-rebase failures are no longer swallowed. Missing remote ref → fine; anything else → abort + hard-reset to the remote PR branch (source of truth) so conflict flows reproduce the conflict in the right direction instead of running the agent on a mid-rebase tree. The conflict e2e was previously passing *through* the swallowed error.
- **Prompt size**: `GetWorkflowJobLogs` now tail-truncates at 50KB like `GetCheckRunLog` (shared helper) — multi-MB logs no longer land in triage prompts.
- **Rebase comments**: head-SHA lookup failures are logged instead of discarded (they silently disabled dedup and produced 'Rebased commit  on main'); comments use the detected default branch instead of hardcoded 'main'.
- **Memory**: ETag response cache bounded (512 entries, LRU) with a 1MiB per-body cap — it grew without limit in a weeks-long daemon.
- **Test**: replaced a vacuous max-retries assertion (scanned for comment text production never emits) with a comment-count pin.

## Testing

- [x] `go test ./...` passes (incl. `-race` and e2e)
- [x] `go vet ./...` / `golangci-lint run` / `golangci-lint fmt --diff` clean
- [x] New unit tests: SyncWorktree failure modes (×3), LRU eviction + oversized-body skip, per-entry clone-dir uniqueness

## Related Issues

Part of the unslop/refactoring series (phase 1 of ~5). Follows #269.
