### PR TITLE
test: phase 3a unslop — one way to build a test agent

### DIFF
--- a/pkg/agent/ci_test.go
+++ b/pkg/agent/ci_test.go
@@ -565,12 +565,7 @@ func TestProcessCIFailures_FixesFailingCI(t *testing.T) {
 
 	agent.ProcessCIFailures(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
@@ -714,8 +709,8 @@ func TestProcessCIFailures_NoRunsThenFailuresAreInvestigated(t *testing.T) {
 	if work.LastCheckedCISHA != "" {
 		t.Fatalf("poll 1: expected LastCheckedCISHA empty, got %q", work.LastCheckedCISHA)
 	}
-	if countClaudeCalls(runner.calls) != 0 {
-		t.Fatalf("poll 1: expected 0 claude calls, got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Fatalf("poll 1: expected 0 claude calls, got %d", countCalls(runner.calls, "claude"))
 	}
 
 	// Poll 2: CI runs now registered with a failure
@@ -723,8 +718,8 @@ func TestProcessCIFailures_NoRunsThenFailuresAreInvestigated(t *testing.T) {
 		{ID: 1, Name: "test", Status: "completed", Conclusion: "failure", Output: "tests failed"},
 	}
 	agent.ProcessCIFailures(context.Background())
-	if countClaudeCalls(runner.calls) != 1 {
-		t.Errorf("poll 2: expected 1 claude call, got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 1 {
+		t.Errorf("poll 2: expected 1 claude call, got %d", countCalls(runner.calls, "claude"))
 	}
 }
 
@@ -1239,7 +1234,7 @@ func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
 	}
 
 	// Only 1 claude call (CI investigation), NOT 2 (CI + matching)
-	claudeCalls := countClaudeCalls(runner.calls)
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call (CI investigation only, no LLM matching), got %d", claudeCalls)
 	}
@@ -1640,16 +1635,16 @@ func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
 
 	// First call: should skip because LastCheckedCISHA matches current HEAD (abc1234)
 	agent.ProcessCIFailures(context.Background())
-	if countClaudeCalls(runner.calls) != 0 {
-		t.Errorf("expected 0 claude calls (same SHA), got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Errorf("expected 0 claude calls (same SHA), got %d", countCalls(runner.calls, "claude"))
 	}
 
 	// Second call: new commit def5678 pushed (e.g., by a human after rebase)
 	// Even though there's a rebase comment mentioning def5678, the agent should
 	// still investigate CI failures on this new commit
 	agent.ProcessCIFailures(context.Background())
-	if countClaudeCalls(runner.calls) != 1 {
-		t.Errorf("expected 1 claude call (new SHA with CI failure), got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 1 {
+		t.Errorf("expected 1 claude call (new SHA with CI failure), got %d", countCalls(runner.calls, "claude"))
 	}
 }
 
@@ -1677,8 +1672,8 @@ func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
 
 	agent.ProcessCIFailures(context.Background())
 
-	if countClaudeCalls(runner.calls) != 0 {
-		t.Errorf("expected 0 claude calls (already reported via comment), got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Errorf("expected 0 claude calls (already reported via comment), got %d", countCalls(runner.calls, "claude"))
 	}
 	if agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCheckedCISHA != "abc1234567890" {
 		t.Errorf("expected LastCheckedCISHA to be recovered to abc1234567890, got %q", agent.state.ActiveIssues[IssueKey("owner", "repo", 42)].LastCheckedCISHA)
@@ -1725,19 +1720,9 @@ func TestProcessCIFailures_NoDuplicateCommentsOnRepeatedPolls(t *testing.T) {
 	if len(gh.addedComments) != 1 {
 		t.Errorf("expected no new comments after second poll, got %d total", len(gh.addedComments))
 	}
-	if countClaudeCalls(runner.calls) != 1 {
-		t.Errorf("expected 1 claude call total (skip second), got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 1 {
+		t.Errorf("expected 1 claude call total (skip second), got %d", countCalls(runner.calls, "claude"))
 	}
-}
-
-func countClaudeCalls(calls []commandCall) int {
-	count := 0
-	for _, c := range calls {
-		if c.Name == "claude" {
-			count++
-		}
-	}
-	return count
 }
 
 func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
@@ -1786,8 +1771,8 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 		t.Fatalf("expected still only 1 comment after second poll (no duplicate), got %d", len(gh.addedComments))
 	}
 	// Verify Claude was not called again
-	if countClaudeCalls(runner.calls) != 1 {
-		t.Errorf("expected only 1 claude call total, got %d", countClaudeCalls(runner.calls))
+	if countCalls(runner.calls, "claude") != 1 {
+		t.Errorf("expected only 1 claude call total, got %d", countCalls(runner.calls, "claude"))
 	}
 }
 
@@ -1819,12 +1804,7 @@ func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 
 	agent.ProcessCIFailures(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call for commit status failure, got %d", claudeCalls)
 	}
@@ -2020,7 +2000,7 @@ func TestProcessCIFailures_ConsolidatesMultipleFailuresIntoSingleComment(t *test
 	agent.ProcessCIFailures(context.Background())
 
 	// All three failures investigated independently
-	claudeCalls := countClaudeCalls(runner.calls)
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 3 {
 		t.Fatalf("expected 3 claude calls (one per failure), got %d", claudeCalls)
 	}

--- a/pkg/agent/ci_test.go
+++ b/pkg/agent/ci_test.go
@@ -554,14 +554,7 @@ func TestProcessCIFailures_FixesFailingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -584,12 +577,7 @@ func TestProcessCIFailures_SkipsPassingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber: 42,
-		PRNumber:    100,
-		BranchName:  "ai/issue-42",
-		Status:      "pr-open",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -608,14 +596,9 @@ func TestProcessCIFailures_StopsAfterMaxRetries(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		BranchName:    "ai/issue-42",
-		Status:        "pr-open",
-		CIFixAttempts: 3,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.CIFixAttempts = 3
+	})
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -637,12 +620,7 @@ func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber: 42,
-		PRNumber:    100,
-		BranchName:  "ai/issue-42",
-		Status:      "pr-open",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -663,12 +641,7 @@ func TestProcessCIFailures_NoRunsDoesNotMarkChecked(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber: 42,
-		PRNumber:    100,
-		BranchName:  "ai/issue-42",
-		Status:      "pr-open",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -695,13 +668,7 @@ func TestProcessCIFailures_NoRunsThenFailuresAreInvestigated(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	// Poll 1: no runs yet — must not mark SHA as checked
 	agent.ProcessCIFailures(context.Background())
@@ -738,14 +705,7 @@ func TestProcessCIFailures_CreatesFlakyIssueWhenUnrelated(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true // Enable flaky issue creation
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -810,14 +770,7 @@ func TestProcessCIFailures_InfrastructureSkipsFlakyIssue(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true // Even with flaky issues enabled, INFRASTRUCTURE should skip
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -864,14 +817,7 @@ func TestProcessCIFailures_SkipsFlakyIssueWhenDisabled(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false // Disabled by default
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -901,14 +847,7 @@ func TestProcessCIFailures_SkipCommentCIUnrelated(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-unrelated"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -944,14 +883,7 @@ func TestProcessCIFailures_SkipCommentCIUnrelated_StillCreatesFlakyIssue(t *test
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-unrelated"}
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -982,14 +914,7 @@ func TestProcessCIFailures_SkipCommentCIInfrastructure(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-infrastructure"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1058,14 +983,7 @@ func TestProcessCIFailures_CheckedCIChecksPopulatedWhenCommentsPosted(t *testing
 			agent := newTestAgent(gh, runner, wt)
 			agent.cfg.SkipFix = true // Prevent push attempts for RELATED
 			// SkipComments is empty — comments will be posted (default behavior)
-			agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-				IssueNumber:  42,
-				IssueTitle:   "Fix bug",
-				PRNumber:     100,
-				BranchName:   "ai/issue-42",
-				Status:       "pr-open",
-				WorktreePath: "/tmp/worktree",
-			}
+			trackWork(agent)
 
 			agent.ProcessCIFailures(context.Background())
 
@@ -1106,14 +1024,7 @@ func TestProcessCIFailures_SkipCommentFlaky(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"flaky"}
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1155,14 +1066,7 @@ func TestProcessCIFailures_SkipsDuplicateFlakyIssue(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1217,14 +1121,7 @@ func TestProcessCIFailures_TitlePreCheckSkipsLLMMatching(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1273,14 +1170,7 @@ func TestProcessCIFailures_CreatesNewFlakyIssueWhenNoDuplicate(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1325,14 +1215,7 @@ func TestProcessCIFailures_CreatesIssueWhenClaudeSaysNone(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = true
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1366,14 +1249,7 @@ func TestProcessCIFailures_SearchAndLinkWithoutCreateFlakyIssues(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false    // Disabled — don't create new issues
 	agent.cfg.FlakyLabel = "kind/ci-flake" // But label is set — enables search-and-link
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1422,14 +1298,7 @@ func TestProcessCIFailures_NoMatchNoCreateWhenDisabled(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false
 	agent.cfg.FlakyLabel = "kind/ci-flake"
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1464,14 +1333,7 @@ func TestProcessCIFailures_NoSearchWhenFlakyLabelEmpty(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.FlakyLabel = "" // No flaky label
 	agent.cfg.CreateFlakyIssues = false
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1506,14 +1368,7 @@ func TestProcessCIFailures_CILaneLinkIncludesJobURL(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false
 	agent.cfg.FlakyLabel = "kind/ci-flake"
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1558,14 +1413,7 @@ func TestProcessCIFailures_CommitStatusCILaneLink(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.CreateFlakyIssues = false
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1623,15 +1471,9 @@ func TestProcessCIFailures_ReinvestigatesAfterNewCommits(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:      42,
-		IssueTitle:       "Fix bug",
-		PRNumber:         100,
-		BranchName:       "ai/issue-42",
-		Status:           "pr-open",
-		WorktreePath:     "/tmp/worktree",
-		LastCheckedCISHA: "abc1234", // Already investigated abc1234
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCheckedCISHA = "abc1234" // Already investigated abc1234
+	})
 
 	// First call: should skip because LastCheckedCISHA matches current HEAD (abc1234)
 	agent.ProcessCIFailures(context.Background())
@@ -1662,13 +1504,7 @@ func TestProcessCIFailures_SkipsAlreadyReportedAfterRestart(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1692,14 +1528,7 @@ func TestProcessCIFailures_NoDuplicateCommentsOnRepeatedPolls(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1737,14 +1566,7 @@ func TestProcessCIFailures_DeduplicatesUnrelatedComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	// First poll cycle: should investigate and post consolidated comment
 	agent.ProcessCIFailures(context.Background())
@@ -1793,14 +1615,7 @@ func TestProcessCIFailures_DetectsCommitStatusFailures(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1828,14 +1643,7 @@ func TestProcessCIFailures_MergesCheckRunsAndCommitStatuses(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1882,14 +1690,7 @@ func TestProcessCIFailures_SkipChecksExcludesFromFailures(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipChecks = []string{"can-be-merged"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1921,14 +1722,7 @@ func TestProcessCIFailures_SkipChecksAllFailuresSkipped(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipChecks = []string{"can-be-merged", "verified"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1950,12 +1744,7 @@ func TestProcessCIFailures_SkipChecksDoesNotAffectAllCompleted(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipChecks = []string{"can-be-merged"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber: 42,
-		PRNumber:    100,
-		BranchName:  "ai/issue-42",
-		Status:      "pr-open",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -1988,14 +1777,7 @@ func TestProcessCIFailures_ConsolidatesMultipleFailuresIntoSingleComment(t *test
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -2051,14 +1833,7 @@ func TestProcessCIFailures_ConsolidatesMixedCategories(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -2100,14 +1875,7 @@ func TestProcessCIFailures_SingleFailureStillConsolidated(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -2143,14 +1911,7 @@ func TestProcessCIFailures_ConsolidatedSkipsInfrastructureSection(t *testing.T) 
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"ci-infrastructure"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 
@@ -2236,14 +1997,7 @@ func TestProcessCIFailures_RelatedPushedFixNoteInConsolidated(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessCIFailures(context.Background())
 

--- a/pkg/agent/conflicts_test.go
+++ b/pkg/agent/conflicts_test.go
@@ -18,13 +18,7 @@ func TestProcessConflicts_SkipsWhenBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessConflicts(context.Background())
 
@@ -48,13 +42,7 @@ func TestProcessRebase_RebasesWhenBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -85,13 +73,7 @@ func TestProcessRebase_RebasesWhenUnstableButBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -115,13 +97,7 @@ func TestProcessConflicts_SkipsUnstableNotBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessConflicts(context.Background())
 
@@ -141,13 +117,7 @@ func TestProcessRebase_SkipsUnstableNotBehind(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -166,13 +136,7 @@ func TestProcessRebase_SkipsDirty(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -198,13 +162,7 @@ func TestProcessRebase_InvokesConflictResolutionWhenRebaseFails(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.codeAgent = codeAgent
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -281,13 +239,7 @@ func TestProcessConflicts_SkipsCleanPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessConflicts(context.Background())
 
@@ -308,13 +260,7 @@ func TestProcessRebase_SkipCommentRebase(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"rebase"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -344,13 +290,7 @@ func TestProcessConflicts_SkipCommentConflict(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.SkipComments = []string{"conflict"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessConflicts(context.Background())
 
@@ -373,13 +313,7 @@ func TestProcessRebase_CleansUnstagedChangesAndRetries(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -427,13 +361,7 @@ func TestProcessConflicts_CleansUnstagedChangesAndRetries(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessConflicts(context.Background())
 
@@ -503,13 +431,7 @@ func TestProcessRebase_DefersWhenMainIsActive(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -531,13 +453,7 @@ func TestProcessRebase_ProceedsWhenMainIsQuiet(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -563,14 +479,9 @@ func TestProcessRebase_DefersWhenMinIntervalNotReached(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:    42,
-		PRNumber:       100,
-		BranchName:     "ai/issue-42",
-		Status:         "pr-open",
-		WorktreePath:   "/tmp/worktree",
-		LastRebaseTime: time.Now().Add(-1 * time.Hour), // rebased 1h ago
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastRebaseTime = time.Now().Add(-1 * time.Hour) // rebased 1h ago
+	})
 
 	agent.ProcessRebase(context.Background())
 
@@ -592,14 +503,9 @@ func TestProcessRebase_ProceedsWhenMinIntervalExpired(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:    42,
-		PRNumber:       100,
-		BranchName:     "ai/issue-42",
-		Status:         "pr-open",
-		WorktreePath:   "/tmp/worktree",
-		LastRebaseTime: time.Now().Add(-5 * time.Hour), // rebased 5h ago
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastRebaseTime = time.Now().Add(-5 * time.Hour) // rebased 5h ago
+	})
 
 	agent.ProcessRebase(context.Background())
 
@@ -624,13 +530,7 @@ func TestProcessRebase_FailOpenOnAPIError(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -655,14 +555,7 @@ func TestProcessRebase_FirstRebaseNoIntervalGuard(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-		// LastRebaseTime is zero — first rebase
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 
@@ -687,13 +580,7 @@ func TestProcessRebase_SetsLastRebaseTimeOnSuccess(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	before := time.Now()
 	agent.ProcessRebase(context.Background())
@@ -717,13 +604,7 @@ func TestProcessRebase_ExactThresholdAllowsRebase(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessRebase(context.Background())
 

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+// loadConfig writes yaml to a temp config file and loads it.
+func loadConfig(t *testing.T, yaml string) (*FileConfig, error) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return LoadFileConfig(path)
+}
+
 func TestLoadFileConfig_Valid(t *testing.T) {
 	yaml := `
 agent: opencode
@@ -26,13 +36,7 @@ projects:
     issues:
       - label: good-for-ai
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,9 +107,7 @@ func TestLoadFileConfig_ValidationErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "config.yaml")
-			os.WriteFile(path, []byte(tt.yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-			_, err := LoadFileConfig(path)
+			_, err := loadConfig(t, tt.yaml)
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -503,13 +505,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         reviewers: [eve]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -568,11 +564,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for invalid skip-comment")
 	}
@@ -586,11 +578,7 @@ func TestLoadFileConfig_FileNotFound(t *testing.T) {
 }
 
 func TestLoadFileConfig_InvalidYAML(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte("{{invalid yaml"), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, "{{invalid yaml")
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
 	}
@@ -605,11 +593,7 @@ projects:
     issues:
       - label: test
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for agent-model with claudecode")
 	}
@@ -623,14 +607,10 @@ projects:
     issues:
       - label: test
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
 	// agent-model without an explicit agent is valid: the agent is inherited
 	// from the global config and the resolved combination is validated when
 	// the code agent is selected.
-	if _, err := LoadFileConfig(path); err != nil {
+	if _, err := loadConfig(t, yaml); err != nil {
 		t.Fatalf("unexpected error for agent-model without explicit agent: %v", err)
 	}
 }
@@ -643,11 +623,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         schedule: "09:00 Invalid/Timezone"
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for invalid schedule timezone")
 	}
@@ -661,11 +637,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         schedule: "09:00 UTC"
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error for valid schedule: %v", err)
 	}
@@ -679,11 +651,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         lookback: "not-a-duration"
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for invalid lookback duration")
 	}
@@ -697,11 +665,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         lookback: "-1h"
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for negative lookback duration")
 	}
@@ -715,11 +679,7 @@ projects:
       - jobs: [https://ci.example.com/job]
         lookback: 24h
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error for valid lookback: %v", err)
 	}
@@ -873,11 +833,7 @@ projects:
         skip-checks:
           - lint-check
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	cfg, err := LoadFileConfig(path)
+	cfg, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -939,11 +895,7 @@ projects:
     issues:
       - label: test
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper: WriteFile errors are caught by subsequent LoadFileConfig
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for unknown YAML key")
 	}
@@ -958,11 +910,7 @@ projects:
       - watch: [1]
         rebase-interval: 8h
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -982,11 +930,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for invalid project rebase-interval")
 	}
@@ -1000,11 +944,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for negative project rebase-interval")
 	}
@@ -1018,11 +958,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for zero project rebase-interval")
 	}
@@ -1036,11 +972,7 @@ projects:
       - watch: [1]
         rebase-interval: "-2h"
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for negative PR rebase-interval")
 	}
@@ -1054,11 +986,7 @@ projects:
       - watch: [1]
         rebase-interval: bad
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for invalid PR rebase-interval")
 	}
@@ -1171,11 +1099,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yaml)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1193,11 +1117,7 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
-	_, err := LoadFileConfig(path)
+	_, err := loadConfig(t, yaml)
 	if err == nil {
 		t.Fatal("expected error for project agent-model with claudecode")
 	}
@@ -1211,14 +1131,10 @@ projects:
     prs:
       - watch: [1]
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	os.WriteFile(path, []byte(yaml), 0o644) //nolint:errcheck // test helper
-
 	// Project-level agent-model without an explicit agent is valid: the agent
 	// is inherited from the global config and the resolved combination is
 	// validated when the code agent is selected.
-	if _, err := LoadFileConfig(path); err != nil {
+	if _, err := loadConfig(t, yaml); err != nil {
 		t.Fatalf("unexpected error for project agent-model without explicit agent: %v", err)
 	}
 }
@@ -1258,13 +1174,7 @@ projects:
       - watch: [6466]
         reactions: []
 `
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(yamlStr), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	fc, err := LoadFileConfig(path)
+	fc, err := loadConfig(t, yamlStr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/agent/integration_test.go
+++ b/pkg/agent/integration_test.go
@@ -437,13 +437,8 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 	}
 
 	// Verify Claude was invoked
-	var claudeCalls int
 	runner.mu.Lock()
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	runner.mu.Unlock()
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call, got %d", claudeCalls)
@@ -474,12 +469,7 @@ func TestIntegration_FullIssueLifecycle(t *testing.T) {
 
 	// Verify Claude was invoked again
 	runner.mu.Lock()
-	claudeCalls = 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls = countCalls(runner.calls, "claude")
 	runner.mu.Unlock()
 	// 1 for implementation + 1 for review + 1 for change summary
 	if claudeCalls != 3 {

--- a/pkg/agent/issues_test.go
+++ b/pkg/agent/issues_test.go
@@ -36,12 +36,10 @@ func TestProcessNewIssues_RechecksForPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber: 42,
-		BranchName:  "ai/issue-42",
-		Status:      "implementing",
-		PRNumber:    0,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.Status = "implementing"
+		w.PRNumber = 0
+	})
 
 	agent.ProcessNewIssues(context.Background())
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -11,12 +11,7 @@ func TestCleanupDone_MergedPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.CleanupDone(context.Background())
 
@@ -34,12 +29,7 @@ func TestCleanupDone_ClosedPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.CleanupDone(context.Background())
 
@@ -57,12 +47,7 @@ func TestCleanupDone_OpenPR(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.CleanupDone(context.Background())
 
@@ -246,14 +231,7 @@ func TestReportOnlyMode_EmptyReactionsGatesAndChecks(t *testing.T) {
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.Reactions = []string{}                           // report-only mode
 	agent.cfg.SlackWebhookURL = "https://hooks.slack.com/test" // enable Slack
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		BranchName:   "ai/issue-42",
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	// All reactions should be skipped
 	if agent.ShouldRunReaction("reviews") {

--- a/pkg/agent/mocks_test.go
+++ b/pkg/agent/mocks_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"time"
 )
@@ -263,16 +264,45 @@ func (m *mockWorktreeManager) OriginDefaultBranch() string { return "origin/main
 
 func (m *mockWorktreeManager) PushRemote() string { return "origin" }
 
-func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt *mockWorktreeManager) *Agent {
-	return &Agent{
-		gh:        gh,
-		runner:    runner,
-		worktrees: wt,
-		state:     NewState(),
-		cfg:       Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", FlakyLabel: "flaky-test", GitHubUser: "test-bot"},
-		logger:    slog.Default(),
-		codeAgent: &ClaudeCodeAgent{},
+// discardLogger returns a logger that drops all output, keeping tests quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// agentOpt customizes an Agent built by newTestAgent.
+type agentOpt func(*Agent)
+
+// withCfg mutates the canonical test Config before the test runs.
+func withCfg(mutate func(*Config)) agentOpt {
+	return func(a *Agent) { mutate(&a.cfg) }
+}
+
+// withCodeAgent replaces the default code agent.
+func withCodeAgent(ca CodeAgent) agentOpt {
+	return func(a *Agent) { a.codeAgent = ca }
+}
+
+// newTestAgent builds an Agent through the production constructor with
+// canonical test doubles: owner/repo config, fresh state, and a discard
+// logger. Options apply after construction.
+func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt WorktreeManager, opts ...agentOpt) *Agent {
+	cfg := Config{Owner: "owner", Repo: "repo", Label: "good-for-ai", FlakyLabel: "flaky-test", GitHubUser: "test-bot"}
+	a := NewAgent(gh, runner, wt, NewState(), cfg, discardLogger(), &ClaudeCodeAgent{})
+	for _, opt := range opts {
+		opt(a)
 	}
+	return a
+}
+
+// countCalls returns how many recorded commands invoked the named binary.
+func countCalls(calls []commandCall, name string) int {
+	count := 0
+	for _, c := range calls {
+		if c.Name == name {
+			count++
+		}
+	}
+	return count
 }
 
 // sequentialMockCodeAgent returns different results for sequential calls.

--- a/pkg/agent/mocks_test.go
+++ b/pkg/agent/mocks_test.go
@@ -294,6 +294,25 @@ func newTestAgent(gh *mockGitHubClient, runner CommandRunner, wt WorktreeManager
 	return a
 }
 
+// trackWork registers the canonical in-flight fixture (issue 42 with PR 100
+// open on branch ai/issue-42) in the agent state, applies any mutations, and
+// returns the tracked work for later assertions.
+func trackWork(a *Agent, mutate ...func(*IssueWork)) *IssueWork {
+	w := &IssueWork{
+		IssueNumber:  42,
+		IssueTitle:   "Fix bug",
+		PRNumber:     100,
+		BranchName:   "ai/issue-42",
+		Status:       StatusPROpen,
+		WorktreePath: "/tmp/worktree",
+	}
+	for _, m := range mutate {
+		m(w)
+	}
+	a.state.ActiveIssues[IssueKey(a.cfg.Owner, a.cfg.Repo, w.IssueNumber)] = w
+	return w
+}
+
 // countCalls returns how many recorded commands invoked the named binary.
 func countCalls(calls []commandCall, name string) int {
 	count := 0

--- a/pkg/agent/plugin_test.go
+++ b/pkg/agent/plugin_test.go
@@ -2,8 +2,6 @@ package agent
 
 import (
 	"context"
-	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -135,7 +133,7 @@ func TestCheckPluginVersion_BestEffortNpmUnavailable(t *testing.T) {
 	// Override HOME so readInstalledPluginVersion finds our fake directory
 	t.Setenv("HOME", fakeHome)
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	// We can't easily mock npm view in a unit test, so we test the components
 	// directly and test CheckPluginVersion integration only when npm is available.
@@ -163,7 +161,7 @@ func TestCheckPluginVersion_BestEffortNpmUnavailable(t *testing.T) {
 func TestCheckPluginVersion_BestEffortPluginNotInstalled(t *testing.T) {
 	// When the plugin is not installed (package.json missing), CheckPluginVersion
 	// should silently return nil (best-effort).
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	t.Setenv("HOME", t.TempDir())
 	finding := CheckPluginVersion(context.Background(), logger)
@@ -200,7 +198,7 @@ func TestCheckPluginVersion_OutdatedWithFakeNpm(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeBin)
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	finding := CheckPluginVersion(context.Background(), logger)
 
 	if finding == nil {
@@ -252,7 +250,7 @@ func TestCheckPluginVersion_SameVersionWithFakeNpm(t *testing.T) {
 	}
 	t.Setenv("PATH", fakeBin)
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	finding := CheckPluginVersion(context.Background(), logger)
 
 	if finding != nil {
@@ -303,7 +301,7 @@ func TestCheckPluginVersion_FindingFormat(t *testing.T) {
 }
 
 func TestStartPluginVersionChecker_DisabledWithoutSlack(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	// Should return nil and not panic with nil Slack reporter
 	ch := StartPluginVersionChecker(context.Background(), nil, logger)
@@ -331,7 +329,7 @@ func TestStartPluginVersionChecker_RunsAndStops(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -53,12 +53,7 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
@@ -212,12 +207,7 @@ func TestProcessReviewComments_AllowsAllWhenWhitelistEmpty(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	// One call: implementation (no triage step)
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call with empty whitelist, got %d", claudeCalls)
@@ -250,12 +240,7 @@ func TestProcessReviewComments_UnaddressedReviewIsProcessed(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call for unaddressed review, got %d", claudeCalls)
 	}
@@ -291,12 +276,7 @@ func TestProcessReviewComments_AlreadyAddressedReviewIsFilteredBySinceID(t *test
 
 	agent.ProcessReviewComments(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 0 {
 		t.Errorf("expected 0 claude calls for already-addressed review, got %d", claudeCalls)
 	}
@@ -332,12 +312,7 @@ func TestProcessReviewComments_MultipleReviewersSimultaneous(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	// copilot's review should be processed — sinceID ensures it's not filtered out
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call for unaddressed copilot review, got %d", claudeCalls)
@@ -584,12 +559,7 @@ func TestProcessReviewComments_NoOpCountPausesReviews(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// Should NOT invoke the agent because no-op limit is reached.
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 0 {
 		t.Errorf("expected 0 claude calls when no-op limit reached, got %d", claudeCalls)
 	}
@@ -649,12 +619,7 @@ func TestProcessReviewComments_NewReviewAfterNoOpPause(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// The new review should be processed since the counter was reset.
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Errorf("expected 1 claude call for new review after counter reset, got %d", claudeCalls)
 	}
@@ -819,12 +784,7 @@ func TestProcessReviewComments_OompaCommandProcessed(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// Should have invoked the agent
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
@@ -863,10 +823,8 @@ func TestProcessReviewComments_IgnoresNonOompaComments(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// Should NOT invoke the agent
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			t.Error("should not invoke claude for comments without /oompa prefix")
-		}
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Error("should not invoke claude for comments without /oompa prefix")
 	}
 
 	// Cursor should still advance past filtered comments
@@ -897,10 +855,8 @@ func TestProcessReviewComments_OompaCommandSkipsNonWhitelisted(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			t.Error("should not invoke claude for non-whitelisted user's /oompa command")
-		}
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Error("should not invoke claude for non-whitelisted user's /oompa command")
 	}
 }
 
@@ -978,12 +934,7 @@ func TestProcessReviewComments_OompaCommandWithReviewComments(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// Should have invoked the agent once (both types combined into one task)
-	claudeCalls := 0
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			claudeCalls++
-		}
-	}
+	claudeCalls := countCalls(runner.calls, "claude")
 	if claudeCalls != 1 {
 		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
 	}
@@ -1058,10 +1009,8 @@ func TestProcessReviewComments_OompaCommandIgnoresBarePrefix(t *testing.T) {
 	agent.ProcessReviewComments(context.Background())
 
 	// Should NOT invoke the agent for bare /oompa with no directive
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			t.Error("should not invoke claude for bare /oompa comment with no directive")
-		}
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Error("should not invoke claude for bare /oompa comment with no directive")
 	}
 
 	// Cursor should still advance past filtered comments
@@ -1091,10 +1040,8 @@ func TestProcessReviewComments_OompaCommandIgnoresBotComments(t *testing.T) {
 
 	agent.ProcessReviewComments(context.Background())
 
-	for _, c := range runner.calls {
-		if c.Name == "claude" {
-			t.Error("should not invoke claude for bot-posted /oompa comment")
-		}
+	if countCalls(runner.calls, "claude") != 0 {
+		t.Error("should not invoke claude for bot-posted /oompa comment")
 	}
 }
 

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -962,26 +962,16 @@ func TestProcessReviewComments_SquashUsesCommitMsgFile(t *testing.T) {
 	}
 	wt := &fixedPathWorktreeManager{fixedPath: worktreeDir}
 
-	agent := &Agent{
-		gh:        gh,
-		runner:    runner,
-		worktrees: wt,
-		state:     NewState(),
-		cfg: Config{
-			Owner:       "owner",
-			Repo:        "repo",
-			Label:       "good-for-ai",
-			FlakyLabel:  "flaky-test",
-			GitHubUser:  "test-bot",
-			SignedOffBy: "Test User <test@example.com>",
-			AssistedBy:  "Claude <noreply@anthropic.com>",
-		},
-		logger: slog.Default(),
-		codeAgent: &commitMsgCodeAgent{
+	agent := newTestAgent(gh, runner, wt,
+		withCfg(func(c *Config) {
+			c.SignedOffBy = "Test User <test@example.com>"
+			c.AssistedBy = "Claude <noreply@anthropic.com>"
+		}),
+		withCodeAgent(&commitMsgCodeAgent{
 			commitMsg: "fix: corrected commit subject\n\nProper body",
 			result:    AgentResult{Result: "Done"},
-		},
-	}
+		}),
+	)
 	trackWork(agent, func(w *IssueWork) {
 		w.WorktreePath = worktreeDir
 	})
@@ -1039,26 +1029,16 @@ func TestProcessReviewComments_AmendUsesCommitMsgFile(t *testing.T) {
 	}
 	wt := &fixedPathWorktreeManager{fixedPath: worktreeDir}
 
-	agent := &Agent{
-		gh:        gh,
-		runner:    runner,
-		worktrees: wt,
-		state:     NewState(),
-		cfg: Config{
-			Owner:       "owner",
-			Repo:        "repo",
-			Label:       "good-for-ai",
-			FlakyLabel:  "flaky-test",
-			GitHubUser:  "test-bot",
-			SignedOffBy: "Test User <test@example.com>",
-			AssistedBy:  "Claude <noreply@anthropic.com>",
-		},
-		logger: slog.Default(),
-		codeAgent: &commitMsgCodeAgent{
+	agent := newTestAgent(gh, runner, wt,
+		withCfg(func(c *Config) {
+			c.SignedOffBy = "Test User <test@example.com>"
+			c.AssistedBy = "Claude <noreply@anthropic.com>"
+		}),
+		withCodeAgent(&commitMsgCodeAgent{
 			commitMsg: "fix: updated commit message\n\nNew body",
 			result:    AgentResult{Result: "Done"},
-		},
-	}
+		}),
+	)
 	trackWork(agent, func(w *IssueWork) {
 		w.WorktreePath = worktreeDir
 	})

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -17,12 +17,9 @@ func TestProcessReviewComments_NoNewComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		PRNumber:      100,
-		Status:        "pr-open",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -42,14 +39,9 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -78,14 +70,9 @@ func TestProcessReviewComments_PushFailureDoesNotAdvanceCursor(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -108,14 +95,9 @@ func TestProcessReviewComments_CursorAdvancesUnconditionally(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -141,14 +123,9 @@ func TestProcessReviewComments_AgentErrorStillAdvancesCursor(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -170,12 +147,9 @@ func TestProcessReviewComments_SkipsNonWhitelistedUsers(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.Reviewers = []string{"trusted-reviewer"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		PRNumber:      100,
-		Status:        "pr-open",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -196,14 +170,9 @@ func TestProcessReviewComments_AllowsAllWhenWhitelistEmpty(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	// No reviewers set — empty whitelist means allow all
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -229,14 +198,9 @@ func TestProcessReviewComments_UnaddressedReviewIsProcessed(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-		LastReviewID: 100, // review 200 > 100, so it's new/unaddressed
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastReviewID = 100 // review 200 > 100, so it's new/unaddressed
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -265,14 +229,9 @@ func TestProcessReviewComments_AlreadyAddressedReviewIsFilteredBySinceID(t *test
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-		LastReviewID: 100, // review 50 <= 100, filtered by sinceID
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastReviewID = 100 // review 50 <= 100, filtered by sinceID
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -299,16 +258,11 @@ func TestProcessReviewComments_MultipleReviewersSimultaneous(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
+	trackWork(agent, func(w *IssueWork) {
 		// LastReviewID 250: oompa already processed coderabbit (ID 200) and gemini (ID 250)
 		// but copilot's review (ID 300) is still unaddressed
-		LastReviewID: 250,
-	}
+		w.LastReviewID = 250
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -344,14 +298,9 @@ func TestProcessReviewComments_SquashesAgentCommits(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -440,14 +389,9 @@ func TestProcessReviewComments_AutosquashesFixupCommits(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -506,15 +450,10 @@ func TestProcessReviewComments_AgentFailureAdvancesCursor(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-		LastReviewID:  100,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+		w.LastReviewID = 100
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -546,15 +485,10 @@ func TestProcessReviewComments_NoOpCountPausesReviews(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.MaxReviewNoOps = 3
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:     42,
-		IssueTitle:      "Fix bug",
-		PRNumber:        100,
-		Status:          "pr-open",
-		WorktreePath:    "/tmp/worktree",
-		LastCommentID:   50,
-		ReviewNoOpCount: 3, // already at limit
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+		w.ReviewNoOpCount = 3 // already at limit
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -589,15 +523,10 @@ func TestProcessReviewComments_NewReviewAfterNoOpPause(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.MaxReviewNoOps = 3
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:     42,
-		IssueTitle:      "Fix bug",
-		PRNumber:        100,
-		Status:          "pr-open",
-		WorktreePath:    "/tmp/worktree",
-		LastReviewID:    250, // cursor at 250, review 300 is new
-		ReviewNoOpCount: 3,   // at limit
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastReviewID = 250  // cursor at 250, review 300 is new
+		w.ReviewNoOpCount = 3 // at limit
+	})
 
 	// Cycle 1: no-op limit reached → cursors advance to 300, counter resets to 0
 	agent.ProcessReviewComments(context.Background())
@@ -647,15 +576,10 @@ func TestProcessReviewComments_NoOpCountResetsOnPush(t *testing.T) {
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:     42,
-		IssueTitle:      "Fix bug",
-		PRNumber:        100,
-		Status:          "pr-open",
-		WorktreePath:    "/tmp/worktree",
-		LastCommentID:   50,
-		ReviewNoOpCount: 2, // was approaching limit
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+		w.ReviewNoOpCount = 2 // was approaching limit
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -678,15 +602,10 @@ func TestProcessReviewComments_NoOpCountIncrementsOnNoPush(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:     42,
-		IssueTitle:      "Fix bug",
-		PRNumber:        100,
-		Status:          "pr-open",
-		WorktreePath:    "/tmp/worktree",
-		LastReviewID:    100,
-		ReviewNoOpCount: 1,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastReviewID = 100
+		w.ReviewNoOpCount = 1
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -712,15 +631,10 @@ func TestProcessReviewComments_CostGuardSkipsReviews(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.MaxPRSessionCost = 10.0
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:    42,
-		IssueTitle:     "Fix bug",
-		PRNumber:       100,
-		Status:         "pr-open",
-		WorktreePath:   "/tmp/worktree",
-		LastCommentID:  50,
-		SessionCostUSD: 11.5, // exceeds $10 threshold
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+		w.SessionCostUSD = 11.5 // exceeds $10 threshold
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -742,15 +656,10 @@ func TestProcessReviewComments_CostTracking(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:    42,
-		IssueTitle:     "Fix bug",
-		PRNumber:       100,
-		Status:         "pr-open",
-		WorktreePath:   "/tmp/worktree",
-		LastCommentID:  50,
-		SessionCostUSD: 2.0, // existing cost
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+		w.SessionCostUSD = 2.0 // existing cost
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -773,13 +682,7 @@ func TestProcessReviewComments_OompaCommandProcessed(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -813,12 +716,7 @@ func TestProcessReviewComments_IgnoresNonOompaComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -846,12 +744,7 @@ func TestProcessReviewComments_OompaCommandSkipsNonWhitelisted(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.cfg.Reviewers = []string{"trusted-reviewer"}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -876,13 +769,7 @@ func TestProcessReviewComments_OompaCommandIncludedInPrompt(t *testing.T) {
 
 	agent := newTestAgent(gh, runner, wt)
 	agent.codeAgent = codeAgent
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -923,13 +810,7 @@ func TestProcessReviewComments_OompaCommandWithReviewComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -971,13 +852,7 @@ func TestProcessReviewComments_OompaCommandCursorAdvancesOnAgentError(t *testing
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -999,12 +874,7 @@ func TestProcessReviewComments_OompaCommandIgnoresBarePrefix(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1031,12 +901,7 @@ func TestProcessReviewComments_OompaCommandIgnoresBotComments(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: "/tmp/worktree",
-	}
+	trackWork(agent)
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1117,13 +982,9 @@ func TestProcessReviewComments_SquashUsesCommitMsgFile(t *testing.T) {
 			result:    AgentResult{Result: "Done"},
 		},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: worktreeDir,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.WorktreePath = worktreeDir
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1198,13 +1059,9 @@ func TestProcessReviewComments_AmendUsesCommitMsgFile(t *testing.T) {
 			result:    AgentResult{Result: "Done"},
 		},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:  42,
-		IssueTitle:   "Fix bug",
-		PRNumber:     100,
-		Status:       "pr-open",
-		WorktreePath: worktreeDir,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.WorktreePath = worktreeDir
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1258,14 +1115,9 @@ func TestProcessReviewComments_SquashWithoutCommitMsgFileUsesNoEdit(t *testing.T
 	agent.codeAgent = &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1305,14 +1157,9 @@ func TestProcessReviewComments_PostsChangeSummaryAfterPush(t *testing.T) {
 			{result: AgentResult{Result: "- Added validation logic to the review handler"}}, // change summary
 		},
 	}
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 
@@ -1364,14 +1211,9 @@ func TestProcessReviewComments_NoChangeSummaryWhenNoPush(t *testing.T) {
 	wt := &mockWorktreeManager{}
 
 	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{
-		IssueNumber:   42,
-		IssueTitle:    "Fix bug",
-		PRNumber:      100,
-		Status:        "pr-open",
-		WorktreePath:  "/tmp/worktree",
-		LastCommentID: 50,
-	}
+	trackWork(agent, func(w *IssueWork) {
+		w.LastCommentID = 50
+	})
 
 	agent.ProcessReviewComments(context.Background())
 

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +14,41 @@ import (
 	"testing"
 	"time"
 )
+
+// slackTestAgent returns an agent configured for org/repo Slack checks with
+// one open PR (#100) tracked in state.
+func slackTestAgent(gh *mockGitHubClient) *Agent {
+	a := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{}, withCfg(func(c *Config) {
+		c.Owner = "org"
+		c.SlackWebhookURL = "http://example.com/webhook"
+	}))
+	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
+		PRNumber:   100,
+		IssueTitle: "Fix test",
+		Status:     StatusPROpen,
+	}
+	return a
+}
+
+// newCountingWebhook builds a SlackReporter posting to a local test server
+// with dedup state isolated under a temp XDG_STATE_HOME. The returned func
+// reports how many webhook posts were received.
+func newCountingWebhook(t *testing.T) (reporter *SlackReporter, posts func() int) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	var mu sync.Mutex
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(ts.Close)
+	reporter = NewSlackReporter(ts.URL, "", discardLogger())
+	reporter.httpClient = ts.Client()
+	return reporter, func() int { mu.Lock(); defer mu.Unlock(); return count }
+}
 
 func TestFormatSlackMessage_GroupsByPR(t *testing.T) {
 	findings := []SlackFinding{
@@ -279,17 +313,7 @@ func TestFormatSlackMessage_HasDividersBetweenProjects(t *testing.T) {
 }
 
 func TestSlackReporter_Dedup(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	findings := []SlackFinding{
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
@@ -299,29 +323,19 @@ func TestSlackReporter_Dedup(t *testing.T) {
 
 	// First report should send
 	reporter.Report(ctx, findings)
-	if postCount != 1 {
-		t.Errorf("expected 1 POST, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST, got %d", posts())
 	}
 
 	// Second report with same DedupKey should be suppressed
 	reporter.Report(ctx, findings)
-	if postCount != 1 {
-		t.Errorf("expected still 1 POST after dedup, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected still 1 POST after dedup, got %d", posts())
 	}
 }
 
 func TestSlackReporter_DedupReset(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	ctx := context.Background()
 
@@ -329,21 +343,21 @@ func TestSlackReporter_DedupReset(t *testing.T) {
 	reporter.Report(ctx, []SlackFinding{
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:abc123:e2e"},
 	})
-	if postCount != 1 {
-		t.Errorf("expected 1 POST, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST, got %d", posts())
 	}
 
 	// Different DedupKey (new SHA) should re-send
 	reporter.Report(ctx, []SlackFinding{
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Fix test", PRURL: "https://github.com/org/repo/pull/100", Category: "ci", Message: "🔴 test failed", DedupKey: "ci:def456:e2e"},
 	})
-	if postCount != 2 {
-		t.Errorf("expected 2 POSTs after new DedupKey, got %d", postCount)
+	if posts() != 2 {
+		t.Errorf("expected 2 POSTs after new DedupKey, got %d", posts())
 	}
 }
 
 func TestSlackReporter_Disabled(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := NewSlackReporter("", "", logger)
 
 	if reporter.IsEnabled() {
@@ -408,20 +422,7 @@ func TestCheckCIStatus_ReportsFailures(t *testing.T) {
 		prHeadSHAs: []string{"abc123"},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckCIStatus(context.Background(), time.Time{})
 
@@ -448,20 +449,7 @@ func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
 		prBehind:       true,
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
@@ -484,20 +472,7 @@ func TestCheckConflicts_ReportsDirty(t *testing.T) {
 		mergeableState: "dirty",
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.checkConflictsWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
@@ -523,20 +498,7 @@ func TestCheckNewReviews_ReportsComments(t *testing.T) {
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckNewReviews(context.Background(), time.Time{})
 
@@ -562,20 +524,7 @@ func TestCheckCIStatus_NoFailures(t *testing.T) {
 		prHeadSHAs: []string{"abc123"},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckCIStatus(context.Background(), time.Time{})
 
@@ -589,20 +538,7 @@ func TestCheckRebaseNeeded_Clean(t *testing.T) {
 		mergeableState: "clean",
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
 
@@ -612,17 +548,7 @@ func TestCheckRebaseNeeded_Clean(t *testing.T) {
 }
 
 func TestSlackReporter_EmptyDedupKey(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	ctx := context.Background()
 
@@ -632,13 +558,13 @@ func TestSlackReporter_EmptyDedupKey(t *testing.T) {
 	}
 
 	reporter.Report(ctx, findings)
-	if postCount != 1 {
-		t.Errorf("expected 1 POST, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST, got %d", posts())
 	}
 
 	reporter.Report(ctx, findings)
-	if postCount != 2 {
-		t.Errorf("expected 2 POSTs (empty DedupKey never suppressed), got %d", postCount)
+	if posts() != 2 {
+		t.Errorf("expected 2 POSTs (empty DedupKey never suppressed), got %d", posts())
 	}
 }
 
@@ -655,17 +581,7 @@ func TestURLHelpers(t *testing.T) {
 }
 
 func TestSlackReporter_CollectAndFlush(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	ctx := context.Background()
 
@@ -678,14 +594,14 @@ func TestSlackReporter_CollectAndFlush(t *testing.T) {
 	})
 
 	// No POST until Flush
-	if postCount != 0 {
-		t.Errorf("expected 0 POSTs before Flush, got %d", postCount)
+	if posts() != 0 {
+		t.Errorf("expected 0 POSTs before Flush, got %d", posts())
 	}
 
 	// Flush should send a single consolidated message
 	reporter.Flush(ctx)
-	if postCount != 1 {
-		t.Errorf("expected 1 POST after Flush, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST after Flush, got %d", posts())
 	}
 
 	// Pending should be drained
@@ -697,23 +613,13 @@ func TestSlackReporter_CollectAndFlush(t *testing.T) {
 
 	// Flushing again with no new findings should not POST
 	reporter.Flush(ctx)
-	if postCount != 1 {
-		t.Errorf("expected still 1 POST after empty Flush, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected still 1 POST after empty Flush, got %d", posts())
 	}
 }
 
 func TestSlackReporter_CollectConcurrent(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	// Simulate concurrent collection from multiple goroutines
 	var wg sync.WaitGroup
@@ -736,23 +642,13 @@ func TestSlackReporter_CollectConcurrent(t *testing.T) {
 
 	// Flush should send all as one message
 	reporter.Flush(context.Background())
-	if postCount != 1 {
-		t.Errorf("expected 1 POST after Flush, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST after Flush, got %d", posts())
 	}
 }
 
 func TestSlackReporter_FlushDedup(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var postCount int
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		postCount++
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	reporter := NewSlackReporter(ts.URL, "", logger)
-	reporter.httpClient = ts.Client()
+	reporter, posts := newCountingWebhook(t)
 
 	ctx := context.Background()
 
@@ -761,8 +657,8 @@ func TestSlackReporter_FlushDedup(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "ci:abc:e2e"},
 	})
 	reporter.Flush(ctx)
-	if postCount != 1 {
-		t.Errorf("expected 1 POST, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected 1 POST, got %d", posts())
 	}
 
 	// Second collect+flush with same DedupKey — should be suppressed
@@ -770,8 +666,8 @@ func TestSlackReporter_FlushDedup(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 100, PRTitle: "Test", Message: "test", DedupKey: "ci:abc:e2e"},
 	})
 	reporter.Flush(ctx)
-	if postCount != 1 {
-		t.Errorf("expected still 1 POST after dedup, got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected still 1 POST after dedup, got %d", posts())
 	}
 }
 
@@ -897,7 +793,7 @@ func TestSlackReporter_FlushDedup_WithinBatch(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
@@ -949,7 +845,7 @@ func TestSlackReporter_FlushDedup_DifferentFindingsSamePR(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
@@ -992,7 +888,7 @@ func TestSlackReporter_FlushDedup_EmptyDedupKeyNotDeduped(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := NewSlackReporter(ts.URL, "", logger)
 	reporter.httpClient = ts.Client()
 
@@ -1029,7 +925,7 @@ func TestLoadLastReportedAt_JSONFileExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	got, reported := loadLastReportedAt(path, logger)
 
 	if !got.Equal(expected) {
@@ -1054,7 +950,7 @@ func TestLoadLastReportedAt_PlainTextBackwardCompat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	got, reported := loadLastReportedAt(path, logger)
 
 	if !got.Equal(expected) {
@@ -1069,7 +965,7 @@ func TestLoadLastReportedAt_FileMissing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nonexistent")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	before := time.Now()
 	got, reported := loadLastReportedAt(path, logger)
 	after := time.Now()
@@ -1089,7 +985,7 @@ func TestLoadLastReportedAt_FileCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	before := time.Now()
 	got, reported := loadLastReportedAt(path, logger)
 	after := time.Now()
@@ -1109,7 +1005,7 @@ func TestLoadLastReportedAt_FileEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	before := time.Now()
 	got, reported := loadLastReportedAt(path, logger)
 	after := time.Now()
@@ -1125,7 +1021,7 @@ func TestLoadLastReportedAt_FileEmpty(t *testing.T) {
 func TestPersistLastReportedAt_WritesAndReads(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "last-report-at")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	ts := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
 	reported := map[string]bool{"rebase:100": true, "conflict:200": true}
@@ -1149,7 +1045,7 @@ func TestPersistLastReportedAt_WritesAndReads(t *testing.T) {
 func TestPersistLastReportedAt_CreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "a", "b", "c", "last-report-at")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	ts := time.Now()
 	persistLastReportedAt(path, ts, make(map[string]bool), logger)
@@ -1192,7 +1088,7 @@ func TestSlackReporter_FlushPersistsLastReportedAt(t *testing.T) {
 	dir := t.TempDir()
 	stateFile := filepath.Join(dir, "last-report-at")
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 	reporter := &SlackReporter{
 		webhookURL:     ts.URL,
 		reported:       make(map[string]bool),
@@ -1236,7 +1132,7 @@ func TestSlackReporter_LastReportedAtSurvivesRestart(t *testing.T) {
 
 	dir := t.TempDir()
 	stateFile := filepath.Join(dir, "last-report-at")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	// First reporter: flush to persist timestamp
 	reporter1 := &SlackReporter{
@@ -1292,20 +1188,7 @@ func TestCheckCIStatus_FiltersStaleFailures(t *testing.T) {
 		prHeadSHAs: []string{"abc123"},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
 
@@ -1329,20 +1212,7 @@ func TestCheckCIStatus_IncludesFailuresWithZeroCompletedAt(t *testing.T) {
 		prHeadSHAs: []string{"abc123"},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
 
@@ -1363,20 +1233,7 @@ func TestCheckNewReviews_FiltersStaleComments(t *testing.T) {
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
 
@@ -1398,20 +1255,7 @@ func TestCheckNewReviews_IncludesCommentsWithZeroCreatedAt(t *testing.T) {
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
 
@@ -1430,7 +1274,7 @@ func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
 
 	dir := t.TempDir()
 	stateFile := filepath.Join(dir, "last-report-at")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	// First reporter: report rebase and conflict findings
 	reporter1 := &SlackReporter{
@@ -1506,7 +1350,7 @@ func TestMigrateOldHashedFiles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := discardLogger()
 		migrateOldHashedFiles(currentFile, logger)
 
 		// Old hashed files should be removed
@@ -1544,7 +1388,7 @@ func TestMigrateOldHashedFiles(t *testing.T) {
 		// Do NOT create the current file — simulate first run after upgrade
 		currentFile := filepath.Join(stateDir, "last-report-at")
 
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := discardLogger()
 		migrateOldHashedFiles(currentFile, logger)
 
 		// Current file should now exist (renamed from the first old file)
@@ -1589,7 +1433,7 @@ func TestMigrateOldHashedFiles(t *testing.T) {
 
 		currentFile := filepath.Join(stateDir, "last-report-at")
 
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		logger := discardLogger()
 		migrateOldHashedFiles(currentFile, logger)
 
 		// .tmp file should NOT be touched (not renamed, not deleted)
@@ -1606,7 +1450,7 @@ func TestMigrateOldHashedFiles(t *testing.T) {
 func TestPersistLastReportedAt_PersistsAllKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "last-report-at")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := discardLogger()
 
 	// Create a large set of keys — all should be persisted since the in-memory
 	// map is the bound (maxDedupEntries), not a separate persist cap.
@@ -1636,20 +1480,7 @@ func TestCheckNewReviews_AllStaleNoFindings(t *testing.T) {
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	a := &Agent{
-		gh:        gh,
-		cfg:       Config{Owner: "org", Repo: "repo", SlackWebhookURL: "http://example.com/webhook"},
-		state:     NewState(),
-		worktrees: &mockWorktreeManager{},
-		logger:    logger,
-	}
-
-	a.state.ActiveIssues["org/repo#100"] = &IssueWork{
-		PRNumber:   100,
-		IssueTitle: "Fix test",
-		Status:     StatusPROpen,
-	}
+	a := slackTestAgent(gh)
 
 	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
 

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -1265,9 +1265,13 @@ func TestCheckNewReviews_IncludesCommentsWithZeroCreatedAt(t *testing.T) {
 }
 
 func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
-	var postCount int
+	var mu sync.Mutex
+	postCount := 0
+	posts := func() int { mu.Lock(); defer mu.Unlock(); return postCount }
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
 		postCount++
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -1291,8 +1295,8 @@ func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 8380, PRTitle: "Add feature", PRURL: "https://github.com/org/repo/pull/8380", Category: "conflict", Message: "merge conflicts", DedupKey: "conflict:8380"},
 	})
 	reporter1.Flush(context.Background())
-	if postCount != 1 {
-		t.Fatalf("expected 1 POST, got %d", postCount)
+	if posts() != 1 {
+		t.Fatalf("expected 1 POST, got %d", posts())
 	}
 
 	// Simulate restart: create new reporter from persisted state
@@ -1312,8 +1316,8 @@ func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 8380, PRTitle: "Add feature", PRURL: "https://github.com/org/repo/pull/8380", Category: "conflict", Message: "merge conflicts", DedupKey: "conflict:8380"},
 	})
 	reporter2.Flush(context.Background())
-	if postCount != 1 {
-		t.Errorf("expected still 1 POST after restart (dedup keys survived), got %d", postCount)
+	if posts() != 1 {
+		t.Errorf("expected still 1 POST after restart (dedup keys survived), got %d", posts())
 	}
 
 	// New finding should still be reported
@@ -1321,8 +1325,8 @@ func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
 		{Owner: "org", Repo: "repo", PRNumber: 9000, PRTitle: "New PR", PRURL: "https://github.com/org/repo/pull/9000", Category: "rebase", Message: "behind main", DedupKey: "rebase:9000"},
 	})
 	reporter2.Flush(context.Background())
-	if postCount != 2 {
-		t.Errorf("expected 2 POSTs (new finding after restart), got %d", postCount)
+	if posts() != 2 {
+		t.Errorf("expected 2 POSTs (new finding after restart), got %d", posts())
 	}
 }
 

--- a/pkg/agent/triage_test.go
+++ b/pkg/agent/triage_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -12,14 +11,12 @@ func TestProcessTriageJobs_NoJobsConfigured(t *testing.T) {
 	gh := &mockGitHubClient{}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:      "owner",
-		Repo:       "repo",
-		TriageJobs: []string{}, // No jobs configured
-	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.TriageJobs = []string{} // No jobs configured
+		}),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should not create any worktrees or run Claude
@@ -39,22 +36,18 @@ func TestProcessTriageJobs_SkipsAlreadyInvestigated(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
 
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+		}),
+	)
 	// Pre-mark run as already investigated
-	state.MarkRunInvestigated("owner/repo/ci.yml", "100")
-
-	cfg := Config{
-		Owner:      "owner",
-		Repo:       "repo",
-		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-	}
-
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a.state.MarkRunInvestigated("owner/repo/ci.yml", "100")
 	a.ProcessTriageJobs(context.Background())
 
 	// Should still be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "100") {
 		t.Error("expected run to remain marked as investigated")
 	}
 	// Should not create any worktrees (no investigation triggered)
@@ -75,19 +68,16 @@ func TestProcessTriageJobs_SkipsSuccessfulRuns(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
 
-	cfg := Config{
-		Owner:      "owner",
-		Repo:       "repo",
-		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-	}
-
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+		}),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Successful run should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected successful run to be marked as investigated")
 	}
 	// Should not create any worktrees (no investigation needed for success)
@@ -110,15 +100,6 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		TriageJobs:        []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		CreateFlakyIssues: true,
-		FlakyLabel:        "ci-flake",
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -126,7 +107,14 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.CreateFlakyIssues = true
+			c.FlakyLabel = "ci-flake"
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	if codeAgent.callCount != 1 {
@@ -146,7 +134,7 @@ func TestProcessTriageJobs_CreatesIssueWhenFlakyIssuesEnabled(t *testing.T) {
 		t.Errorf("expected label 'ci-flake', got %v", issue.Labels)
 	}
 
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
 }
@@ -164,14 +152,6 @@ func TestProcessTriageJobs_DefaultOnlyChecksLatest(t *testing.T) {
 	}
 	runner := &mockCommandRunner{stdout: triageResult}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:      "owner",
-		Repo:       "repo",
-		FlakyLabel: "flaky-test",
-		TriageJobs: []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		// TriageLookback: 0 (default — only check latest)
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -179,7 +159,14 @@ func TestProcessTriageJobs_DefaultOnlyChecksLatest(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "flaky-test"
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			// TriageLookback: 0 (default — only check latest)
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should only investigate 1 run (the latest)
@@ -188,13 +175,13 @@ func TestProcessTriageJobs_DefaultOnlyChecksLatest(t *testing.T) {
 	}
 
 	// Only the latest run should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
-	if state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected run 200 to NOT be marked as investigated")
 	}
-	if state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+	if a.state.IsRunInvestigated("owner/repo/ci.yml", "100") {
 		t.Error("expected run 100 to NOT be marked as investigated")
 	}
 }
@@ -211,14 +198,6 @@ func TestProcessTriageJobs_LookbackInvestigatesAllFailedRuns(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:          "owner",
-		Repo:           "repo",
-		FlakyLabel:     "flaky-test",
-		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		TriageLookback: 24 * time.Hour, // look back 24 hours
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -227,7 +206,14 @@ func TestProcessTriageJobs_LookbackInvestigatesAllFailedRuns(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "flaky-test"
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.TriageLookback = 24 * time.Hour // look back 24 hours
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should investigate 2 runs (300 and 200 are within 24h; 100 is older)
@@ -236,14 +222,14 @@ func TestProcessTriageJobs_LookbackInvestigatesAllFailedRuns(t *testing.T) {
 	}
 
 	// Runs within window should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected run 200 to be marked as investigated")
 	}
 	// Run older than lookback should NOT be investigated
-	if state.IsRunInvestigated("owner/repo/ci.yml", "100") {
+	if a.state.IsRunInvestigated("owner/repo/ci.yml", "100") {
 		t.Error("expected run 100 to NOT be marked as investigated (too old)")
 	}
 }
@@ -260,14 +246,6 @@ func TestProcessTriageJobs_LookbackSkipsSuccessfulRuns(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:          "owner",
-		Repo:           "repo",
-		FlakyLabel:     "flaky-test",
-		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		TriageLookback: 24 * time.Hour,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -275,7 +253,14 @@ func TestProcessTriageJobs_LookbackSkipsSuccessfulRuns(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "flaky-test"
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.TriageLookback = 24 * time.Hour
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Only 1 agent call for the failed run
@@ -284,10 +269,10 @@ func TestProcessTriageJobs_LookbackSkipsSuccessfulRuns(t *testing.T) {
 	}
 
 	// Both runs should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected failed run 300 to be marked as investigated")
 	}
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected passed run 200 to be marked as investigated")
 	}
 }
@@ -303,18 +288,6 @@ func TestProcessTriageJobs_LookbackSkipsAlreadyInvestigated(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-
-	// Pre-mark run 200 as already investigated
-	state.MarkRunInvestigated("owner/repo/ci.yml", "200")
-
-	cfg := Config{
-		Owner:          "owner",
-		Repo:           "repo",
-		FlakyLabel:     "flaky-test",
-		TriageJobs:     []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		TriageLookback: 24 * time.Hour,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -322,7 +295,16 @@ func TestProcessTriageJobs_LookbackSkipsAlreadyInvestigated(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "flaky-test"
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.TriageLookback = 24 * time.Hour
+		}),
+		withCodeAgent(codeAgent),
+	)
+	// Pre-mark run 200 as already investigated
+	a.state.MarkRunInvestigated("owner/repo/ci.yml", "200")
 	a.ProcessTriageJobs(context.Background())
 
 	// Only 1 agent call (run 200 was already investigated)
@@ -330,7 +312,7 @@ func TestProcessTriageJobs_LookbackSkipsAlreadyInvestigated(t *testing.T) {
 		t.Errorf("expected 1 agent call (skip already investigated), got %d", codeAgent.callCount)
 	}
 
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
 }
@@ -350,15 +332,6 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs:        []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		TriageLookback:    24 * time.Hour,
-	}
 
 	// Both runs produce the same failure signature, so titles match exactly.
 	codeAgent := &sequentialMockCodeAgent{
@@ -368,7 +341,15 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.TriageLookback = 24 * time.Hour
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should create exactly 1 issue (first run) and post a run-link comment (second run)
@@ -388,10 +369,10 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob(t *testing.T) {
 	}
 
 	// Both runs should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected run 200 to be marked as investigated")
 	}
 }
@@ -415,15 +396,6 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob_DifferentSignatures(t
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs:        []string{"https://github.com/owner/repo/actions/workflows/ci.yml"},
-		TriageLookback:    24 * time.Hour,
-	}
 
 	// Runs produce DIFFERENT failure signatures — titles will NOT match exactly.
 	// The LLM says NONE for the second run (unreliable matching).
@@ -436,7 +408,15 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob_DifferentSignatures(t
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{"https://github.com/owner/repo/actions/workflows/ci.yml"}
+			c.TriageLookback = 24 * time.Hour
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should create exactly 1 issue (first run) and post a run-link comment (second run)
@@ -456,10 +436,10 @@ func TestProcessTriageJobs_DeduplicatesMultipleRunsSameJob_DifferentSignatures(t
 	}
 
 	// Both runs should be marked as investigated
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "300") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "300") {
 		t.Error("expected run 300 to be marked as investigated")
 	}
-	if !state.IsRunInvestigated("owner/repo/ci.yml", "200") {
+	if !a.state.IsRunInvestigated("owner/repo/ci.yml", "200") {
 		t.Error("expected run 200 to be marked as investigated")
 	}
 
@@ -487,17 +467,6 @@ func TestProcessTriageJobs_DeduplicatesDifferentJobsSameRootCause(t *testing.T) 
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs: []string{
-			"https://github.com/owner/repo/actions/workflows/unit.yml",
-			"https://github.com/owner/repo/actions/workflows/e2e.yml",
-		},
-	}
 
 	// First job: analysis + no match (NONE) → creates issue
 	// Second job: analysis + LLM match → deduplicates
@@ -509,7 +478,17 @@ func TestProcessTriageJobs_DeduplicatesDifferentJobsSameRootCause(t *testing.T) 
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{
+				"https://github.com/owner/repo/actions/workflows/unit.yml",
+				"https://github.com/owner/repo/actions/workflows/e2e.yml",
+			}
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should create exactly 1 issue (first job) and post a run-link (second job)
@@ -534,10 +513,10 @@ func TestProcessTriageJobs_DeduplicatesDifferentJobsSameRootCause(t *testing.T) 
 	}
 
 	// Both runs should be investigated
-	if !state.IsRunInvestigated("owner/repo/unit.yml", "100") {
+	if !a.state.IsRunInvestigated("owner/repo/unit.yml", "100") {
 		t.Error("expected unit.yml run to be marked as investigated")
 	}
-	if !state.IsRunInvestigated("owner/repo/e2e.yml", "100") {
+	if !a.state.IsRunInvestigated("owner/repo/e2e.yml", "100") {
 		t.Error("expected e2e.yml run to be marked as investigated")
 	}
 }
@@ -613,20 +592,19 @@ func TestTriageDedup_DifferentFailuresSameJob_MatchesByJobName(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs:        []string{},
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{}
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	// Different failure signature from the same job
 	title := "CI Failure: periodic-knmstate-e2e-handler-k8s-latest / CRI-O mirror returned HTTP 404"
@@ -736,13 +714,6 @@ func TestTriageDedup_SameJobCycleIssue_MatchesBeforeLLM(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -751,7 +722,13 @@ func TestTriageDedup_SameJobCycleIssue_MatchesBeforeLLM(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	cycleIssues := []Issue{
 		{Number: 10, Title: "CI Failure: owner/repo/ci.yml / Compile error in main.go line 42"},
@@ -794,19 +771,18 @@ func TestTriageDedup_SameFailureSameJob_MatchesExistingIssue(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	// New failure is also a DNS issue, but slightly different title
 	title := "CI Failure: periodic-e2e-test / DNS lookup timed out for registry.k8s.io"
@@ -843,19 +819,18 @@ func TestTriageDedup_ExactTitleMatch_SkipsLLM(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{}, // No results — should NOT be called
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	title := "CI Failure: periodic-e2e-test / CRI-O mirror HTTP 404"
 	analysis := "## Summary\nCRI-O mirror HTTP 404\n\n## Root Cause\nMirror outage"
@@ -894,19 +869,18 @@ func TestTriageDedup_SameJobDifferentSignature_MatchesAcrossDays(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	// Next day: same job, different failure signature from LLM
 	title := "CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / IPAM controller pod CrashLoopBackOff"
@@ -944,19 +918,18 @@ func TestTriageDedup_SameJobNoSignature_MatchesAcrossDays(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	title := "CI Failure: owner/repo/ci.yml / New failure signature"
 	analysis := "## Summary\nNew failure"
@@ -989,13 +962,6 @@ func TestTriageDedup_DifferentJob_DoesNotSameJobMatch(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{
@@ -1003,7 +969,13 @@ func TestTriageDedup_DifferentJob_DoesNotSameJobMatch(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	// Different job name
 	title := "CI Failure: owner/repo/ci.yml / Compile error"
@@ -1110,19 +1082,18 @@ func TestTriageDedup_NoExistingIssues_ReturnsZero(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	codeAgent := &sequentialMockCodeAgent{
 		results: []mockCodeAgentCall{},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	matchedIssue := a.matchExistingTriageIssue(context.Background(),
 		"periodic-e2e-test",
@@ -1147,13 +1118,8 @@ func TestTriageDedup_AddRunLinkComment(t *testing.T) {
 	gh := &mockGitHubClient{}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner: "owner",
-		Repo:  "repo",
-	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), &ClaudeCodeAgent{})
+	a := newTestAgent(gh, runner, wtm)
 
 	run := JobRun{
 		ID:     "12345",
@@ -1255,18 +1221,6 @@ func TestProcessTriageJobs_DeterministicFallbackWhenLLMSaysNone(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs: []string{
-			"https://github.com/owner/repo/actions/workflows/unit.yml",
-			"https://github.com/owner/repo/actions/workflows/e2e.yml",
-			"https://github.com/owner/repo/actions/workflows/lint.yml",
-		},
-	}
 
 	// First job: analysis → no match → creates issue
 	// Second job: analysis + LLM says NONE → deterministic fallback should match
@@ -1281,7 +1235,18 @@ func TestProcessTriageJobs_DeterministicFallbackWhenLLMSaysNone(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{
+				"https://github.com/owner/repo/actions/workflows/unit.yml",
+				"https://github.com/owner/repo/actions/workflows/e2e.yml",
+				"https://github.com/owner/repo/actions/workflows/lint.yml",
+			}
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should create exactly 1 issue (first job); jobs 2 and 3 use deterministic fallback
@@ -1311,13 +1276,6 @@ func TestTriageDedup_DeterministicFallbackWithCycleIssuesMerged(t *testing.T) {
 	}
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-	}
 
 	// LLM says NONE — deterministic fallback should fire after LLM
 	codeAgent := &sequentialMockCodeAgent{
@@ -1326,7 +1284,13 @@ func TestTriageDedup_DeterministicFallbackWithCycleIssuesMerged(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+		}),
+		withCodeAgent(codeAgent),
+	)
 
 	title := "CI Failure: job-b / DNS timeout"
 	analysis := "## Summary\nDNS timeout"
@@ -1379,17 +1343,6 @@ func TestTriageDedup_DeterministicFallbackWithMultiLineNone(t *testing.T) {
 
 	runner := &mockCommandRunner{}
 	wtm := &mockWorktreeManager{}
-	state := NewState()
-	cfg := Config{
-		Owner:             "owner",
-		Repo:              "repo",
-		FlakyLabel:        "ci-flake",
-		CreateFlakyIssues: true,
-		TriageJobs: []string{
-			"https://github.com/owner/repo/actions/workflows/unit.yml",
-			"https://github.com/owner/repo/actions/workflows/e2e.yml",
-		},
-	}
 
 	// First job: analysis → creates issue
 	// Second job: analysis + LLM says NONE → deterministic fallback
@@ -1401,7 +1354,17 @@ func TestTriageDedup_DeterministicFallbackWithMultiLineNone(t *testing.T) {
 		},
 	}
 
-	a := NewAgent(gh, runner, wtm, state, cfg, slog.Default(), codeAgent)
+	a := newTestAgent(gh, runner, wtm,
+		withCfg(func(c *Config) {
+			c.FlakyLabel = "ci-flake"
+			c.CreateFlakyIssues = true
+			c.TriageJobs = []string{
+				"https://github.com/owner/repo/actions/workflows/unit.yml",
+				"https://github.com/owner/repo/actions/workflows/e2e.yml",
+			}
+		}),
+		withCodeAgent(codeAgent),
+	)
 	a.ProcessTriageJobs(context.Background())
 
 	// Should create exactly 1 issue; second job uses deterministic fallback


### PR DESCRIPTION
## Summary

Phase 3a of the unslop series (#269, #270, #271, #272, #273): consolidate the test suite's construction and fixture boilerplate. The suite had three competing ways to build an `Agent`, four hand-rolled copies of the same webhook server, 94 copies of the same `IssueWork` fixture, and 22 copies of the same config write+load block. Net **-899 lines** of test code with zero behavior change to production.

## Changes

**One way to build a test agent** (`mocks_test.go`)
- `newTestAgent` now routes through the production `NewAgent` constructor, so tests get the same wiring production does (previously raw struct fill-in silently skipped the emitter — the exact drift the nil-guard in `Agent.emit` papers over).
- Functional options `withCfg` / `withCodeAgent`; the worktree parameter widened to the `WorktreeManager` interface.
- Adopted everywhere: the 23 inline `NewAgent` preambles in triage tests, the 11 verbatim `&Agent{...}` literals in slack tests, and the 2 commit-msg-file literals in review tests are gone. The only remaining raw literals are `&Agent{cfg: ...}` in pure-function tests.

**Shared fixtures and helpers**
- `trackWork(agent, ...mutate)` registers the canonical in-flight fixture (issue 42 → PR 100 on `ai/issue-42`); 94 hand-copied `IssueWork` literals now express only their scenario's delta (a cursor, a cost, a rebase timestamp).
- `countCalls(calls, name)` replaces ~30 inline "count the claude calls" loops and ci_test.go's private `countClaudeCalls`.
- `discardLogger()` replaces 41 hand-rolled `slog.New(slog.NewTextHandler(io.Discard, nil))` lines; `newTestAgent` previously used the noisy `slog.Default()`.
- slack: `slackTestAgent` (canonical org/repo agent with one tracked PR) and `newCountingWebhook` (XDG_STATE_HOME + httptest + reporter, now mutex-guarded where the old copies raced in principle).
- fileconfig: `loadConfig(t, yaml)` folds the 22 temp-dir/WriteFile/LoadFileConfig blocks — with the write error actually checked instead of `//nolint`-ed away.

**Deferred** (follow-up PR 3b): table-driven merges of the near-identical test-function clusters (conflicts rebase-guard, triage dedup, slack Check\*, issues skip/defer, ci parse/format, review cursor); consolidation of the 8 embed-and-intercept runner wrappers.

## Testing

- `go build ./...`
- `go test ./... -count=1 -race` — all packages pass
- `golangci-lint run` — 0 issues

## Related Issues

Part of the phased unslop series: #269 → #270 → #271 → #272 → #273 → this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test consistency by centralizing agent, issue, logging, configuration, and webhook setup.
  * Standardized call-count assertions across issue processing, reviews, CI, and integration scenarios.
  * Expanded polling assertions to verify behavior before and after CI failures appear.
  * Preserved coverage for triage, Slack reporting, conflicts, rebasing, configuration validation, and issue lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->