### PR TITLE
refactor: phase 2a unslop — delete dead code and stale comments

### DIFF
--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -25,7 +25,7 @@ type ciResult struct {
 	pushed         bool   // whether a fix was pushed
 }
 
-// ProcessCIFailures checks CI status for open PRs and invokes Claude to fix failures.
+// ProcessCIFailures checks CI status for open PRs and invokes the coding agent to fix failures.
 func (a *Agent) ProcessCIFailures(ctx context.Context) {
 	a.emit(Event{
 		Type:     EventActionStarted,
@@ -41,7 +41,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 		State:    "idle",
 		Action:   "CI check complete",
 	})
-	// Sequential phase: GitHub API calls, check run fetching, worktree setup
+	// Scan phase: GitHub API calls, check run fetching, worktree setup
 	var tasks []ciTask
 
 	for _, work := range a.state.ActiveIssues {
@@ -182,11 +182,11 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
-		// Get PR diff to help Claude determine if failure is related
+		// Get PR diff to help the agent determine if failure is related
 		diffOut, _, _ := a.runner.Run(ctx, work.WorktreePath, "git", "diff", "--stat", a.originDefaultBranch())
 		diff := string(diffOut)
 
-		// Get commits in the PR to help Claude identify which commit introduced the failure
+		// Get commits in the PR to help the agent identify which commit introduced the failure
 		commits := a.getPRCommits(ctx, work.WorktreePath)
 
 		// Create one task per failure so each gets its own RELATED/UNRELATED classification.
@@ -214,7 +214,7 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 	// Track insertion order to preserve the task processing sequence.
 	var groupOrder []string
 
-	// Sequential phase: Claude invocations and result collection
+	// Agent phase: investigate each collected failure and gather results
 	runSequential(ctx, tasks, func(ctx context.Context, task ciTask) {
 		// Re-check cost guard before each invocation — multiple tasks can be
 		// enqueued for the same PR, and earlier invocations may have pushed
@@ -338,10 +338,6 @@ func (a *Agent) classifyCIInfrastructure(_ context.Context, task ciTask, cleaned
 	// (e.g. if comments are deleted), so in-memory state is the primary guard.
 	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
 
-	if a.ShouldSkipComment("ci-infrastructure") {
-		a.logger.Info("skipping CI infrastructure comment (--skip-comment)", "pr", task.work.PRNumber)
-	}
-
 	task.work.LastCIStatus = "infrastructure-failure"
 	task.work.LastCheckedCISHA = task.headSHA
 
@@ -379,10 +375,6 @@ func (a *Agent) classifyCIUnrelated(ctx context.Context, task ciTask, cleaned st
 	// Comment markers serve as a secondary dedup mechanism but can be lost
 	// (e.g. if comments are deleted), so in-memory state is the primary guard.
 	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-
-	if a.ShouldSkipComment("ci-unrelated") {
-		a.logger.Info("skipping CI unrelated comment (--skip-comment)", "pr", task.work.PRNumber)
-	}
 
 	task.work.LastCIStatus = "unrelated-failure"
 	task.work.LastCheckedCISHA = task.headSHA
@@ -679,9 +671,6 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 		a.logger.Info("CI failure is related (skip-fix mode, not pushing)", "pr", task.work.PRNumber)
 		// Always mark as checked in memory to prevent re-investigation on next poll.
 		a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-		if a.ShouldSkipComment("ci-related") {
-			a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
-		}
 		task.work.LastCIStatus = "related-skip-fix"
 		task.work.LastCheckedCISHA = task.headSHA
 		return ciResult{
@@ -712,7 +701,7 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 			pushed = true
 		}
 	case hasUncommitted:
-		// Claude left uncommitted changes — amend them into HEAD as fallback
+		// The agent left uncommitted changes — amend them into HEAD as fallback
 		if err := a.gitAmendAll(ctx, task.work.WorktreePath); err != nil {
 			a.logger.Error("failed to amend commit for CI fix", "pr", task.work.PRNumber, "error", err)
 		} else if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
@@ -721,11 +710,11 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 			pushed = true
 		}
 	default:
-		// No fixups and no uncommitted changes — Claude may have amended
+		// No fixups and no uncommitted changes — the agent may have amended
 		// the commit directly. Check if HEAD differs from the remote SHA.
 		localSHA, _, err := a.runner.Run(ctx, task.work.WorktreePath, "git", "rev-parse", "HEAD")
 		if err == nil && strings.TrimSpace(string(localSHA)) != task.headSHA {
-			a.logger.Info("Claude amended commit directly, pushing", "pr", task.work.PRNumber)
+			a.logger.Info("agent amended commit directly, pushing", "pr", task.work.PRNumber)
 			if err := a.gitPush(ctx, task.work.WorktreePath, true); err != nil {
 				a.logger.Error("failed to push CI fix", "pr", task.work.PRNumber, "error", err)
 			} else {
@@ -748,17 +737,13 @@ func (a *Agent) classifyCIRelated(ctx context.Context, task ciTask, cleaned stri
 	if pushed {
 		a.logger.Info("CI failure is related, pushed a fix", "pr", task.work.PRNumber)
 	} else {
-		a.logger.Warn("Claude said RELATED but no changes to push", "pr", task.work.PRNumber)
+		a.logger.Warn("agent said RELATED but no changes to push", "pr", task.work.PRNumber)
 	}
 
 	// Always mark as checked in memory to prevent re-investigation on next poll.
 	// Comment markers serve as a secondary dedup mechanism but can be lost
 	// (e.g. if comments are deleted), so in-memory state is the primary guard.
 	a.markCIChecked(task.work, task.headSHA, task.failures[0].Name)
-
-	if a.ShouldSkipComment("ci-related") {
-		a.logger.Info("skipping CI related comment (--skip-comment)", "pr", task.work.PRNumber)
-	}
 
 	task.work.CIFixAttempts++
 	task.work.LastCIStatus = "failure"

--- a/pkg/agent/ci.go
+++ b/pkg/agent/ci.go
@@ -182,8 +182,13 @@ func (a *Agent) ProcessCIFailures(ctx context.Context) {
 			continue
 		}
 
-		// Get PR diff to help the agent determine if failure is related
-		diffOut, _, _ := a.runner.Run(ctx, work.WorktreePath, "git", "diff", "--stat", a.originDefaultBranch())
+		// Get PR diff to help the agent determine if failure is related.
+		// Degrade gracefully on error: the investigation proceeds with an
+		// empty diff rather than being skipped.
+		diffOut, diffStderr, diffErr := a.runner.Run(ctx, work.WorktreePath, "git", "diff", "--stat", a.originDefaultBranch())
+		if diffErr != nil {
+			a.logger.Warn("failed to get PR diff for CI context", "pr", work.PRNumber, "error", diffErr, "stderr", string(diffStderr))
+		}
 		diff := string(diffOut)
 
 		// Get commits in the PR to help the agent identify which commit introduced the failure

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -771,9 +771,6 @@ func (m *laneTestMockGH) AddIssueComment(context.Context, string, string, int, s
 func (m *laneTestMockGH) AddLabel(context.Context, string, string, int, string) error {
 	return nil
 }
-func (m *laneTestMockGH) RemoveLabel(context.Context, string, string, int, string) error {
-	return nil
-}
 func (m *laneTestMockGH) ListPRsByHead(context.Context, string, string, string, string) ([]PR, error) {
 	return nil, nil
 }
@@ -794,9 +791,6 @@ func (m *laneTestMockGH) GetPRHeadSHA(context.Context, string, string, int) (str
 }
 func (m *laneTestMockGH) HasPRCommentReaction(context.Context, string, string, int64, string, string) (bool, error) {
 	return false, nil
-}
-func (m *laneTestMockGH) ReplyToPRComment(context.Context, string, string, int, int64, string) error {
-	return nil
 }
 func (m *laneTestMockGH) AssignIssue(context.Context, string, string, int, string) error {
 	return nil

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -145,15 +145,13 @@ func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin stri
 // streamEvent represents a single event in Claude's stream-json output.
 type streamEvent struct {
 	Type    string         `json:"type"`
-	Subtype string         `json:"subtype,omitempty"`
 	Message *streamMessage `json:"message,omitempty"`
 	// Result fields (only present when Type == "result")
-	Result        string  `json:"result,omitempty"`
-	CostUSD       float64 `json:"cost_usd,omitempty"`
-	TotalCostUSD  float64 `json:"total_cost_usd,omitempty"`
-	NumTurns      int     `json:"num_turns,omitempty"`
-	DurationMs    int64   `json:"duration_ms,omitempty"`
-	DurationAPIMs int64   `json:"duration_api_ms,omitempty"`
+	Result       string  `json:"result,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+	TotalCostUSD float64 `json:"total_cost_usd,omitempty"`
+	NumTurns     int     `json:"num_turns,omitempty"`
+	DurationMs   int64   `json:"duration_ms,omitempty"`
 }
 
 type streamMessage struct {

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -30,7 +30,6 @@ type CommandRunner interface {
 // StreamingRunner extends CommandRunner with line-by-line stdout streaming.
 type StreamingRunner interface {
 	CommandRunner
-	RunStream(ctx context.Context, workDir string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
 	RunStreamWithStdin(ctx context.Context, workDir string, stdin string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
 }
 
@@ -94,10 +93,6 @@ func (r *ExecRunner) RunWithStdin(ctx context.Context, workDir, stdin, name stri
 		stderr = exitErr.Stderr
 	}
 	return stdout, stderr, err
-}
-
-func (r *ExecRunner) RunStream(ctx context.Context, workDir string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
-	return r.RunStreamWithStdin(ctx, workDir, "", onLine, name, args...)
 }
 
 func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -63,7 +63,6 @@ func (m *mockCommandRunner) RunWithStdin(_ context.Context, workDir, stdin, name
 func streamResultJSON(r AgentResult) []byte {
 	event := streamEvent{
 		Type:    "result",
-		Subtype: "success",
 		Result:  r.Result,
 		CostUSD: r.CostUSD,
 	}

--- a/pkg/agent/conflicts.go
+++ b/pkg/agent/conflicts.go
@@ -48,7 +48,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		State:    "idle",
 		Action:   "Conflict check complete",
 	})
-	// Sequential phase: GitHub API calls, worktree setup, git fetch, automatic rebase attempts
+	// Scan phase: GitHub API calls, worktree setup, git fetch, automatic rebase attempts
 	var tasks []conflictTask
 
 	for _, work := range a.state.ActiveIssues {
@@ -115,9 +115,9 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 			continue
 		}
 
-		// Rebase failed — abort and let Claude try
+		// Rebase failed — abort and let the coding agent try
 		a.runner.Run(ctx, work.WorktreePath, "git", "rebase", "--abort") //nolint:errcheck // best-effort
-		a.logger.Info("automatic rebase failed, invoking Claude to resolve conflicts", "pr", work.PRNumber, "stderr", stderr)
+		a.logger.Info("automatic rebase failed, invoking coding agent to resolve conflicts", "pr", work.PRNumber, "stderr", stderr)
 
 		tasks = append(tasks, conflictTask{
 			work:         work,
@@ -127,7 +127,7 @@ func (a *Agent) ProcessConflicts(ctx context.Context) {
 		})
 	}
 
-	// Sequential phase: Claude invocations for conflict resolution
+	// Agent phase: resolve collected conflicts with the coding agent
 	a.resolveConflictsSequential(ctx, tasks)
 }
 
@@ -187,7 +187,7 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 		State:    "idle",
 		Action:   "Rebase check complete",
 	})
-	// Sequential phase: check states, try automatic rebase, collect failed conflicts into tasks
+	// Scan phase: check states, try automatic rebase, collect failed conflicts into tasks
 	var tasks []conflictTask
 
 	for _, work := range a.state.ActiveIssues {
@@ -283,7 +283,7 @@ func (a *Agent) ProcessRebase(ctx context.Context) {
 		}
 	}
 
-	// Sequential phase: invoke Claude for conflict resolution on collected tasks
+	// Agent phase: resolve collected conflicts with the coding agent
 	a.resolveConflictsSequential(ctx, tasks)
 }
 

--- a/pkg/agent/dryrun.go
+++ b/pkg/agent/dryrun.go
@@ -30,11 +30,6 @@ func (d *DryRunGitHubClient) AddLabel(_ context.Context, _, _ string, issueNumbe
 	return nil
 }
 
-func (d *DryRunGitHubClient) RemoveLabel(_ context.Context, _, _ string, issueNumber int, label string) error {
-	d.logger.Info("[dry-run] would remove label", "issue", issueNumber, "label", label)
-	return nil
-}
-
 func (d *DryRunGitHubClient) AssignIssue(_ context.Context, _, _ string, issueNumber int, user string) error {
 	d.logger.Info("[dry-run] would assign issue", "issue", issueNumber, "user", user)
 	return nil
@@ -62,11 +57,6 @@ func (d *DryRunGitHubClient) AddPRCommentReaction(_ context.Context, _, _ string
 
 func (d *DryRunGitHubClient) AddIssueCommentReaction(_ context.Context, _, _ string, commentID int64, reaction string) error {
 	d.logger.Info("[dry-run] would add issue comment reaction", "comment", commentID, "reaction", reaction)
-	return nil
-}
-
-func (d *DryRunGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, prNumber int, commentID int64, body string) error {
-	d.logger.Info("[dry-run] would reply to comment", "pr", prNumber, "comment", commentID, "body", truncateString(body, 100))
 	return nil
 }
 

--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -46,7 +46,7 @@ func (a *Agent) ensureTrailers(msg string) string {
 	return msg
 }
 
-// buildPRBody constructs a PR description. If Claude wrote a .pr-body.md file
+// buildPRBody constructs a PR description. If the agent wrote a .pr-body.md file
 // (filled from the repo's PR template), that is used. Otherwise falls back to
 // constructing a body from the git log.
 func (a *Agent) buildPRBody(ctx context.Context, worktreePath string, issueNumber int) string {
@@ -289,11 +289,11 @@ func (a *Agent) gitSquashCommits(ctx context.Context, worktreePath string, issue
 		return fmt.Errorf("git reset --soft: %w (stderr: %s)", err, string(stderr))
 	}
 
-	// Unstage .pr-body.md if Claude accidentally staged it — it must not be committed.
+	// Unstage .pr-body.md if the agent accidentally staged it — it must not be committed.
 	a.runner.Run(ctx, worktreePath, "git", "restore", "--staged", ".pr-body.md") //nolint:errcheck // best-effort
 
 	// Create a single commit with a meaningful message.
-	// Strip any Signed-off-by/Assisted-by trailers Claude may have added to individual
+	// Strip any Signed-off-by/Assisted-by trailers the agent may have added to individual
 	// commits before building the body, then append exactly one canonical set of trailers.
 	//
 	// The subject line uses the issue title directly (truncated to 72 chars).

--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -62,7 +61,7 @@ func (a *Agent) buildPRBody(ctx context.Context, worktreePath string, issueNumbe
 	}
 
 	// Fallback: construct from git log body only (skip subject to avoid duplication).
-	logOut, _, _ := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%b---")
+	logOut, _, _ := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%b")
 	rawBody := strings.TrimSpace(string(logOut))
 
 	body := fmt.Sprintf("Fixes #%d\n\n", issueNumber)
@@ -245,15 +244,6 @@ func (a *Agent) gitSquashInto(ctx context.Context, worktreePath, targetSHA strin
 		}
 	}
 	return nil
-}
-
-// conventionalCommitRe matches issue titles that start with a conventional commit prefix.
-// Supports standard prefixes with optional scope and breaking change indicator.
-var conventionalCommitRe = regexp.MustCompile(`^(feat|fix|build|refactor|docs|chore|test|ci|perf|style|revert)(\([^)]+\))?!?:`)
-
-// isConventionalCommitTitle returns true if the title starts with a conventional commit prefix.
-func isConventionalCommitTitle(title string) bool {
-	return conventionalCommitRe.MatchString(title)
 }
 
 // maxSubjectLen is the maximum length of a commit subject line.

--- a/pkg/agent/git_ops.go
+++ b/pkg/agent/git_ops.go
@@ -61,7 +61,11 @@ func (a *Agent) buildPRBody(ctx context.Context, worktreePath string, issueNumbe
 	}
 
 	// Fallback: construct from git log body only (skip subject to avoid duplication).
-	logOut, _, _ := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%b")
+	// Degrade gracefully on error: the body is built without the log section.
+	logOut, logStderr, logErr := a.runner.Run(ctx, worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--format=%b")
+	if logErr != nil {
+		a.logger.Warn("failed to get git log for PR body", "issue", issueNumber, "error", logErr, "stderr", string(logStderr))
+	}
 	rawBody := strings.TrimSpace(string(logOut))
 
 	body := fmt.Sprintf("Fixes #%d\n\n", issueNumber)

--- a/pkg/agent/git_ops_test.go
+++ b/pkg/agent/git_ops_test.go
@@ -7,56 +7,6 @@ import (
 	"testing"
 )
 
-func TestIsConventionalCommitTitle(t *testing.T) {
-	tests := []struct {
-		name     string
-		title    string
-		expected bool
-	}{
-		// Conventional commit prefixes — should match
-		{"feat prefix", "feat: add new feature", true},
-		{"fix prefix", "fix: resolve crash on startup", true},
-		{"build prefix", "build: consolidate multi-arch container build scripts", true},
-		{"refactor prefix", "refactor: simplify handler logic", true},
-		{"docs prefix", "docs: update README", true},
-		{"chore prefix", "chore: bump dependencies", true},
-		{"test prefix", "test: add unit tests for parser", true},
-		{"ci prefix", "ci: fix GitHub Actions workflow", true},
-		{"perf prefix", "perf: optimize database queries", true},
-		{"style prefix", "style: fix formatting", true},
-		{"revert prefix", "revert: undo previous change", true},
-
-		// With scope
-		{"feat with scope", "feat(api): add pagination support", true},
-		{"fix with scope", "fix(auth): handle expired tokens", true},
-		{"refactor with scope", "refactor(build): consolidate scripts", true},
-
-		// With breaking change indicator
-		{"breaking without scope", "feat!: remove deprecated API", true},
-		{"breaking with scope", "feat(api)!: change response format", true},
-
-		// Non-conventional titles — should NOT match
-		{"capitalized word", "Fix the bug", false},
-		{"lowercase no prefix", "implement feature X", false},
-		{"sentence case", "Update README with new instructions", false},
-		{"issue ref prefix", "Fix #42: something", false},
-		{"invalid prefix word", "feature: this is not a valid prefix", false},
-		{"uppercase prefix", "FEAT: uppercase doesn't match", false},
-		{"missing colon", "feat - missing colon", false},
-		{"no space after colon", "feat:missing space is fine", true},
-		{"empty string", "", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isConventionalCommitTitle(tt.title)
-			if got != tt.expected {
-				t.Errorf("isConventionalCommitTitle(%q) = %v, want %v", tt.title, got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestTruncateSubject(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/agent/github.go
+++ b/pkg/agent/github.go
@@ -20,7 +20,6 @@ type GitHubClient interface {
 	GetPRState(ctx context.Context, owner, repo string, prNumber int) (string, error)
 	AddIssueComment(ctx context.Context, owner, repo string, issueNumber int, body string) error
 	AddLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error
-	RemoveLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error
 	ListPRsByHead(ctx context.Context, owner, repo, headOwner, branch string) ([]PR, error)
 	AddPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error
 	AddIssueCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction string) error
@@ -28,7 +27,6 @@ type GitHubClient interface {
 	GetCheckRunLog(ctx context.Context, owner, repo string, checkRunID int64) (string, error)
 	GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error)
 	HasPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction, user string) (bool, error)
-	ReplyToPRComment(ctx context.Context, owner, repo string, prNumber int, commentID int64, body string) error
 	AssignIssue(ctx context.Context, owner, repo string, issueNumber int, user string) error
 	UnassignIssue(ctx context.Context, owner, repo string, issueNumber int, user string) error
 	GetPRMergeable(ctx context.Context, owner, repo string, prNumber int) (string, error)
@@ -204,14 +202,6 @@ func (g *GoGitHubClient) AddLabel(ctx context.Context, owner, repo string, issue
 	_, _, err := g.client.Issues.AddLabelsToIssue(ctx, owner, repo, issueNumber, []string{label})
 	if err != nil {
 		return fmt.Errorf("adding label: %w", err)
-	}
-	return nil
-}
-
-func (g *GoGitHubClient) RemoveLabel(ctx context.Context, owner, repo string, issueNumber int, label string) error {
-	_, err := g.client.Issues.RemoveLabelForIssue(ctx, owner, repo, issueNumber, label)
-	if err != nil {
-		return fmt.Errorf("removing label: %w", err)
 	}
 	return nil
 }
@@ -432,14 +422,6 @@ func (g *GoGitHubClient) HasPRCommentReaction(ctx context.Context, owner, repo s
 		}
 	}
 	return false, nil
-}
-
-func (g *GoGitHubClient) ReplyToPRComment(ctx context.Context, owner, repo string, prNumber int, commentID int64, body string) error {
-	_, _, err := g.client.PullRequests.CreateCommentInReplyTo(ctx, owner, repo, prNumber, body, commentID)
-	if err != nil {
-		return fmt.Errorf("replying to PR comment: %w", err)
-	}
-	return nil
 }
 
 func (g *GoGitHubClient) GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error) {

--- a/pkg/agent/github_test.go
+++ b/pkg/agent/github_test.go
@@ -258,24 +258,6 @@ func TestAddLabel(t *testing.T) {
 	}
 }
 
-func TestRemoveLabel(t *testing.T) {
-	var called bool
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v3/repos/owner/repo/issues/42/labels/good-for-ai", func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	gh := setupTestClient(t, mux)
-	err := gh.RemoveLabel(context.Background(), "owner", "repo", 42, "good-for-ai")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !called {
-		t.Error("expected remove label endpoint to be called")
-	}
-}
-
 func TestListPRsByHead(t *testing.T) {
 	var closedRequests int
 	mux := http.NewServeMux()

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -21,7 +21,6 @@ type fakeGitHub struct {
 	prComments     map[int][]ReviewComment // prNumber -> comments
 	postedComments []string                // issue comments posted
 	addedLabels    []string
-	removedLabels  []string
 	reactions      []string
 	checkRuns      []CheckRun
 	nextPRNumber   int
@@ -154,13 +153,6 @@ func (f *fakeGitHubClient) AddLabel(_ context.Context, _, _ string, _ int, label
 	return nil
 }
 
-func (f *fakeGitHubClient) RemoveLabel(_ context.Context, _, _ string, _ int, label string) error {
-	f.state.mu.Lock()
-	defer f.state.mu.Unlock()
-	f.state.removedLabels = append(f.state.removedLabels, label)
-	return nil
-}
-
 func (f *fakeGitHubClient) ListPRsByHead(_ context.Context, _, _, _, branch string) ([]PR, error) {
 	f.state.mu.Lock()
 	defer f.state.mu.Unlock()
@@ -218,13 +210,6 @@ func (f *fakeGitHubClient) GetPRHeadSHA(_ context.Context, _, _ string, prNumber
 
 func (f *fakeGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, _ int64, _, _ string) (bool, error) {
 	return false, nil
-}
-
-func (f *fakeGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, _ int, commentID int64, body string) error {
-	f.state.mu.Lock()
-	defer f.state.mu.Unlock()
-	f.state.postedComments = append(f.state.postedComments, fmt.Sprintf("reply:%d:%s", commentID, body))
-	return nil
 }
 
 func (f *fakeGitHubClient) GetPRMergeable(_ context.Context, _, _ string, _ int) (string, error) {

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -204,7 +204,14 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		}
 
 		// Check if the agent produced any commits
-		logOut, _, _ := a.runner.Run(ctx, task.worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--oneline")
+		logOut, logStderr, logErr := a.runner.Run(ctx, task.worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--oneline")
+		if logErr != nil {
+			// Distinguish a broken worktree from a genuinely empty branch so
+			// the failure log doesn't blame the agent for a git error.
+			a.logger.Error("failed to check for commits", "issue", task.issue.Number, "error", logErr, "stderr", string(logStderr))
+			a.markIssueFailed(ctx, task.issue.Number, task.work)
+			return
+		}
 		if strings.TrimSpace(string(logOut)) == "" {
 			a.logger.Warn("agent finished but produced no commits", "issue", task.issue.Number)
 			a.markIssueFailed(ctx, task.issue.Number, task.work)

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// ProcessNewIssues finds labeled issues and spawns Claude to implement fixes.
+// ProcessNewIssues finds labeled issues and runs the coding agent to implement fixes.
 func (a *Agent) ProcessNewIssues(ctx context.Context) {
 	if a.cfg.Label == "" {
 		return
@@ -34,7 +34,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		return
 	}
 
-	// Sequential phase: filter issues, create worktrees, insert into state
+	// Scan phase: filter issues, create worktrees, insert into state
 	var tasks []newIssueTask
 
 	for _, issue := range issues {
@@ -137,7 +137,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			Status:       StatusImplementing,
 		}
 
-		// Insert into state map before parallel phase
+		// Insert into state map before the agent phase
 		a.state.ActiveIssues[issueKey] = work
 
 		tasks = append(tasks, newIssueTask{
@@ -148,7 +148,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		})
 	}
 
-	// Sequential phase: run Claude, push, create PR
+	// Agent phase: implement each collected issue, push, create PR
 	runSequential(ctx, tasks, func(ctx context.Context, task newIssueTask) {
 		var success bool
 		defer func() {
@@ -203,10 +203,10 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			return
 		}
 
-		// Check if Claude produced any commits
+		// Check if the agent produced any commits
 		logOut, _, _ := a.runner.Run(ctx, task.worktreePath, "git", "log", a.originDefaultBranch()+"..HEAD", "--oneline")
 		if strings.TrimSpace(string(logOut)) == "" {
-			a.logger.Warn("claude finished but produced no commits", "issue", task.issue.Number)
+			a.logger.Warn("agent finished but produced no commits", "issue", task.issue.Number)
 			a.markIssueFailed(ctx, task.issue.Number, task.work)
 			return
 		}
@@ -214,7 +214,7 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 		// Treat comment-only changes as a failed fix: no functional code changed,
 		// so opening a PR would waste reviewer time.
 		if a.isCommentOnlyDiff(ctx, task.worktreePath) {
-			a.logger.Warn("claude produced comment-only changes, treating as failed fix", "issue", task.issue.Number)
+			a.logger.Warn("agent produced comment-only changes, treating as failed fix", "issue", task.issue.Number)
 			a.markIssueFailed(ctx, task.issue.Number, task.work)
 			return
 		}

--- a/pkg/agent/issues.go
+++ b/pkg/agent/issues.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 )
 
 // ProcessNewIssues finds labeled issues and spawns Claude to implement fixes.
@@ -85,7 +84,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 					BranchName:  branchName,
 					PRNumber:    openPR.Number,
 					Status:      StatusPROpen,
-					CreatedAt:   time.Now(),
 				}
 				continue
 			} else if hasMerged {
@@ -137,7 +135,6 @@ func (a *Agent) ProcessNewIssues(ctx context.Context) {
 			WorktreePath: worktreePath,
 			BranchName:   branchName,
 			Status:       StatusImplementing,
-			CreatedAt:    time.Now(),
 		}
 
 		// Insert into state map before parallel phase

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -108,8 +108,9 @@ func (a *Agent) RefreshToken(ctx context.Context) error {
 	return nil
 }
 
-// runSequential executes a function on each item sequentially.
-// Each role entry runs within its own goroutine, so no worker pool is needed.
+// runSequential executes a function on each item sequentially, one at a
+// time — sequential processing within an agent is a correctness invariant
+// (it protects the agent's git state).
 // Stops early if the context is cancelled (e.g. during graceful shutdown).
 func runSequential[T any](ctx context.Context, items []T, fn func(context.Context, T)) {
 	for _, item := range items {
@@ -120,7 +121,8 @@ func runSequential[T any](ctx context.Context, items []T, fn func(context.Contex
 	}
 }
 
-// Task structs for parallel execution
+// Task structs carrying collected work items from the scan phase to the
+// agent-invocation phase of each reaction.
 
 type newIssueTask struct {
 	issue        Issue
@@ -422,7 +424,7 @@ func (a *Agent) BootstrapWatchedPRs(ctx context.Context) {
 			WorktreePath: worktreePath,
 			BranchName:   branchName,
 			PRNumber:     prNumber,
-			Status:       "pr-open",
+			Status:       StatusPROpen,
 		}
 
 		a.state.ActiveIssues[IssueKey(a.cfg.Owner, a.cfg.Repo, prNumber)] = work
@@ -445,7 +447,7 @@ func (a *Agent) hasExistingBotComment(ctx context.Context, issueNumber int, text
 	return false
 }
 
-// parseFlakyMatch parses Claude's response to a flaky match prompt.
+// parseFlakyMatch parses the coding agent's response to a flaky match prompt.
 // Returns the matched issue number and true if the response is "MATCH <number>".
 // Handles multi-line responses where the LLM appends an explanation after
 // the MATCH line (e.g. "MATCH #42\n\nThis matches because...").

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -423,7 +423,6 @@ func (a *Agent) BootstrapWatchedPRs(ctx context.Context) {
 			BranchName:   branchName,
 			PRNumber:     prNumber,
 			Status:       "pr-open",
-			CreatedAt:    time.Now(),
 		}
 
 		a.state.ActiveIssues[IssueKey(a.cfg.Owner, a.cfg.Repo, prNumber)] = work
@@ -638,14 +637,6 @@ func (a *Agent) CheckCIStatus(ctx context.Context, lastReportedAt time.Time) []S
 	return findings
 }
 
-// CheckRebaseNeeded is a lightweight report-only check that inspects PR mergeable state
-// and returns findings for PRs that are behind the base branch.
-// Fetches mergeable states from GitHub. Use checkRebaseNeededWithStates when states
-// are already available to avoid redundant API calls.
-func (a *Agent) CheckRebaseNeeded(ctx context.Context) []SlackFinding {
-	return a.checkRebaseNeededWithStates(ctx, a.fetchMergeableStates(ctx))
-}
-
 // checkRebaseNeededWithStates checks for outdated PRs using precomputed mergeable states.
 // Includes dynamic rebase deferral context when the main branch is active.
 func (a *Agent) checkRebaseNeededWithStates(ctx context.Context, states map[int]string) []SlackFinding {
@@ -693,14 +684,6 @@ func (a *Agent) checkRebaseNeededWithStates(ctx context.Context, states map[int]
 	}
 
 	return findings
-}
-
-// CheckConflicts is a lightweight report-only check that inspects PR mergeable state
-// and returns findings for PRs with merge conflicts.
-// Fetches mergeable states from GitHub. Use checkConflictsWithStates when states
-// are already available to avoid redundant API calls.
-func (a *Agent) CheckConflicts(ctx context.Context) []SlackFinding {
-	return a.checkConflictsWithStates(ctx, a.fetchMergeableStates(ctx))
 }
 
 // checkConflictsWithStates checks for merge conflicts using precomputed mergeable states.

--- a/pkg/agent/mocks_test.go
+++ b/pkg/agent/mocks_test.go
@@ -17,7 +17,6 @@ type mockGitHubClient struct {
 	addedComments       []string
 	addedCommentTargets []int // issue/PR number each comment was posted to
 	addedLabels         []string
-	removedLabels       []string
 	addedReactions      []string
 	checkRuns           []CheckRun
 	commitStatuses      []CheckRun       // commit status failures (returned by GetCommitStatuses)
@@ -84,11 +83,6 @@ func (m *mockGitHubClient) AddLabel(_ context.Context, _, _ string, _ int, label
 	return nil
 }
 
-func (m *mockGitHubClient) RemoveLabel(_ context.Context, _, _ string, _ int, label string) error {
-	m.removedLabels = append(m.removedLabels, label)
-	return nil
-}
-
 func (m *mockGitHubClient) ListPRsByHead(_ context.Context, _, _, _, _ string) ([]PR, error) {
 	m.prsCallCount++
 	if m.listPRsErr != nil {
@@ -143,11 +137,6 @@ func (m *mockGitHubClient) HasPRCommentReaction(_ context.Context, _, _ string, 
 		}
 	}
 	return false, nil
-}
-
-func (m *mockGitHubClient) ReplyToPRComment(_ context.Context, _, _ string, _ int, commentID int64, body string) error {
-	m.addedComments = append(m.addedComments, fmt.Sprintf("reply:%d:%s", commentID, body))
-	return nil
 }
 
 func (m *mockGitHubClient) GetPRMergeable(_ context.Context, _, _ string, _ int) (string, error) {

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -16,11 +16,9 @@ type OpenCodeAgent struct {
 // opencodeEvent represents a single event in OpenCode's JSONL output.
 // OpenCode emits newline-delimited JSON with event-specific data nested under "part".
 type opencodeEvent struct {
-	Type      string         `json:"type"`
-	Timestamp int64          `json:"timestamp"`
-	SessionID string         `json:"sessionID"`
-	Part      opencodePart   `json:"part"`
-	Error     *opencodeError `json:"error,omitempty"`
+	Type  string         `json:"type"`
+	Part  opencodePart   `json:"part"`
+	Error *opencodeError `json:"error,omitempty"`
 }
 
 // opencodePart contains event-specific data for OpenCode events.
@@ -32,31 +30,17 @@ type opencodePart struct {
 	Cost   float64            `json:"cost,omitempty"`
 	Tokens *opencodeTokens    `json:"tokens,omitempty"`
 	State  *opencodeToolState `json:"state,omitempty"`
-	Time   *opencodeTime      `json:"time,omitempty"`
 }
 
 // opencodeTokens contains token usage information.
 type opencodeTokens struct {
-	Input     int `json:"input"`
-	Output    int `json:"output"`
-	Reasoning int `json:"reasoning"`
-	Cache     *struct {
-		Read  int `json:"read"`
-		Write int `json:"write"`
-	} `json:"cache,omitempty"`
+	Input  int `json:"input"`
+	Output int `json:"output"`
 }
 
 // opencodeToolState contains tool execution state.
 type opencodeToolState struct {
-	Status string         `json:"status,omitempty"`
-	Output string         `json:"output,omitempty"`
-	Input  map[string]any `json:"input,omitempty"`
-}
-
-// opencodeTime contains timing information.
-type opencodeTime struct {
-	Start int64 `json:"start"`
-	End   int64 `json:"end"`
+	Status string `json:"status,omitempty"`
 }
 
 // opencodeError contains error information.

--- a/pkg/agent/review.go
+++ b/pkg/agent/review.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// ProcessReviewComments checks for new review comments and review bodies, then runs Claude to address them.
+// ProcessReviewComments checks for new review comments and review bodies, then runs the coding agent to address them.
 func (a *Agent) ProcessReviewComments(ctx context.Context) {
 	a.emit(Event{
 		Type:     EventActionStarted,
@@ -23,7 +23,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		State:    "idle",
 		Action:   "Review check complete",
 	})
-	// Sequential phase: filter comments, prepare worktrees, add reactions, build tasks
+	// Scan phase: filter comments, prepare worktrees, add reactions, build tasks
 	var tasks []reviewTask
 
 	for _, work := range a.state.ActiveIssues {
@@ -223,7 +223,7 @@ func (a *Agent) ProcessReviewComments(ctx context.Context) {
 		})
 	}
 
-	// Sequential phase: run agent to address review feedback, then push changes
+	// Agent phase: run agent to address review feedback, then push changes
 	runSequential(ctx, tasks, func(ctx context.Context, task reviewTask) {
 		a.emit(Event{
 			Type:      EventAgentInvocation,

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -66,14 +66,6 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID != 60 {
 		t.Errorf("expected lastCommentID 60, got %d", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCommentID)
 	}
-
-	// Oompa does NOT post its own replies — the skill handles all per-comment
-	// communication. Verify no reply comments were posted by the agent.
-	for _, comment := range gh.addedComments {
-		if strings.HasPrefix(comment, "reply:") {
-			t.Errorf("expected no agent-posted replies (skill owns replies), got: %s", comment)
-		}
-	}
 }
 
 func TestProcessReviewComments_PushFailureDoesNotAdvanceCursor(t *testing.T) {
@@ -164,13 +156,6 @@ func TestProcessReviewComments_AgentErrorStillAdvancesCursor(t *testing.T) {
 	}
 
 	agent.ProcessReviewComments(context.Background())
-
-	// Oompa does NOT post its own replies — the skill handles all per-comment communication.
-	for _, comment := range gh.addedComments {
-		if strings.HasPrefix(comment, "reply:") {
-			t.Errorf("expected no agent-posted replies (skill owns replies), got: %s", comment)
-		}
-	}
 
 	// Cursor should still advance (to avoid infinite retry loops)
 	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -461,7 +461,7 @@ func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckRebaseNeeded(context.Background())
+	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -496,7 +496,7 @@ func TestCheckConflicts_ReportsDirty(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckConflicts(context.Background())
+	findings := a.checkConflictsWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -598,7 +598,7 @@ func TestCheckRebaseNeeded_Clean(t *testing.T) {
 		Status:     StatusPROpen,
 	}
 
-	findings := a.CheckRebaseNeeded(context.Background())
+	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for clean state, got %d", len(findings))

--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -170,7 +170,6 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 				IssueTitle:   issue.Title,
 				WorktreePath: worktreePath,
 				BranchName:   branchName,
-				CreatedAt:    time.Now(),
 			}
 
 			// Check if a PR already exists for this branch
@@ -244,7 +243,6 @@ func BuildStateFromGitHub(ctx context.Context, gh GitHubClient, cfg Config, clon
 			BranchName:   pr.Head,
 			PRNumber:     prNumber,
 			Status:       StatusPROpen,
-			CreatedAt:    time.Now(),
 		}
 
 		recoverCommentCursors(ctx, gh, cfg, work, prNumber, logger)

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -11,7 +11,7 @@ import (
 // triageLookbackRunLimit is the maximum number of runs to fetch when scanning a lookback window.
 const triageLookbackRunLimit = 50
 
-// triageRunTask pairs a CI source with a run for parallel investigation.
+// triageRunTask pairs a CI source with a failed run queued for investigation.
 type triageRunTask struct {
 	ciSource CIJobSource
 	run      JobRun

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -338,7 +338,7 @@ func (a *Agent) matchExistingTriageIssue(ctx context.Context, jobName, title, an
 	// exact title match and LLM matching to both fail. Since both runs come
 	// from the same workflow/job in the same triage cycle, they should always
 	// group under the same issue.
-	sameJobCycleIssue := findSameJobCycleIssue(jobName, cycleIssues)
+	sameJobCycleIssue := findSameJobIssue(jobName, cycleIssues)
 	if sameJobCycleIssue > 0 {
 		a.logger.Info("same-job cycle dedup: matching to cycle issue created for this job",
 			"issue", sameJobCycleIssue, "job", jobName)
@@ -419,14 +419,6 @@ func (a *Agent) matchExistingTriageIssue(ctx context.Context, jobName, title, an
 	}
 
 	return 0
-}
-
-// findSameJobCycleIssue returns the issue number of a cycle issue that was
-// created for the same job, or 0 if none exists. It matches by checking if
-// the issue title starts with "CI Failure: <jobName>", which is the title
-// format used by investigateTriageRun.
-func findSameJobCycleIssue(jobName string, cycleIssues []Issue) int {
-	return findSameJobIssue(jobName, cycleIssues)
 }
 
 // findSameJobIssue returns the issue number of an issue that tracks the same

--- a/pkg/agent/triage_test.go
+++ b/pkg/agent/triage_test.go
@@ -653,7 +653,7 @@ func TestTriageDedup_DifferentFailuresSameJob_MatchesByJobName(t *testing.T) {
 	}
 }
 
-func TestFindSameJobCycleIssue(t *testing.T) {
+func TestFindSameJobIssue_CycleIssues(t *testing.T) {
 	tests := []struct {
 		name        string
 		jobName     string
@@ -719,9 +719,9 @@ func TestFindSameJobCycleIssue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findSameJobCycleIssue(tt.jobName, tt.cycleIssues)
+			got := findSameJobIssue(tt.jobName, tt.cycleIssues)
 			if got != tt.want {
-				t.Errorf("findSameJobCycleIssue(%q, ...) = %d, want %d", tt.jobName, got, tt.want)
+				t.Errorf("findSameJobIssue(%q, ...) = %d, want %d", tt.jobName, got, tt.want)
 			}
 		})
 	}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -44,24 +44,25 @@ type AgentResult struct {
 }
 
 // IssueWork tracks the state of work on a single issue.
+// State is held in memory only — it is rebuilt from GitHub on startup by
+// BuildStateFromGitHub and never serialized to disk.
 type IssueWork struct {
-	IssueNumber        int             `json:"issueNumber"`
-	IssueTitle         string          `json:"issueTitle"`
-	WorktreePath       string          `json:"worktreePath"`
-	BranchName         string          `json:"branchName"`
-	PRNumber           int             `json:"prNumber"`
-	LastCommentID      int64           `json:"lastCommentID"`
-	LastReviewID       int64           `json:"lastReviewID"`
-	LastIssueCommentID int64           `json:"lastIssueCommentID,omitempty"` // cursor for PR conversation comments (Issues API)
-	Status             string          `json:"status"`                       // implementing, pr-open, failed, done
-	CIFixAttempts      int             `json:"ciFixAttempts"`
-	LastCIStatus       string          `json:"lastCIStatus"`              // "", "pending", "success", "failure"
-	LastCheckedCISHA   string          `json:"lastCheckedCISHA"`          // last commit SHA investigated for CI failures
-	CheckedCIChecks    map[string]bool `json:"checkedCIChecks,omitempty"` // tracks "sha:check" keys investigated (for dedup without comments)
-	ReviewNoOpCount    int             `json:"reviewNoOpCount,omitempty"` // consecutive cycles where reviews produced no push
-	SessionCostUSD     float64         `json:"sessionCostUSD,omitempty"`  // cumulative agent cost for this PR in current session
-	LastRebaseTime     time.Time       `json:"lastRebaseTime"`            // when this PR was last rebased (for min-interval guard)
-	CreatedAt          time.Time       `json:"createdAt"`
+	IssueNumber        int
+	IssueTitle         string
+	WorktreePath       string
+	BranchName         string
+	PRNumber           int
+	LastCommentID      int64
+	LastReviewID       int64
+	LastIssueCommentID int64  // cursor for PR conversation comments (Issues API)
+	Status             string // implementing, pr-open, failed, done
+	CIFixAttempts      int
+	LastCIStatus       string          // "", "pending", "success", "failure"
+	LastCheckedCISHA   string          // last commit SHA investigated for CI failures
+	CheckedCIChecks    map[string]bool // tracks "sha:check" keys investigated (for dedup without comments)
+	ReviewNoOpCount    int             // consecutive cycles where reviews produced no push
+	SessionCostUSD     float64         // cumulative agent cost for this PR in current session
+	LastRebaseTime     time.Time       // when this PR was last rebased (for min-interval guard)
 }
 
 // PRReview represents a GitHub pull request review (approve, request changes, comment).

--- a/pkg/agent/worktree.go
+++ b/pkg/agent/worktree.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-// WorktreeManager manages git worktrees for parallel issue work.
+// WorktreeManager manages git worktrees, one per issue branch.
 type WorktreeManager interface {
 	EnsureRepoCloned(ctx context.Context) error
 	CreateWorktree(ctx context.Context, branchName string) (worktreePath string, err error)


### PR DESCRIPTION
## Summary

Phase 2a of the unslop series (follows #269, #270): pure deletions of dead code and stale comments — verified zero production readers for every removal. Net **-158 lines** with no behavior change. This clears the ground for the upcoming interface/pipeline refactors (2b/2c) so their diffs stay focused.

## Changes

- **Never-called GitHubClient methods**: `RemoveLabel` and `ReplyToPRComment` had zero production callers (per-comment replies were delegated to the coding agent's skill long ago) yet were implemented **five times each** (GoGitHubClient, DryRunGitHubClient, 3 test doubles). Deleted everywhere, including the mock bookkeeping only they wrote and two now-tautological test assertions.
- **`StreamingRunner.RunStream`**: zero callers anywhere, including tests.
- **`Agent.CheckRebaseNeeded`/`CheckConflicts`**: exported wrappers called only by tests; production uses the `*WithStates` variants. Tests retargeted to the production entry points.
- **`IssueWork.CreatedAt`**: written in five places, read nowhere.
- **`IssueWork` JSON tags**: no (de)serialization of state exists anywhere — fossils of a removed persistence layer (state is rebuilt from GitHub, per AGENTS.md).
- **`%b---` git-log sentinel** in `buildPRBody`: nothing ever split on it, so literal `---` horizontal rules leaked into every fallback PR description.
- **`isConventionalCommitTitle` + regex**: only its own test called it. **`findSameJobCycleIssue`**: pure rename-wrapper, inlined.
- **Dead stream-parser fields**: claude `Subtype`/`DurationAPIMs`; opencode `Timestamp`/`SessionID`/`Part.Time` (+`opencodeTime` type)/`Tokens.Reasoning`/`Tokens.Cache`/`ToolState.Output`/`ToolState.Input` — never read after decoding (encoding/json ignores unknown keys).
- **Stale comments**: 'parallel execution' fossils from the removed parallel design; 'Claude' in agent-agnostic logs/comments (opencode-backed runs logged 'claude finished but produced no commits'); `"pr-open"` literal → `StatusPROpen`.
- **Log-only no-op blocks**: four `if a.ShouldSkipComment(...) { log }` blocks in the `classifyCI*` handlers had no behavioral effect — the real gate lives in `postConsolidatedCIComment`. Leftovers from the pre-consolidation per-classifier commenting design.

## Testing

- [x] `go test ./...` passes (incl. `-race` and e2e)
- [x] `go vet ./...` / `golangci-lint run` / `golangci-lint fmt --diff` clean
- [x] Every deletion preceded by a grep verifying zero production references

## Related Issues

Part of the unslop/refactoring series (phase 2a of ~5). Follows #269, #270.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated CI, conflict-resolution, issue, and review progress messages with clearer scan and coding-agent phase labels.
  * Consolidated CI comment handling to reduce redundant category-specific processing messages.
  * Improved triage matching for repeated failures associated with the same job.
  * Simplified event and state handling to provide more consistent processing across agent workflows.
* **Refactor**
  * Removed unused GitHub actions and report-only interfaces that are no longer part of supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->