### PR TITLE
refactor: phase 2b unslop — honest interfaces and one backend invoker

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -12,38 +12,42 @@ type CodeAgent interface {
 		logger *slog.Logger, resume bool) (AgentResult, error)
 }
 
-// ClaudeCodeAgent implements CodeAgent for Claude Code CLI.
-type ClaudeCodeAgent struct{}
+// cliAgentSpec describes how to invoke and parse one CLI coding agent backend.
+// The invocation flow is identical for every backend (stream when possible,
+// pipe the prompt via stdin, salvage cost on failure); only the binary, its
+// arguments, the per-line log decoder, and the result parser differ.
+type cliAgentSpec struct {
+	binary  string
+	args    []string
+	logLine func(logger *slog.Logger, line []byte)
+	parse   func(stdout []byte) (AgentResult, error)
+}
 
-// Run invokes Claude Code in headless mode with streaming output and parses the result.
-// If resume is true, --continue is passed to resume the most recent session in workDir.
-// The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
-// On invocation failure the partial stream output is still parsed so any cost
-// it reports can be billed against session budgets alongside the error.
-func (c *ClaudeCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
-	logger *slog.Logger, resume bool) (AgentResult, error) {
-	args := []string{"-p", "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions"}
-	if resume {
-		args = append(args, "--continue")
-	}
-
+// runCLIAgent invokes a CLI coding agent backend described by spec.
+// The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for
+// large prompts. Output is streamed line-by-line to the logger when the
+// runner supports it. On invocation failure the partial output is still
+// parsed so any cost it reports can be billed against session budgets
+// alongside the error (cost-only: result text never propagates on failure).
+func runCLIAgent(ctx context.Context, runner CommandRunner, workDir, prompt string,
+	logger *slog.Logger, spec cliAgentSpec) (AgentResult, error) {
 	var stdout, stderr []byte
 	var err error
 
 	if sr, ok := runner.(StreamingRunner); ok && logger != nil {
 		stdout, stderr, err = sr.RunStreamWithStdin(ctx, workDir, prompt, func(line []byte) {
-			logStreamEvent(logger, line)
-		}, "claude", args...)
+			spec.logLine(logger, line)
+		}, spec.binary, spec.args...)
 	} else {
-		stdout, stderr, err = runner.RunWithStdin(ctx, workDir, prompt, "claude", args...)
+		stdout, stderr, err = runner.RunWithStdin(ctx, workDir, prompt, spec.binary, spec.args...)
 	}
 
 	if err != nil {
-		// Best-effort cost salvage: a run that failed after emitting its
-		// result event still consumed tokens.
-		salvaged, _ := parseStreamResult(stdout)
-		return AgentResult{CostUSD: salvaged.CostUSD}, fmt.Errorf("claude invocation failed: %w (stderr: %s)", err, string(stderr))
+		// Best-effort cost salvage: failed runs still bill the tokens they
+		// consumed before dying.
+		salvaged, _ := spec.parse(stdout)
+		return AgentResult{CostUSD: salvaged.CostUSD}, fmt.Errorf("%s invocation failed: %w (stderr: %s)", spec.binary, err, string(stderr))
 	}
 
-	return parseStreamResult(stdout)
+	return spec.parse(stdout)
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -31,10 +31,16 @@ type cliAgentSpec struct {
 // alongside the error (cost-only: result text never propagates on failure).
 func runCLIAgent(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, spec cliAgentSpec) (AgentResult, error) {
+	// Guard against malformed specs: a nil parser makes the invocation
+	// meaningless, and panicking would take down the whole daemon.
+	if spec.parse == nil {
+		return AgentResult{}, fmt.Errorf("cli agent spec for %q has no parser", spec.binary)
+	}
+
 	var stdout, stderr []byte
 	var err error
 
-	if sr, ok := runner.(StreamingRunner); ok && logger != nil {
+	if sr, ok := runner.(StreamingRunner); ok && logger != nil && spec.logLine != nil {
 		stdout, stderr, err = sr.RunStreamWithStdin(ctx, workDir, prompt, func(line []byte) {
 			spec.logLine(logger, line)
 		}, spec.binary, spec.args...)

--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -174,6 +174,9 @@ func parseDirectGCSURL(jobURL string) (CIJobSource, error) {
 // parseGitHubActionsURL parses a GitHub Actions workflow URL like:
 // https://github.com/nmstate/kubernetes-nmstate/actions/workflows/nightly.yml
 func parseGitHubActionsURL(jobURL string, ghClient GitHubClient, lookback time.Duration) (CIJobSource, error) {
+	if ghClient == nil {
+		return nil, fmt.Errorf("github client is required for GitHub Actions job source: %s", jobURL)
+	}
 	// Regex: github.com/{owner}/{repo}/actions/workflows/{workflow}
 	re := regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/actions/workflows/([^/?#]+)`)
 	matches := re.FindStringSubmatch(jobURL)

--- a/pkg/agent/cisource.go
+++ b/pkg/agent/cisource.go
@@ -25,10 +25,16 @@ type CIJobSource interface {
 
 	// JobName returns the human-readable job name.
 	JobName() string
+
+	// RunLabel returns the human label for a failed run of this source in
+	// reports: "lane" for matrix-lane sources, "triage job" otherwise.
+	RunLabel() string
 }
 
 // ParseCIJobURL determines the CI backend from the URL and returns a CIJobSource.
-func ParseCIJobURL(jobURL string, ghClient GitHubClient) (CIJobSource, error) {
+// lookback bounds how far back run listing scans for sources that support
+// server-side time filtering (GitHub Actions); GCS-backed sources ignore it.
+func ParseCIJobURL(jobURL string, ghClient GitHubClient, lookback time.Duration) (CIJobSource, error) {
 	// GCS-backed CI: any URL containing /view/gs/{bucket}/{prefix}
 	if strings.Contains(jobURL, "/view/gs/") {
 		bucket, prefix := extractBucketPrefix(jobURL)
@@ -49,7 +55,7 @@ func ParseCIJobURL(jobURL string, ghClient GitHubClient) (CIJobSource, error) {
 
 	// GitHub Actions: github.com/{owner}/{repo}/actions/workflows/{workflow}
 	if strings.Contains(jobURL, "github.com/") && strings.Contains(jobURL, "/actions/workflows/") {
-		return parseGitHubActionsURL(jobURL, ghClient)
+		return parseGitHubActionsURL(jobURL, ghClient, lookback)
 	}
 
 	return nil, fmt.Errorf("unrecognized CI job URL format: %s", jobURL)
@@ -167,7 +173,7 @@ func parseDirectGCSURL(jobURL string) (CIJobSource, error) {
 
 // parseGitHubActionsURL parses a GitHub Actions workflow URL like:
 // https://github.com/nmstate/kubernetes-nmstate/actions/workflows/nightly.yml
-func parseGitHubActionsURL(jobURL string, ghClient GitHubClient) (CIJobSource, error) {
+func parseGitHubActionsURL(jobURL string, ghClient GitHubClient, lookback time.Duration) (CIJobSource, error) {
 	// Regex: github.com/{owner}/{repo}/actions/workflows/{workflow}
 	re := regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/actions/workflows/([^/?#]+)`)
 	matches := re.FindStringSubmatch(jobURL)
@@ -185,6 +191,7 @@ func parseGitHubActionsURL(jobURL string, ghClient GitHubClient) (CIJobSource, e
 		workflow: workflow,
 		jobName:  fmt.Sprintf("%s/%s/%s", owner, repo, workflow),
 		gh:       ghClient,
+		lookback: lookback,
 	}, nil
 }
 
@@ -195,6 +202,8 @@ type GCSJobSource struct {
 	jobName string
 	client  *http.Client
 }
+
+func (g *GCSJobSource) RunLabel() string { return "triage job" }
 
 func (g *GCSJobSource) JobName() string {
 	return g.jobName
@@ -402,6 +411,8 @@ func newGCSDirectoryJobSource(bucket, prefix string) (*GCSDirectoryJobSource, er
 		resolvedRuns: make(map[string]gcsRef),
 	}, nil
 }
+
+func (g *GCSDirectoryJobSource) RunLabel() string { return "triage job" }
 
 func (g *GCSDirectoryJobSource) JobName() string {
 	return g.jobName
@@ -679,6 +690,15 @@ type GitHubActionsJobSource struct {
 	lanePatterns []string         // optional: glob patterns for matrix job names (lane-level filtering)
 	matchedJobs  map[string]int64 // runID → matched job ID (populated by ListRecentRuns for lane-level log fetch)
 	lookback     time.Duration    // optional: lookback window for filtering runs
+}
+
+// RunLabel distinguishes matrix-lane sources from whole-workflow sources in
+// report wording.
+func (g *GitHubActionsJobSource) RunLabel() string {
+	if len(g.lanePatterns) > 0 {
+		return "lane"
+	}
+	return "triage job"
 }
 
 func (g *GitHubActionsJobSource) JobName() string {

--- a/pkg/agent/cisource_test.go
+++ b/pkg/agent/cisource_test.go
@@ -105,7 +105,7 @@ func TestParseGitHubActionsURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			source, err := parseGitHubActionsURL(tc.url, mockGH)
+			source, err := parseGitHubActionsURL(tc.url, mockGH, 0)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -170,7 +170,7 @@ func TestParseGCSDirectoryURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			source, err := ParseCIJobURL(tc.url, nil)
+			source, err := ParseCIJobURL(tc.url, nil, 0)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -214,7 +214,7 @@ func TestParseGCSDirectoryURL_DetectedByParseCIJobURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			source, err := ParseCIJobURL(tc.url, nil)
+			source, err := ParseCIJobURL(tc.url, nil, 0)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -226,7 +226,7 @@ func TestParseGCSDirectoryURL_DetectedByParseCIJobURL(t *testing.T) {
 
 	// Non-directory GCS URLs should still route to GCSJobSource
 	nonDirURL := "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-job/"
-	source, err := ParseCIJobURL(nonDirURL, nil)
+	source, err := ParseCIJobURL(nonDirURL, nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error for non-directory URL: %v", err)
 	}

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -1,145 +1,32 @@
 package agent
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
-	"strings"
-	"sync"
+	"unicode/utf8"
 )
 
-const (
-	// scannerInitBufSize is the initial buffer size for the bufio.Scanner
-	// used when streaming command output (64 KB).
-	scannerInitBufSize = 64 * 1024
-	// scannerMaxBufSize is the maximum buffer size the scanner will grow to
-	// when reading long lines from command output (10 MB).
-	scannerMaxBufSize = 10 * 1024 * 1024
-)
+// ClaudeCodeAgent implements CodeAgent for Claude Code CLI.
+type ClaudeCodeAgent struct{}
 
-// CommandRunner executes external commands.
-type CommandRunner interface {
-	Run(ctx context.Context, workDir string, name string, args ...string) (stdout []byte, stderr []byte, err error)
-	RunWithStdin(ctx context.Context, workDir string, stdin string, name string, args ...string) (stdout []byte, stderr []byte, err error)
-}
-
-// StreamingRunner extends CommandRunner with line-by-line stdout streaming.
-type StreamingRunner interface {
-	CommandRunner
-	RunStreamWithStdin(ctx context.Context, workDir string, stdin string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
-}
-
-// ExecRunner is the concrete CommandRunner using os/exec.
-type ExecRunner struct {
-	// Env holds additional environment variables to set on commands.
-	Env []string
-	mu  sync.RWMutex // protects Env
-}
-
-// SetGHToken updates the GH_TOKEN environment variable in a thread-safe manner.
-func (r *ExecRunner) SetGHToken(token string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Update existing GH_TOKEN or append if not found
-	ghTokenKey := "GH_TOKEN="
-	found := false
-	for i, env := range r.Env {
-		if len(env) >= len(ghTokenKey) && env[:len(ghTokenKey)] == ghTokenKey {
-			r.Env[i] = ghTokenKey + token
-			found = true
-			break
-		}
+// Run invokes Claude Code in headless mode with streaming output and parses
+// the result. If resume is true, --continue resumes the most recent session
+// in workDir. See runCLIAgent for the shared invocation semantics.
+func (c *ClaudeCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
+	logger *slog.Logger, resume bool) (AgentResult, error) {
+	args := []string{"-p", "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions"}
+	if resume {
+		args = append(args, "--continue")
 	}
-	if !found {
-		r.Env = append(r.Env, ghTokenKey+token)
-	}
-}
-
-func (r *ExecRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = workDir
-	r.mu.RLock()
-	if len(r.Env) > 0 {
-		cmd.Env = append(cmd.Environ(), r.Env...)
-	}
-	r.mu.RUnlock()
-
-	stdout, err = cmd.Output()
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		stderr = exitErr.Stderr
-	}
-	return stdout, stderr, err
-}
-
-func (r *ExecRunner) RunWithStdin(ctx context.Context, workDir, stdin, name string, args ...string) (stdout, stderr []byte, err error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = workDir
-	if stdin != "" {
-		cmd.Stdin = strings.NewReader(stdin)
-	}
-	r.mu.RLock()
-	if len(r.Env) > 0 {
-		cmd.Env = append(cmd.Environ(), r.Env...)
-	}
-	r.mu.RUnlock()
-
-	stdout, err = cmd.Output()
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		stderr = exitErr.Stderr
-	}
-	return stdout, stderr, err
-}
-
-func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = workDir
-	if stdin != "" {
-		cmd.Stdin = strings.NewReader(stdin)
-	}
-	r.mu.RLock()
-	if len(r.Env) > 0 {
-		cmd.Env = append(cmd.Environ(), r.Env...)
-	}
-	r.mu.RUnlock()
-
-	pipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
-
-	if err := cmd.Start(); err != nil {
-		return nil, nil, err
-	}
-
-	var stdoutBuf bytes.Buffer
-	scanner := bufio.NewScanner(pipe)
-	scanner.Buffer(make([]byte, 0, scannerInitBufSize), scannerMaxBufSize)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		stdoutBuf.Write(line)
-		stdoutBuf.WriteByte('\n')
-		if onLine != nil {
-			onLine(append([]byte{}, line...))
-		}
-	}
-	scanErr := scanner.Err()
-
-	// Always call Wait to release child process resources and avoid zombies.
-	waitErr := cmd.Wait()
-
-	// Prefer the scanner error if present -- it describes the read failure.
-	if scanErr != nil {
-		return stdoutBuf.Bytes(), stderrBuf.Bytes(), scanErr
-	}
-	return stdoutBuf.Bytes(), stderrBuf.Bytes(), waitErr
+	return runCLIAgent(ctx, runner, workDir, prompt, logger, cliAgentSpec{
+		binary:  "claude",
+		args:    args,
+		logLine: logStreamEvent,
+		parse:   parseStreamResult,
+	})
 }
 
 // streamEvent represents a single event in Claude's stream-json output.
@@ -164,6 +51,21 @@ type streamContent struct {
 	Name string `json:"name,omitempty"` // for tool_use
 }
 
+// logPreviewLen caps agent text output in debug logs.
+const logPreviewLen = 200
+
+// previewText truncates s for log output without splitting a UTF-8 sequence.
+func previewText(s string) string {
+	if len(s) <= logPreviewLen {
+		return s
+	}
+	cut := logPreviewLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "..."
+}
+
 // logStreamEvent logs a stream-json event at appropriate levels.
 func logStreamEvent(logger *slog.Logger, line []byte) {
 	var event streamEvent
@@ -181,11 +83,7 @@ func logStreamEvent(logger *slog.Logger, line []byte) {
 			case "tool_use":
 				logger.Debug("claude using tool", "tool", c.Name)
 			case "text":
-				text := c.Text
-				if len(text) > 200 {
-					text = text[:200] + "..."
-				}
-				logger.Debug("claude", "text", text)
+				logger.Debug("claude", "text", previewText(c.Text))
 			}
 		}
 	case "result":
@@ -221,25 +119,4 @@ func parseStreamResult(stdout []byte) (AgentResult, error) {
 		}
 	}
 	return AgentResult{}, fmt.Errorf("no result event found in stream output (stdout: %s)", string(stdout))
-}
-
-// BuildAgentEnv builds the environment variable slice for agent invocations.
-// Only passes through git identity; other variables (like GH_TOKEN) are
-// inherited from the system environment. This allows subprocesses to use
-// system-level authentication or credential helpers (e.g. gh auth git-credential).
-func BuildAgentEnv(cfg Config) []string {
-	var env []string
-	if cfg.GitAuthorName != "" {
-		env = append(env,
-			fmt.Sprintf("GIT_AUTHOR_NAME=%s", cfg.GitAuthorName),
-			fmt.Sprintf("GIT_COMMITTER_NAME=%s", cfg.GitAuthorName),
-		)
-	}
-	if cfg.GitAuthorEmail != "" {
-		env = append(env,
-			fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", cfg.GitAuthorEmail),
-			fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", cfg.GitAuthorEmail),
-		)
-	}
-	return env
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -529,26 +529,17 @@ func (a *Agent) markCIChecked(work *IssueWork, sha, checkName string) {
 
 // originDefaultBranch returns "origin/<default-branch>" (e.g. "origin/main", "origin/master").
 func (a *Agent) originDefaultBranch() string {
-	if wtm, ok := a.worktrees.(*GitWorktreeManager); ok {
-		return wtm.OriginDefaultBranch()
-	}
-	return "origin/main"
+	return a.worktrees.OriginDefaultBranch()
 }
 
 // defaultBranch returns the default branch name (e.g. "main", "master").
 func (a *Agent) defaultBranch() string {
-	if wtm, ok := a.worktrees.(*GitWorktreeManager); ok {
-		return wtm.DefaultBranch()
-	}
-	return "main"
+	return a.worktrees.DefaultBranch()
 }
 
 // pushRemote returns the name of the push remote (e.g. "origin", "fork").
 func (a *Agent) pushRemote() string {
-	if wtm, ok := a.worktrees.(*GitWorktreeManager); ok {
-		return wtm.PushRemote()
-	}
-	return "origin"
+	return a.worktrees.PushRemote()
 }
 
 // issueAssignedTo returns true if the given user is among the issue's assignees.

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -86,6 +86,12 @@ func (a *Agent) SetTokenFunc(fn func(context.Context) (string, error)) {
 	a.tokenFunc = fn
 }
 
+// tokenSettingRunner is the optional capability a CommandRunner implements to
+// receive refreshed GitHub tokens for its subprocess environment.
+type tokenSettingRunner interface {
+	SetGHToken(token string)
+}
+
 // RefreshToken updates the GitHub token if a token function is set.
 // Call this before each poll cycle to ensure the token is fresh.
 // The fresh token is propagated to subprocesses via the runner's
@@ -101,8 +107,8 @@ func (a *Agent) RefreshToken(ctx context.Context) error {
 	}
 
 	// Update the runner's GH_TOKEN environment variable
-	if execRunner, ok := a.runner.(*ExecRunner); ok {
-		execRunner.SetGHToken(token)
+	if r, ok := a.runner.(tokenSettingRunner); ok {
+		r.SetGHToken(token)
 	}
 
 	return nil

--- a/pkg/agent/mocks_test.go
+++ b/pkg/agent/mocks_test.go
@@ -257,6 +257,12 @@ func (m *mockWorktreeManager) RemoveWorktree(_ context.Context, worktreePath str
 	return nil
 }
 
+func (m *mockWorktreeManager) DefaultBranch() string { return "main" }
+
+func (m *mockWorktreeManager) OriginDefaultBranch() string { return "origin/main" }
+
+func (m *mockWorktreeManager) PushRemote() string { return "origin" }
+
 func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt *mockWorktreeManager) *Agent {
 	return &Agent{
 		gh:        gh,

--- a/pkg/agent/opencode.go
+++ b/pkg/agent/opencode.go
@@ -68,11 +68,7 @@ func logOpencodeEvent(logger *slog.Logger, line []byte) {
 			logger.Debug("opencode using tool", "tool", event.Part.Tool, "status", status)
 		}
 	case "text":
-		text := event.Part.Text
-		if len(text) > 200 {
-			text = text[:200] + "..."
-		}
-		if text != "" {
+		if text := previewText(event.Part.Text); text != "" {
 			logger.Debug("opencode", "text", text)
 		}
 	case "step_finish":
@@ -163,11 +159,8 @@ func parseOpencodeResult(stdout []byte) (AgentResult, error) {
 }
 
 // Run invokes OpenCode CLI with JSON output and parses the result.
-// If resume is true, --continue is passed to resume the most recent session in workDir.
-// The prompt is passed via stdin to avoid hitting the OS ARG_MAX limit for large prompts.
-// On invocation failure the partial stream output is still parsed so any cost
-// it reports (OpenCode bills per step) can be billed against session budgets
-// alongside the error.
+// If resume is true, --continue resumes the most recent session in workDir.
+// See runCLIAgent for the shared invocation semantics.
 func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, prompt string,
 	logger *slog.Logger, resume bool) (AgentResult, error) {
 	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
@@ -177,24 +170,10 @@ func (o *OpenCodeAgent) Run(ctx context.Context, runner CommandRunner, workDir, 
 	if o.Model != "" {
 		args = append(args, "--model", o.Model)
 	}
-
-	var stdout, stderr []byte
-	var err error
-
-	if sr, ok := runner.(StreamingRunner); ok && logger != nil {
-		stdout, stderr, err = sr.RunStreamWithStdin(ctx, workDir, prompt, func(line []byte) {
-			logOpencodeEvent(logger, line)
-		}, "opencode", args...)
-	} else {
-		stdout, stderr, err = runner.RunWithStdin(ctx, workDir, prompt, "opencode", args...)
-	}
-
-	if err != nil {
-		// Best-effort cost salvage: sum the step costs emitted before the
-		// failure — the failed run still billed those steps.
-		salvaged, _ := parseOpencodeResult(stdout)
-		return AgentResult{CostUSD: salvaged.CostUSD}, fmt.Errorf("opencode invocation failed: %w (stderr: %s)", err, string(stderr))
-	}
-
-	return parseOpencodeResult(stdout)
+	return runCLIAgent(ctx, runner, workDir, prompt, logger, cliAgentSpec{
+		binary:  "opencode",
+		args:    args,
+		logLine: logOpencodeEvent,
+		parse:   parseOpencodeResult,
+	})
 }

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+const (
+	// scannerInitBufSize is the initial buffer size for the bufio.Scanner
+	// used when streaming command output (64 KB).
+	scannerInitBufSize = 64 * 1024
+	// scannerMaxBufSize is the maximum buffer size the scanner will grow to
+	// when reading long lines from command output (10 MB).
+	scannerMaxBufSize = 10 * 1024 * 1024
+)
+
+// CommandRunner executes external commands.
+type CommandRunner interface {
+	Run(ctx context.Context, workDir string, name string, args ...string) (stdout []byte, stderr []byte, err error)
+	RunWithStdin(ctx context.Context, workDir string, stdin string, name string, args ...string) (stdout []byte, stderr []byte, err error)
+}
+
+// StreamingRunner extends CommandRunner with line-by-line stdout streaming.
+type StreamingRunner interface {
+	CommandRunner
+	RunStreamWithStdin(ctx context.Context, workDir string, stdin string, onLine func(line []byte), name string, args ...string) (stdout []byte, stderr []byte, err error)
+}
+
+// ExecRunner is the concrete CommandRunner using os/exec.
+type ExecRunner struct {
+	// Env holds additional environment variables to set on commands.
+	Env []string
+	mu  sync.RWMutex // protects Env
+}
+
+// SetGHToken updates the GH_TOKEN environment variable in a thread-safe manner.
+func (r *ExecRunner) SetGHToken(token string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Update existing GH_TOKEN or append if not found
+	const ghTokenKey = "GH_TOKEN="
+	for i, env := range r.Env {
+		if strings.HasPrefix(env, ghTokenKey) {
+			r.Env[i] = ghTokenKey + token
+			return
+		}
+	}
+	r.Env = append(r.Env, ghTokenKey+token)
+}
+
+// command builds an exec.Cmd with the runner's env overlay applied.
+// Runner-level variables are appended after the process environment;
+// os/exec documents last-wins semantics for duplicate keys, so overlay
+// values (e.g. refreshed GH_TOKEN) shadow inherited ones.
+func (r *ExecRunner) command(ctx context.Context, workDir, stdin, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = workDir
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	r.mu.RLock()
+	if len(r.Env) > 0 {
+		cmd.Env = append(cmd.Environ(), r.Env...)
+	}
+	r.mu.RUnlock()
+	return cmd
+}
+
+func (r *ExecRunner) Run(ctx context.Context, workDir, name string, args ...string) (stdout, stderr []byte, err error) {
+	return r.RunWithStdin(ctx, workDir, "", name, args...)
+}
+
+func (r *ExecRunner) RunWithStdin(ctx context.Context, workDir, stdin, name string, args ...string) (stdout, stderr []byte, err error) {
+	cmd := r.command(ctx, workDir, stdin, name, args...)
+	stdout, err = cmd.Output()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = exitErr.Stderr
+	}
+	return stdout, stderr, err
+}
+
+func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin string, onLine func(line []byte), name string, args ...string) (stdout, stderr []byte, err error) {
+	cmd := r.command(ctx, workDir, stdin, name, args...)
+
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	var stdoutBuf bytes.Buffer
+	scanner := bufio.NewScanner(pipe)
+	scanner.Buffer(make([]byte, 0, scannerInitBufSize), scannerMaxBufSize)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		stdoutBuf.Write(line)
+		stdoutBuf.WriteByte('\n')
+		if onLine != nil {
+			onLine(append([]byte{}, line...))
+		}
+	}
+	scanErr := scanner.Err()
+
+	// Always call Wait to release child process resources and avoid zombies.
+	waitErr := cmd.Wait()
+
+	// Prefer the scanner error if present -- it describes the read failure.
+	if scanErr != nil {
+		return stdoutBuf.Bytes(), stderrBuf.Bytes(), scanErr
+	}
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), waitErr
+}
+
+// BuildAgentEnv builds the environment variable slice for agent invocations.
+// Only passes through git identity; other variables (like GH_TOKEN) are
+// inherited from the system environment. This allows subprocesses to use
+// system-level authentication or credential helpers (e.g. gh auth git-credential).
+func BuildAgentEnv(cfg Config) []string {
+	var env []string
+	if cfg.GitAuthorName != "" {
+		env = append(env,
+			fmt.Sprintf("GIT_AUTHOR_NAME=%s", cfg.GitAuthorName),
+			fmt.Sprintf("GIT_COMMITTER_NAME=%s", cfg.GitAuthorName),
+		)
+	}
+	if cfg.GitAuthorEmail != "" {
+		env = append(env,
+			fmt.Sprintf("GIT_AUTHOR_EMAIL=%s", cfg.GitAuthorEmail),
+			fmt.Sprintf("GIT_COMMITTER_EMAIL=%s", cfg.GitAuthorEmail),
+		)
+	}
+	return env
+}

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -113,6 +113,12 @@ func (r *ExecRunner) RunStreamWithStdin(ctx context.Context, workDir, stdin stri
 	}
 	scanErr := scanner.Err()
 
+	// Close the pipe before Wait: if the scanner stopped early (e.g. a line
+	// exceeded the buffer cap), unread output could block the child forever,
+	// and Wait must not be called until reads complete or the pipe is closed.
+	// After a normal EOF this is a harmless no-op.
+	pipe.Close() //nolint:errcheck,gosec // best-effort unblock before Wait
+
 	// Always call Wait to release child process resources and avoid zombies.
 	waitErr := cmd.Wait()
 

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -410,10 +410,11 @@ func TestCheckCIStatus_ReportsFailures(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -449,10 +450,11 @@ func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -484,10 +486,11 @@ func TestCheckConflicts_ReportsDirty(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -522,10 +525,11 @@ func TestCheckNewReviews_ReportsComments(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -560,10 +564,11 @@ func TestCheckCIStatus_NoFailures(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -586,10 +591,11 @@ func TestCheckRebaseNeeded_Clean(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -1288,10 +1294,11 @@ func TestCheckCIStatus_FiltersStaleFailures(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -1324,10 +1331,11 @@ func TestCheckCIStatus_IncludesFailuresWithZeroCompletedAt(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -1357,10 +1365,11 @@ func TestCheckNewReviews_FiltersStaleComments(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -1391,10 +1400,11 @@ func TestCheckNewReviews_IncludesCommentsWithZeroCreatedAt(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
@@ -1628,10 +1638,11 @@ func TestCheckNewReviews_AllStaleNoFindings(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	a := &Agent{
-		gh:     gh,
-		cfg:    Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:  NewState(),
-		logger: logger,
+		gh:        gh,
+		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
+		state:     NewState(),
+		worktrees: &mockWorktreeManager{},
+		logger:    logger,
 	}
 
 	a.state.ActiveIssues["org/repo#100"] = &IssueWork{

--- a/pkg/agent/triage.go
+++ b/pkg/agent/triage.go
@@ -32,13 +32,10 @@ func (a *Agent) ProcessTriageJobs(ctx context.Context) {
 	for _, jobURL := range a.cfg.TriageJobs {
 		a.logger.Debug("processing triage job", "url", jobURL)
 
-		ciSource, err := ParseCIJobURL(jobURL, a.gh)
+		ciSource, err := ParseCIJobURL(jobURL, a.gh, a.cfg.TriageLookback)
 		if err != nil {
 			a.logger.Error("failed to parse CI job URL", "url", jobURL, "error", err)
 			continue
-		}
-		if ghaSource, ok := ciSource.(*GitHubActionsJobSource); ok {
-			ghaSource.lookback = a.cfg.TriageLookback
 		}
 		ciSources = append(ciSources, ciSource)
 	}
@@ -278,12 +275,7 @@ func (a *Agent) investigateTriageRun(ctx context.Context, ciSource CIJobSource, 
 	if a.SlackEnabled() {
 		failureSig := extractFailureSignature(analysis)
 
-		// Vary wording: "lane" for matrix job sources with lane patterns,
-		// "triage job" for standalone CI jobs (including workflow-level GHA)
-		label := "triage job"
-		if gha, ok := ciSource.(*GitHubActionsJobSource); ok && len(gha.lanePatterns) > 0 {
-			label = "lane"
-		}
+		label := ciSource.RunLabel()
 
 		var msg string
 		if failureSig != "" {

--- a/pkg/agent/worktree.go
+++ b/pkg/agent/worktree.go
@@ -15,6 +15,13 @@ type WorktreeManager interface {
 	CreateWorktree(ctx context.Context, branchName string) (worktreePath string, err error)
 	RemoveWorktree(ctx context.Context, worktreePath string) error
 	SyncWorktree(ctx context.Context, worktreePath string) error
+	// DefaultBranch returns the default branch name of the upstream repo
+	// (e.g. "main", "master").
+	DefaultBranch() string
+	// OriginDefaultBranch returns "origin/<default-branch>".
+	OriginDefaultBranch() string
+	// PushRemote returns the git remote name to push to ("fork" or "origin").
+	PushRemote() string
 }
 
 // GitWorktreeManager implements WorktreeManager using git commands.

--- a/pkg/agent/worktree.go
+++ b/pkg/agent/worktree.go
@@ -16,7 +16,9 @@ type WorktreeManager interface {
 	RemoveWorktree(ctx context.Context, worktreePath string) error
 	SyncWorktree(ctx context.Context, worktreePath string) error
 	// DefaultBranch returns the default branch name of the upstream repo
-	// (e.g. "main", "master").
+	// (e.g. "main", "master"). Implementations that detect the branch
+	// lazily may return "main" as a fallback until detection has run
+	// (for GitWorktreeManager, during EnsureRepoCloned).
 	DefaultBranch() string
 	// OriginDefaultBranch returns "origin/<default-branch>".
 	OriginDefaultBranch() string


### PR DESCRIPTION
## Summary

Phase 2b of the unslop series (follows #269–#271): kills the type-assertion escape hatches that defeated the package's interfaces, and collapses the two copy-pasted CLI-backend invocation flows into one. No behavior change intended; one class of silent failure becomes loud (see below).

## Changes

- **`WorktreeManager` widened** with `DefaultBranch`/`OriginDefaultBranch`/`PushRemote`: the Agent helpers previously reached these via `.(*GitWorktreeManager)` assertions with silent `"main"`/`"origin/main"`/`"origin"` fallbacks — every mock silently got main-branch semantics, and a missing manager was indistinguishable from a master-default repo. Now direct interface calls with no fallback; mocks implement the accessors explicitly; test `Agent` literals that relied on the fallback now declare their manager (missing dependency ⇒ loud panic instead of silently wrong git ranges).
- **`RefreshToken`** asserts a narrow `tokenSettingRunner` capability instead of the concrete `*ExecRunner`.
- **`CIJobSource` leak fixed**: the triage loop asserted `*GitHubActionsJobSource` twice — to mutate the unexported `lookback` after construction, and to read `lanePatterns` for Slack wording. Lookback is now a `ParseCIJobURL` constructor parameter (GCS sources ignore it); wording comes from a new `CIJobSource.RunLabel()` implemented per source.
- **One CLI-agent invoker**: both backends duplicated the full invocation flow (streaming assert → per-line log decode → stdin fallback → cost salvage → stderr-wrapped error). Now a single `runCLIAgent` driven by a per-backend spec `{binary, args, log decoder, parser}`.
- **Files match their names**: runner infrastructure (`CommandRunner`/`ExecRunner`/`BuildAgentEnv`) moves from `claude.go` to new `runner.go`; `ClaudeCodeAgent` moves from `agent.go` to `claude.go`; `agent.go` holds the interface + invoker. `ExecRunner.Run` now delegates to `RunWithStdin`; env-overlay construction is one helper with the last-wins semantics documented.
- The 200-byte log preview truncation existed in both backends as raw byte slicing that could split UTF-8; now one rune-safe `previewText` helper.

## Testing

- [x] `go test ./...` passes (incl. `-race` and e2e)
- [x] `go vet ./...` / `golangci-lint run` / `golangci-lint fmt --diff` clean

## Related Issues

Part of the unslop/refactoring series (phase 2b of ~5). Follows #269, #270, #271.
