### PR TITLE
test: phase 3b unslop — table-drive the duplicated test clusters

### DIFF
--- a/pkg/agent/ci_test.go
+++ b/pkg/agent/ci_test.go
@@ -505,7 +505,7 @@ func TestWriteStructuredBody(t *testing.T) {
 		},
 		{
 			name:            "empty emits no sections",
-			wantNotContains: []string{"### Error", "### Root Cause"},
+			wantNotContains: []string{"### Error", "### Root Cause", "### Recommendation"},
 		},
 	}
 	for _, tt := range tests {
@@ -532,37 +532,34 @@ func TestWriteStructuredBody(t *testing.T) {
 // fence longer than its longest run so the content cannot break out.
 func TestWriteFenced(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
-		wantContains []string
+		name string
+		body string
+		want string // exact output: heading plus opening and closing fence
 	}{
 		{
-			name:         "no backticks uses standard fence",
-			body:         "plain error text",
-			wantContains: []string{"```\nplain error text\n```"},
+			name: "no backticks uses standard fence",
+			body: "plain error text",
+			want: "\n### Error\n```\nplain error text\n```\n",
 		},
 		{
 			// A 4-backtick fence avoids breakout and the body is preserved unchanged.
-			name:         "triple backticks in body use longer fence",
-			body:         "Error in ```yaml\nkey: value\n```",
-			wantContains: []string{"````", "Error in ```yaml\nkey: value\n```"},
+			name: "triple backticks in body use longer fence",
+			body: "Error in ```yaml\nkey: value\n```",
+			want: "\n### Error\n````\nError in ```yaml\nkey: value\n```\n````\n",
 		},
 		{
 			// Fence must be longer than 5, the longest backtick run in the body.
-			name:         "long backtick run uses even longer fence",
-			body:         "Some `````long````` backtick run",
-			wantContains: []string{"``````"},
+			name: "long backtick run uses even longer fence",
+			body: "Some `````long````` backtick run",
+			want: "\n### Error\n``````\nSome `````long````` backtick run\n``````\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var b strings.Builder
 			writeFenced(&b, "### Error", tt.body)
-			output := b.String()
-			for _, want := range tt.wantContains {
-				if !strings.Contains(output, want) {
-					t.Errorf("output missing %q, got: %s", want, output)
-				}
+			if got := b.String(); got != tt.want {
+				t.Errorf("writeFenced output = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/agent/ci_test.go
+++ b/pkg/agent/ci_test.go
@@ -7,8 +7,26 @@ import (
 	"testing"
 )
 
-func TestParseCIStructuredFields_AllFields(t *testing.T) {
-	input := `ERROR_SUMMARY: test assertion failed in kubevirt handler
+// TestParseCIStructuredFields covers extraction of the structured CI
+// investigation fields (ERROR_SUMMARY, ROOT_CAUSE, EVIDENCE, RECOMMENDATION,
+// FAILING_TEST) from an agent result: complete and partial field sets, fully
+// unstructured input, multi-line evidence that stops only at column-0 field
+// headers, and skipping of the CLASSIFICATION line.
+func TestParseCIStructuredFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		// wantExact maps field name to its exact expected value; an empty
+		// string asserts the field must be empty.
+		wantExact map[string]string
+		// wantContains and wantNotContains map field name to substrings the
+		// field must or must not contain.
+		wantContains    map[string][]string
+		wantNotContains map[string][]string
+	}{
+		{
+			name: "all fields",
+			input: `ERROR_SUMMARY: test assertion failed in kubevirt handler
 
 ROOT_CAUSE: The PR changed GenerateNetworkOverrideMachineConfig() but didn't update the test fixture to include the new nmstate config fields.
 
@@ -19,66 +37,48 @@ TestKubeVirtHandler/should_generate_nmstate_config:
 
 RECOMMENDATION: Update test fixtures to include new nmstate config fields.
 
-FAILING_TEST: TestKubeVirtHandler/should_generate_nmstate_config`
-
-	errorSummary, rootCause, evidence, recommendation, failingTest := parseCIStructuredFields(input)
-
-	if errorSummary != "test assertion failed in kubevirt handler" {
-		t.Errorf("errorSummary = %q, want %q", errorSummary, "test assertion failed in kubevirt handler")
-	}
-	if !strings.Contains(rootCause, "GenerateNetworkOverrideMachineConfig") {
-		t.Errorf("rootCause missing expected content, got %q", rootCause)
-	}
-	if !strings.Contains(evidence, "autoconf: false") {
-		t.Errorf("evidence missing expected content, got %q", evidence)
-	}
-	if !strings.Contains(recommendation, "Update test fixtures") {
-		t.Errorf("recommendation missing expected content, got %q", recommendation)
-	}
-	if failingTest != "TestKubeVirtHandler/should_generate_nmstate_config" {
-		t.Errorf("failingTest = %q, want %q", failingTest, "TestKubeVirtHandler/should_generate_nmstate_config")
-	}
-}
-
-func TestParseCIStructuredFields_MissingFields(t *testing.T) {
-	input := `Some preamble text.
+FAILING_TEST: TestKubeVirtHandler/should_generate_nmstate_config`,
+			wantExact: map[string]string{
+				"errorSummary": "test assertion failed in kubevirt handler",
+				"failingTest":  "TestKubeVirtHandler/should_generate_nmstate_config",
+			},
+			wantContains: map[string][]string{
+				"rootCause":      {"GenerateNetworkOverrideMachineConfig"},
+				"evidence":       {"autoconf: false"},
+				"recommendation": {"Update test fixtures"},
+			},
+		},
+		{
+			name: "missing fields stay empty",
+			input: `Some preamble text.
 
 ERROR_SUMMARY: HTTP 500 from git server
 
-ROOT_CAUSE: GitHub's git server returned HTTP 500 during clone.`
-
-	errorSummary, rootCause, evidence, recommendation, failingTest := parseCIStructuredFields(input)
-
-	if errorSummary != "HTTP 500 from git server" {
-		t.Errorf("errorSummary = %q, want %q", errorSummary, "HTTP 500 from git server")
-	}
-	if !strings.Contains(rootCause, "HTTP 500") {
-		t.Errorf("rootCause = %q, expected to contain 'HTTP 500'", rootCause)
-	}
-	if evidence != "" {
-		t.Errorf("evidence should be empty, got %q", evidence)
-	}
-	if recommendation != "" {
-		t.Errorf("recommendation should be empty, got %q", recommendation)
-	}
-	if failingTest != "" {
-		t.Errorf("failingTest should be empty, got %q", failingTest)
-	}
-}
-
-func TestParseCIStructuredFields_NoFields(t *testing.T) {
-	input := "GitHub git server returned HTTP 500. This is an infrastructure failure."
-
-	errorSummary, rootCause, evidence, recommendation, failingTest := parseCIStructuredFields(input)
-
-	if errorSummary != "" || rootCause != "" || evidence != "" || recommendation != "" || failingTest != "" {
-		t.Errorf("expected all empty fields for unstructured input, got: summary=%q root=%q evidence=%q rec=%q test=%q",
-			errorSummary, rootCause, evidence, recommendation, failingTest)
-	}
-}
-
-func TestParseCIStructuredFields_EvidenceMultiLine(t *testing.T) {
-	input := `ERROR_SUMMARY: test timeout
+ROOT_CAUSE: GitHub's git server returned HTTP 500 during clone.`,
+			wantExact: map[string]string{
+				"errorSummary":   "HTTP 500 from git server",
+				"evidence":       "",
+				"recommendation": "",
+				"failingTest":    "",
+			},
+			wantContains: map[string][]string{
+				"rootCause": {"HTTP 500"},
+			},
+		},
+		{
+			name:  "unstructured input yields no fields",
+			input: "GitHub git server returned HTTP 500. This is an infrastructure failure.",
+			wantExact: map[string]string{
+				"errorSummary":   "",
+				"rootCause":      "",
+				"evidence":       "",
+				"recommendation": "",
+				"failingTest":    "",
+			},
+		},
+		{
+			name: "multi-line evidence stops at next field",
+			input: `ERROR_SUMMARY: test timeout
 
 EVIDENCE:
 === RUN TestNetworkPolicy
@@ -86,39 +86,83 @@ EVIDENCE:
     waiting for pod readiness
 --- FAIL: TestNetworkPolicy (300.12s)
 
-RECOMMENDATION: Retest with /retest`
-
-	_, _, evidence, recommendation, _ := parseCIStructuredFields(input)
-
-	if !strings.Contains(evidence, "TestNetworkPolicy") {
-		t.Errorf("evidence missing test name, got %q", evidence)
-	}
-	if !strings.Contains(evidence, "timeout after 300s") {
-		t.Errorf("evidence missing timeout message, got %q", evidence)
-	}
-	// Evidence should stop at the next field
-	if strings.Contains(evidence, "RECOMMENDATION") {
-		t.Errorf("evidence should not contain RECOMMENDATION field, got %q", evidence)
-	}
-	if recommendation != "Retest with /retest" {
-		t.Errorf("recommendation = %q, want %q", recommendation, "Retest with /retest")
-	}
-}
-
-func TestParseCIStructuredFields_ClassificationLineSkipped(t *testing.T) {
-	input := `CLASSIFICATION: INFRASTRUCTURE
+RECOMMENDATION: Retest with /retest`,
+			wantExact: map[string]string{
+				"recommendation": "Retest with /retest",
+			},
+			wantContains: map[string][]string{
+				"evidence": {"TestNetworkPolicy", "timeout after 300s"},
+			},
+			wantNotContains: map[string][]string{
+				"evidence": {"RECOMMENDATION"},
+			},
+		},
+		{
+			name: "classification line skipped",
+			input: `CLASSIFICATION: INFRASTRUCTURE
 
 ERROR_SUMMARY: DNS resolution failure
 
-ROOT_CAUSE: Cluster DNS was unavailable.`
+ROOT_CAUSE: Cluster DNS was unavailable.`,
+			wantExact: map[string]string{
+				"errorSummary": "DNS resolution failure",
+				"rootCause":    "Cluster DNS was unavailable.",
+			},
+		},
+		{
+			// Indented lines that look like field headers must not terminate
+			// evidence capture because they are not at column 0.
+			name: "indented field-like lines stay in evidence",
+			input: `ERROR_SUMMARY: test failure
 
-	errorSummary, rootCause, _, _, _ := parseCIStructuredFields(input)
+EVIDENCE:
+  test output:
+    RECOMMENDATION: some test recommendation output
+    ROOT_CAUSE: some diagnostic line
+  more test output
 
-	if errorSummary != "DNS resolution failure" {
-		t.Errorf("errorSummary = %q, want %q", errorSummary, "DNS resolution failure")
+RECOMMENDATION: Retest with /retest`,
+			wantExact: map[string]string{
+				"recommendation": "Retest with /retest",
+			},
+			wantContains: map[string][]string{
+				"evidence": {
+					"RECOMMENDATION: some test recommendation output",
+					"ROOT_CAUSE: some diagnostic line",
+				},
+			},
+		},
 	}
-	if rootCause != "Cluster DNS was unavailable." {
-		t.Errorf("rootCause = %q, want %q", rootCause, "Cluster DNS was unavailable.")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errorSummary, rootCause, evidence, recommendation, failingTest := parseCIStructuredFields(tt.input)
+			got := map[string]string{
+				"errorSummary":   errorSummary,
+				"rootCause":      rootCause,
+				"evidence":       evidence,
+				"recommendation": recommendation,
+				"failingTest":    failingTest,
+			}
+			for field, want := range tt.wantExact {
+				if got[field] != want {
+					t.Errorf("%s = %q, want %q", field, got[field], want)
+				}
+			}
+			for field, subs := range tt.wantContains {
+				for _, sub := range subs {
+					if !strings.Contains(got[field], sub) {
+						t.Errorf("%s missing %q, got %q", field, sub, got[field])
+					}
+				}
+			}
+			for field, subs := range tt.wantNotContains {
+				for _, sub := range subs {
+					if strings.Contains(got[field], sub) {
+						t.Errorf("%s should not contain %q, got %q", field, sub, got[field])
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -159,207 +203,253 @@ func TestFormatCISummaryHeader(t *testing.T) {
 	}
 }
 
+// TestFormatCIRelatedDetails covers the collapsible details block for a
+// related CI failure: the full section layout when a fix was pushed, the
+// fix-needed variant without an Action section, and HTML escaping of the
+// check name.
 func TestFormatCIRelatedDetails(t *testing.T) {
-	r := ciResult{
-		check:          "unit-tests",
-		category:       "related",
-		errorSummary:   "test assertion failed",
-		rootCause:      "PR changed the handler but test fixture was not updated.",
-		evidence:       "Expected: \"autoconf: false\"\nGot: \"\"",
-		recommendation: "Update test fixtures.",
-		pushed:         true,
+	tests := []struct {
+		name            string
+		r               ciResult
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "pushed fix renders all sections",
+			r: ciResult{
+				check:          "unit-tests",
+				category:       "related",
+				errorSummary:   "test assertion failed",
+				rootCause:      "PR changed the handler but test fixture was not updated.",
+				evidence:       "Expected: \"autoconf: false\"\nGot: \"\"",
+				recommendation: "Update test fixtures.",
+				pushed:         true,
+			},
+			wantContains: []string{
+				"<details>",
+				"🔴 Related",
+				"<code>unit-tests</code>",
+				"fix pushed",
+				"### Error",
+				"autoconf: false",
+				"### Root Cause",
+				"handler but test fixture",
+				"### Action",
+				"</details>",
+			},
+		},
+		{
+			name: "not pushed omits Action section",
+			r: ciResult{
+				check:          "lint",
+				category:       "related",
+				errorSummary:   "lint failure",
+				recommendation: "Fix lint errors.",
+			},
+			wantContains:    []string{"fix needed"},
+			wantNotContains: []string{"### Action"},
+		},
+		{
+			// Check name must be HTML-escaped inside <code> tags.
+			name: "HTML-escapes check name",
+			r: ciResult{
+				check:        "pull-ci-<org>/repo-e2e",
+				category:     "related",
+				errorSummary: "test failed",
+			},
+			wantContains:    []string{"&lt;org&gt;"},
+			wantNotContains: []string{"<org>"},
+		},
 	}
-
-	output := formatCIRelatedDetails(r)
-
-	if !strings.Contains(output, "<details>") {
-		t.Errorf("expected collapsible details block")
-	}
-	if !strings.Contains(output, "🔴 Related") {
-		t.Errorf("expected Related emoji marker")
-	}
-	if !strings.Contains(output, "<code>unit-tests</code>") {
-		t.Errorf("expected check name in code block")
-	}
-	if !strings.Contains(output, "fix pushed") {
-		t.Errorf("expected 'fix pushed' in summary")
-	}
-	if !strings.Contains(output, "### Error") {
-		t.Errorf("expected Error section")
-	}
-	if !strings.Contains(output, "autoconf: false") {
-		t.Errorf("expected evidence in Error section")
-	}
-	if !strings.Contains(output, "### Root Cause") {
-		t.Errorf("expected Root Cause section")
-	}
-	if !strings.Contains(output, "handler but test fixture") {
-		t.Errorf("expected root cause content")
-	}
-	if !strings.Contains(output, "### Action") {
-		t.Errorf("expected Action section for pushed fix")
-	}
-	if !strings.Contains(output, "</details>") {
-		t.Errorf("expected closing details tag")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := formatCIRelatedDetails(tt.r)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q, got: %s", want, output)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(output, notWant) {
+					t.Errorf("output should not contain %q, got: %s", notWant, output)
+				}
+			}
+		})
 	}
 }
 
-func TestFormatCIRelatedDetails_NotPushed(t *testing.T) {
-	r := ciResult{
-		check:          "lint",
-		category:       "related",
-		errorSummary:   "lint failure",
-		recommendation: "Fix lint errors.",
-	}
-
-	output := formatCIRelatedDetails(r)
-
-	if !strings.Contains(output, "fix needed") {
-		t.Errorf("expected 'fix needed' in summary for non-pushed fix")
-	}
-	if strings.Contains(output, "### Action") {
-		t.Errorf("should not have Action section when fix was not pushed")
-	}
-}
-
+// TestFormatCIUnrelatedDetails covers the collapsible details block for an
+// unrelated CI failure: the flaky-issue reference and Known Issue section
+// when a flaky issue exists, their absence when none does, and HTML escaping
+// of the check name.
 func TestFormatCIUnrelatedDetails(t *testing.T) {
-	r := ciResult{
-		check:          "e2e-conformance",
-		category:       "unrelated",
-		errorSummary:   "SCTP ingress test timeout",
-		rootCause:      "This test has been flaking independently due to cluster network latency.",
-		evidence:       "TestNetworkPolicyV2 — timeout after 300s",
-		recommendation: "Skip or quarantine the test.",
-		failingTest:    "TestNetworkPolicyV2",
-		flakyIssue:     6381,
+	tests := []struct {
+		name            string
+		r               ciResult
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "flaky issue referenced",
+			r: ciResult{
+				check:          "e2e-conformance",
+				category:       "unrelated",
+				errorSummary:   "SCTP ingress test timeout",
+				rootCause:      "This test has been flaking independently due to cluster network latency.",
+				evidence:       "TestNetworkPolicyV2 — timeout after 300s",
+				recommendation: "Skip or quarantine the test.",
+				failingTest:    "TestNetworkPolicyV2",
+				flakyIssue:     6381,
+			},
+			wantContains: []string{
+				"<details>",
+				"⚠️ Unrelated",
+				"flaky test (#6381)",
+				"### Known Issue",
+				"#6381",
+			},
+		},
+		{
+			name: "no flaky issue omits Known Issue section",
+			r: ciResult{
+				check:        "e2e-network",
+				category:     "unrelated",
+				errorSummary: "network timeout",
+			},
+			wantContains:    []string{"flaky test"},
+			wantNotContains: []string{"Known Issue"},
+		},
+		{
+			name: "HTML-escapes check name",
+			r: ciResult{
+				check:        "e2e-<shard>&test",
+				category:     "unrelated",
+				errorSummary: "flaky timeout",
+			},
+			wantContains: []string{"&lt;shard&gt;&amp;test"},
+		},
 	}
-	agent := &Agent{cfg: Config{}}
-
-	output := formatCIUnrelatedDetails(r, agent)
-
-	if !strings.Contains(output, "<details>") {
-		t.Errorf("expected collapsible details block")
-	}
-	if !strings.Contains(output, "⚠️ Unrelated") {
-		t.Errorf("expected Unrelated emoji marker")
-	}
-	if !strings.Contains(output, "flaky test (#6381)") {
-		t.Errorf("expected flaky issue reference in summary")
-	}
-	if !strings.Contains(output, "### Known Issue") {
-		t.Errorf("expected Known Issue section")
-	}
-	if !strings.Contains(output, "#6381") {
-		t.Errorf("expected issue reference")
-	}
-}
-
-func TestFormatCIUnrelatedDetails_NoFlakyIssue(t *testing.T) {
-	r := ciResult{
-		check:        "e2e-network",
-		category:     "unrelated",
-		errorSummary: "network timeout",
-	}
-	agent := &Agent{cfg: Config{}}
-
-	output := formatCIUnrelatedDetails(r, agent)
-
-	if !strings.Contains(output, "flaky test") {
-		t.Errorf("expected 'flaky test' label")
-	}
-	if strings.Contains(output, "Known Issue") {
-		t.Errorf("should not have Known Issue section without flaky issue")
-	}
-}
-
-func TestFormatCIInfrastructureSection_Grouped(t *testing.T) {
-	infra := []ciResult{
-		{check: "test-deploy", category: "infrastructure", errorSummary: "HTTP 500 from git server", rootCause: "GitHub outage", recommendation: "Retest with /retest"},
-		{check: "check-license-header", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
-		{check: "e2e-dual-conversion", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
-	}
-
-	output := formatCIInfrastructureSection(infra)
-
-	if !strings.Contains(output, "🔧 Infrastructure (3)") {
-		t.Errorf("expected grouped infrastructure header with count 3")
-	}
-	if !strings.Contains(output, "HTTP 500 from git server") {
-		t.Errorf("expected error summary in header")
-	}
-	// All checks should appear in the table
-	if !strings.Contains(output, "`test-deploy`") {
-		t.Errorf("expected test-deploy in table")
-	}
-	if !strings.Contains(output, "`check-license-header`") {
-		t.Errorf("expected check-license-header in table")
-	}
-	if !strings.Contains(output, "`e2e-dual-conversion`") {
-		t.Errorf("expected e2e-dual-conversion in table")
-	}
-	// Should use root cause from first result
-	if !strings.Contains(output, "GitHub outage") {
-		t.Errorf("expected root cause from first result")
-	}
-	if !strings.Contains(output, "Retest with /retest") {
-		t.Errorf("expected recommendation from first result")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &Agent{cfg: Config{}}
+			output := formatCIUnrelatedDetails(tt.r, agent)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q, got: %s", want, output)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(output, notWant) {
+					t.Errorf("output should not contain %q, got: %s", notWant, output)
+				}
+			}
+		})
 	}
 }
 
-func TestFormatCIInfrastructureSection_SingleCheck(t *testing.T) {
-	infra := []ciResult{
-		{check: "build", category: "infrastructure", errorSummary: "OOM killed", rootCause: "Runner ran out of memory."},
+// TestFormatCIInfrastructureSection covers grouping of infrastructure
+// failures in the consolidated comment: identical errors collapse into one
+// grouped block listing every check, a single check gets its own compact
+// block, mixed errors split into separate groups, and single-check names are
+// HTML-escaped.
+func TestFormatCIInfrastructureSection(t *testing.T) {
+	tests := []struct {
+		name         string
+		infra        []ciResult
+		wantContains []string
+	}{
+		{
+			name: "grouped identical errors",
+			infra: []ciResult{
+				{check: "test-deploy", category: "infrastructure", errorSummary: "HTTP 500 from git server", rootCause: "GitHub outage", recommendation: "Retest with /retest"},
+				{check: "check-license-header", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
+				{check: "e2e-dual-conversion", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
+			},
+			// All checks appear in the table; root cause and recommendation
+			// come from the first result.
+			wantContains: []string{
+				"🔧 Infrastructure (3)",
+				"HTTP 500 from git server",
+				"`test-deploy`",
+				"`check-license-header`",
+				"`e2e-dual-conversion`",
+				"GitHub outage",
+				"Retest with /retest",
+			},
+		},
+		{
+			name: "single check",
+			infra: []ciResult{
+				{check: "build", category: "infrastructure", errorSummary: "OOM killed", rootCause: "Runner ran out of memory."},
+			},
+			wantContains: []string{
+				"🔧 Infrastructure: <code>build</code>",
+				"OOM killed",
+				"Runner ran out of memory",
+			},
+		},
+		{
+			// Two groups: one with 2 checks (HTTP 500) and one single (OOM).
+			name: "mixed errors split into groups",
+			infra: []ciResult{
+				{check: "test-deploy", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
+				{check: "e2e-bgp", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
+				{check: "build", category: "infrastructure", errorSummary: "OOM killed"},
+			},
+			wantContains: []string{
+				"Infrastructure (2)",
+				"Infrastructure: <code>build</code>",
+			},
+		},
+		{
+			name: "HTML-escapes single check name",
+			infra: []ciResult{
+				{check: "build-<arch>", category: "infrastructure", errorSummary: "OOM killed"},
+			},
+			wantContains: []string{"&lt;arch&gt;"},
+		},
 	}
-
-	output := formatCIInfrastructureSection(infra)
-
-	if !strings.Contains(output, "🔧 Infrastructure: <code>build</code>") {
-		t.Errorf("expected single infrastructure check format")
-	}
-	if !strings.Contains(output, "OOM killed") {
-		t.Errorf("expected error summary")
-	}
-	if !strings.Contains(output, "Runner ran out of memory") {
-		t.Errorf("expected root cause")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := formatCIInfrastructureSection(tt.infra)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q, got: %s", want, output)
+				}
+			}
+		})
 	}
 }
 
-func TestFormatCIInfrastructureSection_MixedErrors(t *testing.T) {
-	infra := []ciResult{
-		{check: "test-deploy", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
-		{check: "e2e-bgp", category: "infrastructure", errorSummary: "HTTP 500 from git server"},
-		{check: "build", category: "infrastructure", errorSummary: "OOM killed"},
+// TestResultSummaryLine covers the one-line summary choice: a structured
+// error summary wins over the free-form explanation, which is truncated to
+// its first sentence when used as the fallback.
+func TestResultSummaryLine(t *testing.T) {
+	tests := []struct {
+		name string
+		r    ciResult
+		want string
+	}{
+		{
+			name: "prefers error summary",
+			r: ciResult{
+				errorSummary: "structured summary",
+				explanation:  "Full explanation with many details. Second sentence.",
+			},
+			want: "structured summary",
+		},
+		{
+			name: "falls back to first sentence of explanation",
+			r:    ciResult{explanation: "Full explanation with many details. Second sentence."},
+			want: "Full explanation with many details.",
+		},
 	}
-
-	output := formatCIInfrastructureSection(infra)
-
-	// Should have two groups: one with 2 (HTTP 500) and one single (OOM)
-	if !strings.Contains(output, "Infrastructure (2)") {
-		t.Errorf("expected grouped header with count 2")
-	}
-	if !strings.Contains(output, "Infrastructure: <code>build</code>") {
-		t.Errorf("expected single check format for OOM")
-	}
-}
-
-func TestResultSummaryLine_PrefersErrorSummary(t *testing.T) {
-	r := ciResult{
-		errorSummary: "structured summary",
-		explanation:  "Full explanation with many details. Second sentence.",
-	}
-	got := resultSummaryLine(r)
-	if got != "structured summary" {
-		t.Errorf("resultSummaryLine = %q, want %q", got, "structured summary")
-	}
-}
-
-func TestResultSummaryLine_FallsBackToExplanation(t *testing.T) {
-	r := ciResult{
-		explanation: "Full explanation with many details. Second sentence.",
-	}
-	got := resultSummaryLine(r)
-	if got != "Full explanation with many details." {
-		t.Errorf("resultSummaryLine = %q, want %q", got, "Full explanation with many details.")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resultSummaryLine(tt.r); got != tt.want {
+				t.Errorf("resultSummaryLine = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -381,164 +471,100 @@ func TestEscapeHTML(t *testing.T) {
 	}
 }
 
-func TestWriteStructuredBody_AllFields(t *testing.T) {
-	var b strings.Builder
-	r := ciResult{
-		evidence:       "line 1\nline 2",
-		rootCause:      "Something broke.",
-		recommendation: "Fix it.",
+// TestWriteStructuredBody covers section emission in writeStructuredBody:
+// every section when evidence, root cause, and recommendation are set, the
+// summary as Error-section fallback when evidence is missing, and no
+// sections at all for an empty result.
+func TestWriteStructuredBody(t *testing.T) {
+	tests := []struct {
+		name            string
+		summary         string
+		r               ciResult
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:    "all fields",
+			summary: "summary line",
+			r: ciResult{
+				evidence:       "line 1\nline 2",
+				rootCause:      "Something broke.",
+				recommendation: "Fix it.",
+			},
+			wantContains: []string{
+				"### Error",
+				"line 1\nline 2",
+				"### Root Cause",
+				"### Recommendation",
+			},
+		},
+		{
+			name:         "no evidence uses summary",
+			summary:      "fallback summary",
+			wantContains: []string{"fallback summary"},
+		},
+		{
+			name:            "empty emits no sections",
+			wantNotContains: []string{"### Error", "### Root Cause"},
+		},
 	}
-	writeStructuredBody(&b, "summary line", r)
-	output := b.String()
-
-	if !strings.Contains(output, "### Error") {
-		t.Errorf("expected Error section")
-	}
-	if !strings.Contains(output, "line 1\nline 2") {
-		t.Errorf("expected evidence content")
-	}
-	if !strings.Contains(output, "### Root Cause") {
-		t.Errorf("expected Root Cause section")
-	}
-	if !strings.Contains(output, "### Recommendation") {
-		t.Errorf("expected Recommendation section")
-	}
-}
-
-func TestWriteStructuredBody_NoEvidence_UsesSummary(t *testing.T) {
-	var b strings.Builder
-	r := ciResult{}
-	writeStructuredBody(&b, "fallback summary", r)
-	output := b.String()
-
-	if !strings.Contains(output, "fallback summary") {
-		t.Errorf("expected summary as fallback in Error section")
-	}
-}
-
-func TestWriteStructuredBody_Empty(t *testing.T) {
-	var b strings.Builder
-	r := ciResult{}
-	writeStructuredBody(&b, "", r)
-	output := b.String()
-
-	if strings.Contains(output, "### Error") {
-		t.Errorf("should not have Error section with empty summary and evidence")
-	}
-	if strings.Contains(output, "### Root Cause") {
-		t.Errorf("should not have Root Cause section with empty rootCause")
-	}
-}
-
-func TestFormatCIRelatedDetails_HTMLEscapesCheckName(t *testing.T) {
-	r := ciResult{
-		check:        "pull-ci-<org>/repo-e2e",
-		category:     "related",
-		errorSummary: "test failed",
-		pushed:       false,
-	}
-
-	output := formatCIRelatedDetails(r)
-
-	// Check name should be HTML-escaped inside <code> tags
-	if !strings.Contains(output, "&lt;org&gt;") {
-		t.Errorf("expected HTML-escaped check name, got: %s", output)
-	}
-	if strings.Contains(output, "<org>") {
-		t.Errorf("check name with < and > should be escaped, got: %s", output)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			writeStructuredBody(&b, tt.summary, tt.r)
+			output := b.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q, got: %s", want, output)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(output, notWant) {
+					t.Errorf("output should not contain %q, got: %s", notWant, output)
+				}
+			}
+		})
 	}
 }
 
-func TestFormatCIUnrelatedDetails_HTMLEscapesCheckName(t *testing.T) {
-	r := ciResult{
-		check:        "e2e-<shard>&test",
-		category:     "unrelated",
-		errorSummary: "flaky timeout",
+// TestWriteFenced covers fence selection in writeFenced: a plain body gets a
+// standard triple-backtick fence, and a body containing backtick runs gets a
+// fence longer than its longest run so the content cannot break out.
+func TestWriteFenced(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantContains []string
+	}{
+		{
+			name:         "no backticks uses standard fence",
+			body:         "plain error text",
+			wantContains: []string{"```\nplain error text\n```"},
+		},
+		{
+			// A 4-backtick fence avoids breakout and the body is preserved unchanged.
+			name:         "triple backticks in body use longer fence",
+			body:         "Error in ```yaml\nkey: value\n```",
+			wantContains: []string{"````", "Error in ```yaml\nkey: value\n```"},
+		},
+		{
+			// Fence must be longer than 5, the longest backtick run in the body.
+			name:         "long backtick run uses even longer fence",
+			body:         "Some `````long````` backtick run",
+			wantContains: []string{"``````"},
+		},
 	}
-	agent := &Agent{cfg: Config{}}
-
-	output := formatCIUnrelatedDetails(r, agent)
-
-	if !strings.Contains(output, "&lt;shard&gt;&amp;test") {
-		t.Errorf("expected HTML-escaped check name, got: %s", output)
-	}
-}
-
-func TestFormatCIInfrastructureSection_HTMLEscapesSingleCheck(t *testing.T) {
-	infra := []ciResult{
-		{check: "build-<arch>", category: "infrastructure", errorSummary: "OOM killed"},
-	}
-
-	output := formatCIInfrastructureSection(infra)
-
-	if !strings.Contains(output, "&lt;arch&gt;") {
-		t.Errorf("expected HTML-escaped check name in single infra block, got: %s", output)
-	}
-}
-
-func TestWriteFenced_NoBackticks(t *testing.T) {
-	var b strings.Builder
-	writeFenced(&b, "### Error", "plain error text")
-	output := b.String()
-
-	if !strings.Contains(output, "```\nplain error text\n```") {
-		t.Errorf("expected standard triple-backtick fence, got: %s", output)
-	}
-}
-
-func TestWriteFenced_WithBackticks(t *testing.T) {
-	var b strings.Builder
-	body := "Error in ```yaml\nkey: value\n```"
-	writeFenced(&b, "### Error", body)
-	output := b.String()
-
-	// Should use a longer fence (4 backticks) to avoid breakout
-	if !strings.Contains(output, "````") {
-		t.Errorf("expected longer fence for body with backticks, got: %s", output)
-	}
-	// Should contain the body unchanged
-	if !strings.Contains(output, body) {
-		t.Errorf("expected body to be preserved unchanged, got: %s", output)
-	}
-}
-
-func TestWriteFenced_WithLongBacktickRun(t *testing.T) {
-	var b strings.Builder
-	body := "Some `````long````` backtick run"
-	writeFenced(&b, "### Error", body)
-	output := b.String()
-
-	// Should use fence longer than 5 (the longest run)
-	if !strings.Contains(output, "``````") {
-		t.Errorf("expected 6+ backtick fence, got: %s", output)
-	}
-}
-
-func TestParseCIStructuredFields_EvidenceWithFieldLikeLines(t *testing.T) {
-	// Evidence block contains indented lines that look like field headers.
-	// These should NOT terminate evidence capture because they're not at column 0.
-	input := `ERROR_SUMMARY: test failure
-
-EVIDENCE:
-  test output:
-    RECOMMENDATION: some test recommendation output
-    ROOT_CAUSE: some diagnostic line
-  more test output
-
-RECOMMENDATION: Retest with /retest`
-
-	_, _, evidence, recommendation, _ := parseCIStructuredFields(input)
-
-	// The indented field-like lines should be captured as evidence
-	if !strings.Contains(evidence, "RECOMMENDATION: some test recommendation output") {
-		t.Errorf("expected indented RECOMMENDATION to be captured as evidence, got %q", evidence)
-	}
-	if !strings.Contains(evidence, "ROOT_CAUSE: some diagnostic line") {
-		t.Errorf("expected indented ROOT_CAUSE to be captured as evidence, got %q", evidence)
-	}
-	// The actual RECOMMENDATION field (at column 0) should still be parsed
-	if recommendation != "Retest with /retest" {
-		t.Errorf("recommendation = %q, want %q", recommendation, "Retest with /retest")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			writeFenced(&b, "### Error", tt.body)
+			output := b.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q, got: %s", want, output)
+				}
+			}
+		})
 	}
 }
 
@@ -567,65 +593,47 @@ func TestProcessCIFailures_FixesFailingCI(t *testing.T) {
 	}
 }
 
-func TestProcessCIFailures_SkipsPassingCI(t *testing.T) {
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "test", Status: "completed", Conclusion: "success"},
+// TestProcessCIFailures_SkipsWithoutInvokingClaude covers the reasons a CI
+// poll ends without invoking claude or posting comments: CI passed, the
+// fix-attempt budget is exhausted, or a check is still running.
+func TestProcessCIFailures_SkipsWithoutInvokingClaude(t *testing.T) {
+	tests := []struct {
+		name          string
+		checkRun      CheckRun
+		ciFixAttempts int
+	}{
+		{
+			name:     "passing CI",
+			checkRun: CheckRun{ID: 1, Name: "test", Status: "completed", Conclusion: "success"},
+		},
+		{
+			name:          "max retries reached",
+			checkRun:      CheckRun{ID: 1, Name: "test", Status: "completed", Conclusion: "failure"},
+			ciFixAttempts: 3,
+		},
+		{
+			name:     "pending CI",
+			checkRun: CheckRun{ID: 1, Name: "test", Status: "in_progress", Conclusion: ""},
 		},
 	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{checkRuns: []CheckRun{tt.checkRun}}
+			runner := &mockCommandRunner{}
+			wt := &mockWorktreeManager{}
 
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
+			agent := newTestAgent(gh, runner, wt)
+			trackWork(agent, func(w *IssueWork) { w.CIFixAttempts = tt.ciFixAttempts })
 
-	agent.ProcessCIFailures(context.Background())
+			agent.ProcessCIFailures(context.Background())
 
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when CI passes")
-	}
-}
-
-func TestProcessCIFailures_StopsAfterMaxRetries(t *testing.T) {
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "test", Status: "completed", Conclusion: "failure"},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent, func(w *IssueWork) {
-		w.CIFixAttempts = 3
-	})
-
-	agent.ProcessCIFailures(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude after max retries")
-	}
-	if len(gh.addedComments) != 0 {
-		t.Error("expected no comments after max retries")
-	}
-}
-
-func TestProcessCIFailures_SkipsPendingCI(t *testing.T) {
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "test", Status: "in_progress", Conclusion: ""},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessCIFailures(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude while CI is still running")
+			if len(runner.calls) != 0 {
+				t.Error("should not invoke claude")
+			}
+			if len(gh.addedComments) != 0 {
+				t.Errorf("expected no comments, got %v", gh.addedComments)
+			}
+		})
 	}
 }
 

--- a/pkg/agent/conflicts_test.go
+++ b/pkg/agent/conflicts_test.go
@@ -421,152 +421,55 @@ func (r *unstagedChangesRebaseRunner) Run(ctx context.Context, workDir, name str
 	return nil, nil, nil
 }
 
-func TestProcessRebase_DefersWhenMainIsActive(t *testing.T) {
-	// High-velocity repo: >5 commits in 2h → rebase should be deferred.
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		recentCommits:  10, // active main branch
+// TestProcessRebase_Guards covers the guard matrix in shouldRebaseNow as
+// exercised through ProcessRebase: main-branch activity, the minimum rebase
+// interval, and fail-open behavior when the commit count is unavailable.
+func TestProcessRebase_Guards(t *testing.T) {
+	tests := []struct {
+		name            string
+		recentCommits   int
+		countCommitsErr error
+		sinceLastRebase time.Duration // zero = never rebased
+		wantRebase      bool
+	}{
+		{name: "defers when main is active (>5 commits in window)", recentCommits: 10, wantRebase: false},
+		{name: "proceeds when main is quiet", recentCommits: 2, wantRebase: true},
+		{name: "defers when min interval not reached", sinceLastRebase: 1 * time.Hour, wantRebase: false},
+		{name: "proceeds when min interval expired", recentCommits: 2, sinceLastRebase: 5 * time.Hour, wantRebase: true},
+		{name: "fail-open when commit count unavailable", countCommitsErr: fmt.Errorf("API rate limit exceeded"), wantRebase: true},
+		{name: "first rebase skips the interval guard", recentCommits: 3, wantRebase: true},
+		{name: "exact activity threshold still rebases (only >threshold defers)", recentCommits: 5, wantRebase: true},
 	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{
+				mergeableState:  "behind",
+				recentCommits:   tt.recentCommits,
+				countCommitsErr: tt.countCommitsErr,
+			}
+			runner := &mockCommandRunner{}
+			agent := newTestAgent(gh, runner, &mockWorktreeManager{})
+			trackWork(agent, func(w *IssueWork) {
+				if tt.sinceLastRebase != 0 {
+					w.LastRebaseTime = time.Now().Add(-tt.sinceLastRebase)
+				}
+			})
 
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
+			agent.ProcessRebase(context.Background())
 
-	agent.ProcessRebase(context.Background())
-
-	// Should NOT have attempted any git operations (rebase deferred)
-	for _, c := range runner.calls {
-		if c.Name == "git" {
-			t.Errorf("should not run git commands when main is active, got: git %v", c.Args)
-		}
-	}
-}
-
-func TestProcessRebase_ProceedsWhenMainIsQuiet(t *testing.T) {
-	// Quiet repo: ≤5 commits in 2h → rebase should proceed.
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		recentCommits:  2, // quiet main branch
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessRebase(context.Background())
-
-	// Should have attempted a rebase
-	var rebaseCalls int
-	for _, c := range runner.calls {
-		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
-			rebaseCalls++
-		}
-	}
-	if rebaseCalls == 0 {
-		t.Error("expected git rebase to be called when main is quiet")
-	}
-}
-
-func TestProcessRebase_DefersWhenMinIntervalNotReached(t *testing.T) {
-	// Rebase 1h ago, main is quiet → still deferred because 4h minimum not reached.
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		recentCommits:  0, // very quiet
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent, func(w *IssueWork) {
-		w.LastRebaseTime = time.Now().Add(-1 * time.Hour) // rebased 1h ago
-	})
-
-	agent.ProcessRebase(context.Background())
-
-	// Should NOT have attempted any git operations
-	for _, c := range runner.calls {
-		if c.Name == "git" {
-			t.Errorf("should not rebase when min interval not reached, got: git %v", c.Args)
-		}
-	}
-}
-
-func TestProcessRebase_ProceedsWhenMinIntervalExpired(t *testing.T) {
-	// Rebase 5h ago, main is quiet → rebase proceeds.
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		recentCommits:  2, // quiet
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent, func(w *IssueWork) {
-		w.LastRebaseTime = time.Now().Add(-5 * time.Hour) // rebased 5h ago
-	})
-
-	agent.ProcessRebase(context.Background())
-
-	var rebaseCalls int
-	for _, c := range runner.calls {
-		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
-			rebaseCalls++
-		}
-	}
-	if rebaseCalls == 0 {
-		t.Error("expected git rebase when min interval expired and main is quiet")
-	}
-}
-
-func TestProcessRebase_FailOpenOnAPIError(t *testing.T) {
-	// Can't count commits → fail-open, rebase proceeds.
-	gh := &mockGitHubClient{
-		mergeableState:  "behind",
-		countCommitsErr: fmt.Errorf("API rate limit exceeded"),
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessRebase(context.Background())
-
-	var rebaseCalls int
-	for _, c := range runner.calls {
-		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
-			rebaseCalls++
-		}
-	}
-	if rebaseCalls == 0 {
-		t.Error("expected git rebase to proceed on API error (fail-open)")
-	}
-}
-
-func TestProcessRebase_FirstRebaseNoIntervalGuard(t *testing.T) {
-	// First rebase (LastRebaseTime is zero) → should proceed without interval guard.
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		recentCommits:  3, // below threshold
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessRebase(context.Background())
-
-	var rebaseCalls int
-	for _, c := range runner.calls {
-		if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
-			rebaseCalls++
-		}
-	}
-	if rebaseCalls == 0 {
-		t.Error("expected git rebase on first rebase (no interval guard for zero time)")
+			rebased := false
+			for _, c := range runner.calls {
+				if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "rebase" {
+					rebased = true
+				}
+			}
+			if rebased != tt.wantRebase {
+				t.Errorf("rebase attempted = %v, want %v", rebased, tt.wantRebase)
+			}
+			if !tt.wantRebase && countCalls(runner.calls, "git") != 0 {
+				t.Errorf("deferred rebase should run no git commands, got %d", countCalls(runner.calls, "git"))
+			}
+		})
 	}
 }
 
@@ -619,65 +522,38 @@ func TestProcessRebase_ExactThresholdAllowsRebase(t *testing.T) {
 	}
 }
 
-func TestShouldRebaseNow_ConfigurableInterval24h(t *testing.T) {
-	// RebaseInterval = 24h, last rebase 20h ago → skip (minimum interval not reached)
-	gh := &mockGitHubClient{
-		recentCommits: 0, // quiet main
+// TestShouldRebaseNow_Interval covers the configurable minimum-interval
+// logic directly: a custom interval, its expiry, and the 4h default.
+func TestShouldRebaseNow_Interval(t *testing.T) {
+	tests := []struct {
+		name       string
+		interval   time.Duration // zero = 4h default
+		sinceLast  time.Duration
+		wantAllow  bool
+		wantReason string
+	}{
+		{"24h interval not reached", 24 * time.Hour, 20 * time.Hour, false, "minimum interval not reached"},
+		{"24h interval expired", 24 * time.Hour, 25 * time.Hour, true, ""},
+		{"zero interval falls back to 4h default", 0, 3 * time.Hour, false, "minimum interval not reached"},
 	}
-	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
-	agent.cfg.RebaseInterval = 24 * time.Hour
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{recentCommits: 0} // quiet main
+			agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
+			agent.cfg.RebaseInterval = tt.interval
 
-	work := &IssueWork{
-		PRNumber:       100,
-		LastRebaseTime: time.Now().Add(-20 * time.Hour), // 20h ago
-	}
+			work := &IssueWork{
+				PRNumber:       100,
+				LastRebaseTime: time.Now().Add(-tt.sinceLast),
+			}
 
-	allowed, reason := agent.shouldRebaseNow(context.Background(), work)
-	if allowed {
-		t.Error("expected rebase to be deferred (20h < 24h interval)")
-	}
-	if reason != "minimum interval not reached" {
-		t.Errorf("expected reason 'minimum interval not reached', got %q", reason)
-	}
-}
-
-func TestShouldRebaseNow_ConfigurableInterval24hExpired(t *testing.T) {
-	// RebaseInterval = 24h, last rebase 25h ago → allow
-	gh := &mockGitHubClient{
-		recentCommits: 0, // quiet main
-	}
-	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
-	agent.cfg.RebaseInterval = 24 * time.Hour
-
-	work := &IssueWork{
-		PRNumber:       100,
-		LastRebaseTime: time.Now().Add(-25 * time.Hour), // 25h ago
-	}
-
-	allowed, _ := agent.shouldRebaseNow(context.Background(), work)
-	if !allowed {
-		t.Error("expected rebase to be allowed (25h > 24h interval)")
-	}
-}
-
-func TestShouldRebaseNow_ZeroIntervalUsesDefault(t *testing.T) {
-	// RebaseInterval = 0 (not set) → use 4h default
-	gh := &mockGitHubClient{
-		recentCommits: 0,
-	}
-	agent := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{})
-	// agent.cfg.RebaseInterval is zero (default)
-
-	work := &IssueWork{
-		PRNumber:       100,
-		LastRebaseTime: time.Now().Add(-3 * time.Hour), // 3h ago, less than 4h default
-	}
-
-	allowed, reason := agent.shouldRebaseNow(context.Background(), work)
-	if allowed {
-		t.Error("expected rebase to be deferred (3h < 4h default interval)")
-	}
-	if reason != "minimum interval not reached" {
-		t.Errorf("expected reason 'minimum interval not reached', got %q", reason)
+			allowed, reason := agent.shouldRebaseNow(context.Background(), work)
+			if allowed != tt.wantAllow {
+				t.Errorf("allowed = %v, want %v (reason %q)", allowed, tt.wantAllow, reason)
+			}
+			if !tt.wantAllow && reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
 	}
 }

--- a/pkg/agent/conflicts_test.go
+++ b/pkg/agent/conflicts_test.go
@@ -551,7 +551,7 @@ func TestShouldRebaseNow_Interval(t *testing.T) {
 			if allowed != tt.wantAllow {
 				t.Errorf("allowed = %v, want %v (reason %q)", allowed, tt.wantAllow, reason)
 			}
-			if !tt.wantAllow && reason != tt.wantReason {
+			if reason != tt.wantReason {
 				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
 			}
 		})

--- a/pkg/agent/fileconfig_test.go
+++ b/pkg/agent/fileconfig_test.go
@@ -89,27 +89,211 @@ projects:
 	}
 }
 
-func TestLoadFileConfig_ValidationErrors(t *testing.T) {
+// TestLoadFileConfig_Validation covers LoadFileConfig accept/reject
+// behaviour: YAML parse errors, unknown keys, schema violations (projects,
+// repo format, roles), and field-level validation of reactions, agent,
+// agent-model, skip-comment, schedule, lookback, and rebase-interval.
+func TestLoadFileConfig_Validation(t *testing.T) {
 	tests := []struct {
-		name string
-		yaml string
+		name    string
+		yaml    string
+		wantErr bool
 	}{
-		{"no_projects", "agent: opencode\nprojects: []\n"},
-		{"invalid_repo", "projects:\n  - repo: invalid\n    prs:\n      - watch: [1]\n"},
-		{"no_roles", "projects:\n  - repo: owner/repo\n"},
-		{"prs_without_watch", "projects:\n  - repo: owner/repo\n    prs:\n      - reactions: [ci]\n"},
-		{"triage_without_jobs_or_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - schedule: \"09:00 Europe/Madrid\"\n"},
-		{"triage_workflow_without_lanes", "projects:\n  - repo: owner/repo\n    triage:\n      - workflow: test.yml\n"},
-		{"triage_lanes_without_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - lanes: [\"e2e*\"]\n"},
-		{"triage_jobs_and_workflow", "projects:\n  - repo: owner/repo\n    triage:\n      - jobs: [\"https://ci.example.com/job1\"]\n        workflow: test.yml\n        lanes: [\"e2e*\"]\n"},
-		{"invalid_reaction", "projects:\n  - repo: owner/repo\n    prs:\n      - watch: [1]\n        reactions: [invalid]\n"},
-		{"invalid_agent", "agent: badagent\nprojects:\n  - repo: owner/repo\n    issues:\n      - label: test\n"},
+		{name: "no_projects", yaml: "agent: opencode\nprojects: []\n", wantErr: true},
+		{name: "invalid_repo", yaml: "projects:\n  - repo: invalid\n    prs:\n      - watch: [1]\n", wantErr: true},
+		{name: "no_roles", yaml: "projects:\n  - repo: owner/repo\n", wantErr: true},
+		{name: "prs_without_watch", yaml: "projects:\n  - repo: owner/repo\n    prs:\n      - reactions: [ci]\n", wantErr: true},
+		{name: "triage_without_jobs_or_workflow", yaml: "projects:\n  - repo: owner/repo\n    triage:\n      - schedule: \"09:00 Europe/Madrid\"\n", wantErr: true},
+		{name: "triage_workflow_without_lanes", yaml: "projects:\n  - repo: owner/repo\n    triage:\n      - workflow: test.yml\n", wantErr: true},
+		{name: "triage_lanes_without_workflow", yaml: "projects:\n  - repo: owner/repo\n    triage:\n      - lanes: [\"e2e*\"]\n", wantErr: true},
+		{name: "triage_jobs_and_workflow", yaml: "projects:\n  - repo: owner/repo\n    triage:\n      - jobs: [\"https://ci.example.com/job1\"]\n        workflow: test.yml\n        lanes: [\"e2e*\"]\n", wantErr: true},
+		{name: "invalid_reaction", yaml: "projects:\n  - repo: owner/repo\n    prs:\n      - watch: [1]\n        reactions: [invalid]\n", wantErr: true},
+		{name: "invalid_agent", yaml: "agent: badagent\nprojects:\n  - repo: owner/repo\n    issues:\n      - label: test\n", wantErr: true},
+		{name: "invalid_yaml", yaml: "{{invalid yaml", wantErr: true},
+		{
+			name: "unknown_keys_rejected",
+			yaml: `
+agent: opencode
+unknown-field: some-value
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid_skip_comment",
+			yaml: `
+projects:
+  - repo: owner/repo
+    skip-comment:
+      - invalid-category
+    prs:
+      - watch: [1]
+`,
+			wantErr: true,
+		},
+		{
+			name: "agent_model_without_opencode",
+			yaml: `
+agent: claudecode
+agent-model: some-model
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`,
+			wantErr: true,
+		},
+		{
+			// agent-model without an explicit agent is valid: the agent is
+			// inherited from the global config and the resolved combination
+			// is validated when the code agent is selected.
+			name: "agent_model_without_agent_set",
+			yaml: `
+agent-model: some-model
+projects:
+  - repo: owner/repo
+    issues:
+      - label: test
+`,
+			wantErr: false,
+		},
+		{
+			name: "project_agent_model_without_opencode",
+			yaml: `
+agent: claudecode
+projects:
+  - repo: owner/repo
+    agent-model: some-model
+    prs:
+      - watch: [1]
+`,
+			wantErr: true,
+		},
+		{
+			// Project-level agent-model without an explicit agent is valid:
+			// the agent is inherited from the global config and the resolved
+			// combination is validated when the code agent is selected.
+			name: "project_agent_model_without_agent_set",
+			yaml: `
+projects:
+  - repo: owner/repo
+    agent-model: some-model
+    prs:
+      - watch: [1]
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid_schedule_timezone",
+			yaml: `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        schedule: "09:00 Invalid/Timezone"
+`,
+			wantErr: true,
+		},
+		{
+			name: "valid_schedule",
+			yaml: `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        schedule: "09:00 UTC"
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid_lookback",
+			yaml: `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        lookback: "not-a-duration"
+`,
+			wantErr: true,
+		},
+		{
+			name: "negative_lookback",
+			yaml: `
+projects:
+  - repo: owner/repo
+    triage:
+      - jobs: [https://ci.example.com/job]
+        lookback: "-1h"
+`,
+			wantErr: true,
+		},
+		{
+			name: "rebase_interval_invalid_project",
+			yaml: `
+projects:
+  - repo: owner/repo
+    rebase-interval: not-a-duration
+    prs:
+      - watch: [1]
+`,
+			wantErr: true,
+		},
+		{
+			name: "rebase_interval_negative_project",
+			yaml: `
+projects:
+  - repo: owner/repo
+    rebase-interval: "-1h"
+    prs:
+      - watch: [1]
+`,
+			wantErr: true,
+		},
+		{
+			name: "rebase_interval_zero_project",
+			yaml: `
+projects:
+  - repo: owner/repo
+    rebase-interval: "0s"
+    prs:
+      - watch: [1]
+`,
+			wantErr: true,
+		},
+		{
+			name: "rebase_interval_negative_pr",
+			yaml: `
+projects:
+  - repo: owner/repo
+    prs:
+      - watch: [1]
+        rebase-interval: "-2h"
+`,
+			wantErr: true,
+		},
+		{
+			name: "rebase_interval_invalid_pr",
+			yaml: `
+projects:
+  - repo: owner/repo
+    prs:
+      - watch: [1]
+        rebase-interval: bad
+`,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := loadConfig(t, tt.yaml)
-			if err == nil {
+			if tt.wantErr && err == nil {
 				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}
@@ -555,119 +739,10 @@ func TestBuildRoleEntries_GlobalOverrides(t *testing.T) {
 	}
 }
 
-func TestLoadFileConfig_InvalidSkipComment(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    skip-comment:
-      - invalid-category
-    prs:
-      - watch: [1]
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for invalid skip-comment")
-	}
-}
-
 func TestLoadFileConfig_FileNotFound(t *testing.T) {
 	_, err := LoadFileConfig("/nonexistent/path.yaml")
 	if err == nil {
 		t.Fatal("expected error for missing file")
-	}
-}
-
-func TestLoadFileConfig_InvalidYAML(t *testing.T) {
-	_, err := loadConfig(t, "{{invalid yaml")
-	if err == nil {
-		t.Fatal("expected error for invalid YAML")
-	}
-}
-
-func TestLoadFileConfig_AgentModelWithoutOpenCode(t *testing.T) {
-	yaml := `
-agent: claudecode
-agent-model: some-model
-projects:
-  - repo: owner/repo
-    issues:
-      - label: test
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for agent-model with claudecode")
-	}
-}
-
-func TestLoadFileConfig_AgentModelWithoutAgentSet(t *testing.T) {
-	yaml := `
-agent-model: some-model
-projects:
-  - repo: owner/repo
-    issues:
-      - label: test
-`
-	// agent-model without an explicit agent is valid: the agent is inherited
-	// from the global config and the resolved combination is validated when
-	// the code agent is selected.
-	if _, err := loadConfig(t, yaml); err != nil {
-		t.Fatalf("unexpected error for agent-model without explicit agent: %v", err)
-	}
-}
-
-func TestLoadFileConfig_InvalidSchedule(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    triage:
-      - jobs: [https://ci.example.com/job]
-        schedule: "09:00 Invalid/Timezone"
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for invalid schedule timezone")
-	}
-}
-
-func TestLoadFileConfig_ValidSchedule(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    triage:
-      - jobs: [https://ci.example.com/job]
-        schedule: "09:00 UTC"
-`
-	_, err := loadConfig(t, yaml)
-	if err != nil {
-		t.Fatalf("unexpected error for valid schedule: %v", err)
-	}
-}
-
-func TestLoadFileConfig_InvalidLookback(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    triage:
-      - jobs: [https://ci.example.com/job]
-        lookback: "not-a-duration"
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for invalid lookback duration")
-	}
-}
-
-func TestLoadFileConfig_NegativeLookback(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    triage:
-      - jobs: [https://ci.example.com/job]
-        lookback: "-1h"
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for negative lookback duration")
 	}
 }
 
@@ -886,21 +961,6 @@ func TestReactionsNilVsEmpty(t *testing.T) {
 	}
 }
 
-func TestLoadFileConfig_UnknownKeysRejected(t *testing.T) {
-	yaml := `
-agent: opencode
-unknown-field: some-value
-projects:
-  - repo: owner/repo
-    issues:
-      - label: test
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for unknown YAML key")
-	}
-}
-
 func TestLoadFileConfig_RebaseIntervalValid(t *testing.T) {
 	yaml := `
 projects:
@@ -919,76 +979,6 @@ projects:
 	}
 	if fc.Projects[0].PRs[0].RebaseInterval != "8h" {
 		t.Errorf("expected PR rebase-interval '8h', got %q", fc.Projects[0].PRs[0].RebaseInterval)
-	}
-}
-
-func TestLoadFileConfig_RebaseIntervalInvalidProject(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    rebase-interval: not-a-duration
-    prs:
-      - watch: [1]
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for invalid project rebase-interval")
-	}
-}
-
-func TestLoadFileConfig_RebaseIntervalNegativeProject(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    rebase-interval: "-1h"
-    prs:
-      - watch: [1]
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for negative project rebase-interval")
-	}
-}
-
-func TestLoadFileConfig_RebaseIntervalZeroProject(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    rebase-interval: "0s"
-    prs:
-      - watch: [1]
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for zero project rebase-interval")
-	}
-}
-
-func TestLoadFileConfig_RebaseIntervalNegativePR(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    prs:
-      - watch: [1]
-        rebase-interval: "-2h"
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for negative PR rebase-interval")
-	}
-}
-
-func TestLoadFileConfig_RebaseIntervalInvalidPR(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    prs:
-      - watch: [1]
-        rebase-interval: bad
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for invalid PR rebase-interval")
 	}
 }
 
@@ -1105,37 +1095,6 @@ projects:
 	}
 	if fc.Projects[0].AgentModel != "google-vertex-anthropic/claude-sonnet-4-20250514" {
 		t.Errorf("expected project agent-model, got %q", fc.Projects[0].AgentModel)
-	}
-}
-
-func TestLoadFileConfig_ProjectAgentModelWithoutOpenCode(t *testing.T) {
-	yaml := `
-agent: claudecode
-projects:
-  - repo: owner/repo
-    agent-model: some-model
-    prs:
-      - watch: [1]
-`
-	_, err := loadConfig(t, yaml)
-	if err == nil {
-		t.Fatal("expected error for project agent-model with claudecode")
-	}
-}
-
-func TestLoadFileConfig_ProjectAgentModelWithoutAgentSet(t *testing.T) {
-	yaml := `
-projects:
-  - repo: owner/repo
-    agent-model: some-model
-    prs:
-      - watch: [1]
-`
-	// Project-level agent-model without an explicit agent is valid: the agent
-	// is inherited from the global config and the resolved combination is
-	// validated when the code agent is selected.
-	if _, err := loadConfig(t, yaml); err != nil {
-		t.Fatalf("unexpected error for project agent-model without explicit agent: %v", err)
 	}
 }
 

--- a/pkg/agent/issues_test.go
+++ b/pkg/agent/issues_test.go
@@ -440,11 +440,11 @@ func TestProcessNewIssues_SquashCommitMessage(t *testing.T) {
 
 			subject := strings.SplitN(commitMsg, "\n", 2)[0]
 			if tt.longTitle {
-				if len(subject) > 72 {
-					t.Errorf("subject line exceeds 72 chars (%d): %q", len(subject), subject)
-				}
-				if !strings.HasSuffix(subject, "...") {
-					t.Errorf("truncated subject should end with '...', got: %q", subject)
+				// truncateSubject breaks at the last word boundary before
+				// 72 runes and appends an ellipsis.
+				want := "CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s..."
+				if subject != want {
+					t.Errorf("subject = %q, want %q", subject, want)
 				}
 			} else if subject != tt.wantSubject {
 				t.Errorf("subject = %q, want %q", subject, tt.wantSubject)
@@ -458,8 +458,8 @@ func TestProcessNewIssues_SquashCommitMessage(t *testing.T) {
 			if want := fmt.Sprintf("Related-to: #%d", tt.issue.Number); !strings.Contains(commitMsg, want) {
 				t.Errorf("expected commit body to contain %q, got: %s", want, commitMsg)
 			}
-			if !strings.Contains(commitMsg, "Signed-off-by") {
-				t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+			if !strings.Contains(commitMsg, "Signed-off-by: Test User <test@example.com>") {
+				t.Errorf("expected commit message to contain the configured sign-off, got: %s", commitMsg)
 			}
 		})
 	}

--- a/pkg/agent/issues_test.go
+++ b/pkg/agent/issues_test.go
@@ -2,28 +2,108 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
 )
 
-func TestProcessNewIssues_SkipsAlreadyTracked(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 42, Title: "Fix bug"}},
+// TestProcessNewIssues_SkipsAndDefers covers every reason a labeled issue is
+// not picked up: it is already tracked, a PR for its branch or a linked PR
+// already exists (open or merged), or a pre-flight GitHub call fails and the
+// issue is deferred to the next poll.
+func TestProcessNewIssues_SkipsAndDefers(t *testing.T) {
+	tests := []struct {
+		name     string
+		gh       *mockGitHubClient
+		preTrack bool // issue 42 already in state before the poll
+		// wantStatus is the expected tracked status afterwards; empty means
+		// the issue must not be tracked (so the next poll retries it).
+		wantStatus string
+		wantPR     int
+	}{
+		{
+			name:       "skips issue already tracked",
+			gh:         &mockGitHubClient{issues: []Issue{{Number: 42, Title: "Fix bug"}}},
+			preTrack:   true,
+			wantStatus: StatusPROpen,
+		},
+		{
+			name: "adopts existing open PR for the branch",
+			gh: &mockGitHubClient{
+				issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+				prs:    []PR{{Number: 100, State: "open", Head: "ai/issue-42"}},
+			},
+			wantStatus: StatusPROpen,
+			wantPR:     100,
+		},
+		{
+			name: "skips issue with linked PR",
+			gh: &mockGitHubClient{
+				issues:   []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+				linkedPR: true, // an open PR (e.g. human-created) already references the issue
+			},
+		},
+		{
+			name: "defers when PR listing fails",
+			gh: &mockGitHubClient{
+				issues:     []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+				listPRsErr: &mockError{msg: "boom"},
+			},
+		},
+		{
+			name: "defers when linked PR check fails",
+			gh: &mockGitHubClient{
+				issues:      []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+				linkedPRErr: &mockError{msg: "boom"},
+			},
+		},
+		{
+			name: "skips issue whose fix PR was merged",
+			gh: &mockGitHubClient{
+				issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
+				prs:    []PR{{Number: 100, State: "closed", Merged: true, Head: "ai/issue-42"}},
+			},
+		},
 	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &mockCommandRunner{}
+			wt := &mockWorktreeManager{}
+			agent := newTestAgent(tt.gh, runner, wt)
+			if tt.preTrack {
+				agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{IssueNumber: 42, Status: StatusPROpen}
+			}
 
-	agent := newTestAgent(gh, runner, wt)
-	agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{IssueNumber: 42, Status: "pr-open"}
+			agent.ProcessNewIssues(context.Background())
 
-	agent.ProcessNewIssues(context.Background())
+			if len(runner.calls) != 0 {
+				t.Error("should not invoke the code agent")
+			}
+			if len(wt.createdBranches) != 0 {
+				t.Error("should not create a worktree")
+			}
+			if len(tt.gh.addedComments) != 0 {
+				t.Errorf("should not comment on the issue, got %v", tt.gh.addedComments)
+			}
 
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree for already tracked issue")
-	}
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude for already tracked issue")
+			work, tracked := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+			if tt.wantStatus == "" {
+				if tracked {
+					t.Error("issue should not be tracked so the next poll retries it")
+				}
+				return
+			}
+			if !tracked {
+				t.Fatal("issue 42 should be tracked")
+			}
+			if work.Status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", work.Status, tt.wantStatus)
+			}
+			if work.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %d, want %d", work.PRNumber, tt.wantPR)
+			}
+		})
 	}
 }
 
@@ -108,128 +188,6 @@ func TestProcessNewIssues_SkipCommentIssueInProgress(t *testing.T) {
 		if strings.Contains(comment, "working on this issue") {
 			t.Errorf("expected issue-in-progress comment to be suppressed, got: %q", comment)
 		}
-	}
-}
-
-func TestProcessNewIssues_SkipsWhenPRExists(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		prs:    []PR{{Number: 100, State: "open", Head: "ai/issue-42"}},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
-
-	// Should not invoke Claude
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when PR already exists")
-	}
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree when PR already exists")
-	}
-
-	work, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if !ok {
-		t.Fatal("issue 42 should be tracked")
-	}
-	if work.PRNumber != 100 {
-		t.Errorf("expected PR 100, got %d", work.PRNumber)
-	}
-	if work.Status != "pr-open" {
-		t.Errorf("expected status 'pr-open', got %q", work.Status)
-	}
-}
-
-func TestProcessNewIssues_SkipsLinkedPR(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues:   []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		linkedPR: true, // an open PR (e.g. human-created) already references the issue
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when a linked PR exists")
-	}
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree when a linked PR exists")
-	}
-	if len(gh.addedComments) != 0 {
-		t.Errorf("should not comment on issue with linked PR, got %v", gh.addedComments)
-	}
-	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
-		t.Error("issue with linked PR should not be tracked")
-	}
-}
-
-func TestProcessNewIssues_DefersOnListPRsError(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues:     []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		listPRsErr: &mockError{msg: "boom"},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when PR listing fails")
-	}
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree when PR listing fails")
-	}
-	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
-		t.Error("deferred issue should not be tracked so the next poll retries it")
-	}
-}
-
-func TestProcessNewIssues_DefersOnLinkedPRCheckError(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues:      []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		linkedPRErr: &mockError{msg: "boom"},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when linked PR check fails")
-	}
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree when linked PR check fails")
-	}
-	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
-		t.Error("deferred issue should not be tracked so the next poll retries it")
-	}
-}
-
-func TestProcessNewIssues_SkipsMergedPR(t *testing.T) {
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 42, Title: "Fix bug", Body: "broken"}},
-		prs:    []PR{{Number: 100, State: "closed", Merged: true, Head: "ai/issue-42"}},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
-
-	if len(runner.calls) != 0 {
-		t.Error("should not invoke claude when the fix PR was merged")
-	}
-	if len(wt.createdBranches) != 0 {
-		t.Error("should not create worktree when the fix PR was merged")
-	}
-	if _, ok := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]; ok {
-		t.Error("issue with merged PR should not be tracked")
 	}
 }
 
@@ -431,123 +389,79 @@ func TestProcessNewIssues_SquashesCommits(t *testing.T) {
 	}
 }
 
-func TestProcessNewIssues_SquashesCommits_ConventionalCommitTitle(t *testing.T) {
-	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 1532, Title: "build: consolidate multi-arch container build scripts", Body: "Consolidate build scripts"}},
-	}
-	runner := &mockCommandRunner{stdout: claudeResult}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.cfg.SignedOffBy = "Test User <test@example.com>"
-	agent.ProcessNewIssues(context.Background())
-
-	// Verify the commit message uses the issue title as the subject
-	// and puts "Related-to: #N" in the body (no auto-close keywords)
-	for _, c := range runner.calls {
-		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
-			continue
-		}
-		commitMsg := c.Args[2]
-		// The subject line should be the issue title as-is
-		lines := strings.SplitN(commitMsg, "\n", 2)
-		if lines[0] != "build: consolidate multi-arch container build scripts" {
-			t.Errorf("expected subject line to be the conventional commit title, got: %q", lines[0])
-		}
-		// Should NOT contain auto-close keywords
-		if strings.Contains(commitMsg, "Fix #1532") || strings.Contains(commitMsg, "Fixes #1532") || strings.Contains(commitMsg, "Closes #1532") {
-			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
-		}
-		// Should contain "Related-to: #1532" in the body
-		if !strings.Contains(commitMsg, "Related-to: #1532") {
-			t.Errorf("expected commit body to contain 'Related-to: #1532', got: %s", commitMsg)
-		}
-		// Should still have trailers
-		if !strings.Contains(commitMsg, "Signed-off-by") {
-			t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
-		}
-		return
-	}
-	t.Error("expected git commit -m to be called")
-}
-
-func TestProcessNewIssues_SquashesCommits_NonConventionalTitle(t *testing.T) {
-	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 42, Title: "implement feature X", Body: "broken"}},
-	}
-	runner := &mockCommandRunner{stdout: claudeResult}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.cfg.SignedOffBy = "Test User <test@example.com>"
-	agent.ProcessNewIssues(context.Background())
-
-	// Verify the commit message uses the issue title as subject and
-	// references the issue in the body with "Related-to:" (no auto-close keywords)
-	for _, c := range runner.calls {
-		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
-			continue
-		}
-		commitMsg := c.Args[2]
-		lines := strings.SplitN(commitMsg, "\n", 2)
-		if lines[0] != "implement feature X" {
-			t.Errorf("expected subject line to be 'implement feature X', got: %q", lines[0])
-		}
-		// Should NOT contain auto-close keywords
-		if strings.Contains(commitMsg, "Fix #42") || strings.Contains(commitMsg, "Fixes #42") || strings.Contains(commitMsg, "Closes #42") {
-			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
-		}
-		// Should contain "Related-to: #42" in the body
-		if !strings.Contains(commitMsg, "Related-to: #42") {
-			t.Errorf("expected commit body to contain 'Related-to: #42', got: %s", commitMsg)
-		}
-		if !strings.Contains(commitMsg, "Signed-off-by") {
-			t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
-		}
-		return
-	}
-	t.Error("expected git commit -m to be called")
-}
-
-func TestProcessNewIssues_SquashesCommits_LongTitle(t *testing.T) {
-	claudeResult := streamResultJSON(AgentResult{Result: "Fixed it"})
+// TestProcessNewIssues_SquashCommitMessage covers how the squash commit
+// message is built from the issue title: the title becomes the subject
+// (truncated at 72 chars), the body references the issue with Related-to
+// instead of auto-close keywords, and configured trailers are appended.
+func TestProcessNewIssues_SquashCommitMessage(t *testing.T) {
 	longTitle := "CI Failure: pull-e2e-cluster-network-addons-operator-monitoring-k8s / The pull-e2e-cluster-network-addons-operator-monitoring-k8s"
-	gh := &mockGitHubClient{
-		issues: []Issue{{Number: 2799, Title: longTitle, Body: "CI is failing"}},
+	tests := []struct {
+		name        string
+		issue       Issue
+		wantSubject string // empty: checked by the long-title rules instead
+		longTitle   bool
+	}{
+		{
+			name:        "conventional commit title used as-is",
+			issue:       Issue{Number: 1532, Title: "build: consolidate multi-arch container build scripts", Body: "Consolidate build scripts"},
+			wantSubject: "build: consolidate multi-arch container build scripts",
+		},
+		{
+			name:        "non-conventional title used as-is",
+			issue:       Issue{Number: 42, Title: "implement feature X", Body: "broken"},
+			wantSubject: "implement feature X",
+		},
+		{
+			name:      "long title truncated to 72 chars with ellipsis",
+			issue:     Issue{Number: 2799, Title: longTitle, Body: "CI is failing"},
+			longTitle: true,
+		},
 	}
-	runner := &mockCommandRunner{stdout: claudeResult}
-	wt := &mockWorktreeManager{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{issues: []Issue{tt.issue}}
+			runner := &mockCommandRunner{stdout: streamResultJSON(AgentResult{Result: "Fixed it"})}
+			agent := newTestAgent(gh, runner, &mockWorktreeManager{})
+			agent.cfg.SignedOffBy = "Test User <test@example.com>"
 
-	agent := newTestAgent(gh, runner, wt)
-	agent.ProcessNewIssues(context.Background())
+			agent.ProcessNewIssues(context.Background())
 
-	// Verify the commit subject is truncated to 72 characters
-	for _, c := range runner.calls {
-		if c.Name != "git" || len(c.Args) < 3 || c.Args[0] != "commit" || c.Args[1] != "-m" {
-			continue
-		}
-		commitMsg := c.Args[2]
-		lines := strings.SplitN(commitMsg, "\n", 2)
-		subject := lines[0]
-		if len(subject) > 72 {
-			t.Errorf("subject line exceeds 72 chars (%d): %q", len(subject), subject)
-		}
-		if !strings.HasSuffix(subject, "...") {
-			t.Errorf("truncated subject should end with '...', got: %q", subject)
-		}
-		// Should NOT contain auto-close keywords
-		if strings.Contains(commitMsg, "Fix #2799") || strings.Contains(commitMsg, "Fixes #2799") {
-			t.Errorf("commit message should not contain auto-close keywords, got: %s", commitMsg)
-		}
-		// Should contain "Related-to: #2799" in the body
-		if !strings.Contains(commitMsg, "Related-to: #2799") {
-			t.Errorf("expected commit body to contain 'Related-to: #2799', got: %s", commitMsg)
-		}
-		return
+			var commitMsg string
+			for _, c := range runner.calls {
+				if c.Name == "git" && len(c.Args) >= 3 && c.Args[0] == "commit" && c.Args[1] == "-m" {
+					commitMsg = c.Args[2]
+					break
+				}
+			}
+			if commitMsg == "" {
+				t.Fatal("expected git commit -m to be called")
+			}
+
+			subject := strings.SplitN(commitMsg, "\n", 2)[0]
+			if tt.longTitle {
+				if len(subject) > 72 {
+					t.Errorf("subject line exceeds 72 chars (%d): %q", len(subject), subject)
+				}
+				if !strings.HasSuffix(subject, "...") {
+					t.Errorf("truncated subject should end with '...', got: %q", subject)
+				}
+			} else if subject != tt.wantSubject {
+				t.Errorf("subject = %q, want %q", subject, tt.wantSubject)
+			}
+
+			for _, keyword := range []string{"Fix #", "Fixes #", "Closes #"} {
+				if strings.Contains(commitMsg, fmt.Sprintf("%s%d", keyword, tt.issue.Number)) {
+					t.Errorf("commit message should not contain auto-close keyword %q: %s", keyword, commitMsg)
+				}
+			}
+			if want := fmt.Sprintf("Related-to: #%d", tt.issue.Number); !strings.Contains(commitMsg, want) {
+				t.Errorf("expected commit body to contain %q, got: %s", want, commitMsg)
+			}
+			if !strings.Contains(commitMsg, "Signed-off-by") {
+				t.Errorf("expected commit message to contain 'Signed-off-by', got: %s", commitMsg)
+			}
+		})
 	}
-	t.Error("expected git commit -m to be called")
 }
 
 // commentOnlyDiffRunner simulates Claude producing commits whose diff contains

--- a/pkg/agent/issues_test.go
+++ b/pkg/agent/issues_test.go
@@ -27,6 +27,7 @@ func TestProcessNewIssues_SkipsAndDefers(t *testing.T) {
 			gh:         &mockGitHubClient{issues: []Issue{{Number: 42, Title: "Fix bug"}}},
 			preTrack:   true,
 			wantStatus: StatusPROpen,
+			wantPR:     100,
 		},
 		{
 			name: "adopts existing open PR for the branch",
@@ -72,7 +73,7 @@ func TestProcessNewIssues_SkipsAndDefers(t *testing.T) {
 			wt := &mockWorktreeManager{}
 			agent := newTestAgent(tt.gh, runner, wt)
 			if tt.preTrack {
-				agent.state.ActiveIssues[IssueKey("owner", "repo", 42)] = &IssueWork{IssueNumber: 42, Status: StatusPROpen}
+				trackWork(agent)
 			}
 
 			agent.ProcessNewIssues(context.Background())

--- a/pkg/agent/review_test.go
+++ b/pkg/agent/review_test.go
@@ -55,84 +55,114 @@ func TestProcessReviewComments_AddressesHumanComments(t *testing.T) {
 	}
 }
 
-func TestProcessReviewComments_PushFailureDoesNotAdvanceCursor(t *testing.T) {
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+// TestProcessReviewComments_CursorAdvancement covers when the per-PR review
+// cursors (LastCommentID/LastReviewID) move after a processing cycle. Cursors
+// advance after a successful agent run and even when the agent errors or fails
+// (issue #164: re-processing the same reviews costs $0.50-1.00 per cycle), but
+// stay put when changes were detected and the push failed, so the comments are
+// retried on the next poll cycle. Every cycle without a successful push
+// increments ReviewNoOpCount.
+func TestProcessReviewComments_CursorAdvancement(t *testing.T) {
+	tests := []struct {
+		name              string
+		prReviews         []PRReview // optional review fixture alongside comment 60
+		runner            *mockCommandRunner
+		codeAgent         CodeAgent // nil keeps the default claude agent driven by runner
+		initReviewID      int64
+		wantClaudeCalls   int
+		wantLastCommentID int64
+		wantLastReviewID  int64
+		wantNoOpCount     int
+	}{
+		{
+			// Runner returns non-empty stdout (triggers changeDetected) and an
+			// error (causes push to fail); sequentialMockCodeAgent makes the
+			// agent call succeed despite the broken runner. The cursor must NOT
+			// advance so the comments are retried on the next poll cycle.
+			name:   "push failure does not advance cursor",
+			runner: &mockCommandRunner{stdout: []byte("dirty"), err: fmt.Errorf("git failed")},
+			codeAgent: &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+			},
+			wantClaudeCalls:   0,
+			wantLastCommentID: 50,
+			wantLastReviewID:  0,
+			wantNoOpCount:     1,
+		},
+		{
+			// Cursor should always advance after a successful agent run.
+			name:              "success advances cursor unconditionally",
+			runner:            &mockCommandRunner{claudeResults: [][]byte{streamResultJSON(AgentResult{Result: "Done"})}},
+			wantClaudeCalls:   1,
+			wantLastCommentID: 60,
+			wantLastReviewID:  0,
+			wantNoOpCount:     1,
+		},
+		{
+			// When the agent errors out, cursor should still advance to avoid
+			// infinite retry loops.
+			name:   "agent error still advances cursor",
+			runner: &mockCommandRunner{},
+			codeAgent: &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
+			},
+			wantClaudeCalls:   0,
+			wantLastCommentID: 60,
+			wantLastReviewID:  0,
+			wantNoOpCount:     1,
+		},
+		{
+			// Issue #164: when the agent fails (e.g., git corruption), both
+			// cursors must advance and the failure counts as a no-op cycle.
+			name:      "agent failure advances comment and review cursors",
+			prReviews: []PRReview{{ID: 200, User: "copilot", Body: "Review feedback"}},
+			runner:    &mockCommandRunner{},
+			codeAgent: &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
+			},
+			initReviewID:      100,
+			wantClaudeCalls:   0,
+			wantLastCommentID: 60,
+			wantLastReviewID:  200,
+			wantNoOpCount:     1,
 		},
 	}
-	// Runner returns non-empty stdout (triggers changeDetected) and an error (causes push to fail)
-	runner := &mockCommandRunner{stdout: []byte("dirty"), err: fmt.Errorf("git failed")}
-	wt := &mockWorktreeManager{}
 
-	agent := newTestAgent(gh, runner, wt)
-	// Use sequentialMockCodeAgent so the agent call succeeds despite the broken runner
-	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
-	}
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{
+				prComments: []ReviewComment{
+					{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+				},
+				prReviews: tt.prReviews,
+			}
+			wt := &mockWorktreeManager{}
 
-	agent.ProcessReviewComments(context.Background())
+			agent := newTestAgent(gh, tt.runner, wt)
+			if tt.codeAgent != nil {
+				agent.codeAgent = tt.codeAgent
+			}
+			trackWork(agent, func(w *IssueWork) {
+				w.LastCommentID = 50
+				w.LastReviewID = tt.initReviewID
+			})
 
-	// Cursor should NOT advance when changes were detected but push failed,
-	// so the comments are retried on the next poll cycle.
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastCommentID != 50 {
-		t.Errorf("expected LastCommentID to stay at 50, got %d", work.LastCommentID)
-	}
-}
+			agent.ProcessReviewComments(context.Background())
 
-func TestProcessReviewComments_CursorAdvancesUnconditionally(t *testing.T) {
-	implResult := streamResultJSON(AgentResult{Result: "Done"})
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
-		},
-	}
-	runner := &mockCommandRunner{claudeResults: [][]byte{implResult}}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-	})
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Cursor should always advance after a successful agent run.
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastCommentID != 60 {
-		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
-	}
-}
-
-func TestProcessReviewComments_AgentErrorStillAdvancesCursor(t *testing.T) {
-	// When the agent errors out, cursor should still advance to avoid
-	// infinite retry loops ($0.50-1.00 each time).
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
-	}
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-	})
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Cursor should still advance (to avoid infinite retry loops)
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastCommentID != 60 {
-		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
+			if got := countCalls(tt.runner.calls, "claude"); got != tt.wantClaudeCalls {
+				t.Errorf("expected %d claude calls, got %d", tt.wantClaudeCalls, got)
+			}
+			work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+			if work.LastCommentID != tt.wantLastCommentID {
+				t.Errorf("expected LastCommentID %d, got %d", tt.wantLastCommentID, work.LastCommentID)
+			}
+			if work.LastReviewID != tt.wantLastReviewID {
+				t.Errorf("expected LastReviewID %d, got %d", tt.wantLastReviewID, work.LastReviewID)
+			}
+			if work.ReviewNoOpCount != tt.wantNoOpCount {
+				t.Errorf("expected ReviewNoOpCount %d, got %d", tt.wantNoOpCount, work.ReviewNoOpCount)
+			}
+		})
 	}
 }
 
@@ -432,76 +462,116 @@ func (r *reviewFixupRunner) Run(ctx context.Context, workDir, name string, args 
 	return nil, nil, nil
 }
 
-func TestProcessReviewComments_AgentFailureAdvancesCursor(t *testing.T) {
-	// Issue #164: When the agent fails (e.g., git corruption), cursors must advance
-	// to prevent infinite retry loops that waste API credits.
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+// TestProcessReviewComments_NoOpCount covers the ReviewNoOpCount lifecycle
+// (issue #164): an agent cycle that produces no push increments the counter, a
+// successful push resets it to 0, and once the counter reaches
+// cfg.MaxReviewNoOps the agent is not invoked at all — cursors advance past
+// the stale reviews and the counter resets so reviews arriving later can be
+// processed.
+func TestProcessReviewComments_NoOpCount(t *testing.T) {
+	tests := []struct {
+		name              string
+		prComments        []ReviewComment
+		prReviews         []PRReview
+		claudeResults     [][]byte
+		fixupRunner       bool      // wrap the runner in reviewFixupRunner (fixup commits → successful autosquash + push)
+		codeAgent         CodeAgent // nil keeps the default claude agent driven by runner
+		maxNoOps          int
+		initCommentID     int64
+		initReviewID      int64
+		initNoOpCount     int
+		wantClaudeCalls   int
+		wantNoOpCount     int
+		wantLastCommentID int64
+		wantLastReviewID  int64
+	}{
+		{
+			// Simulates the scenario where push keeps failing on the same
+			// reviews: with the counter already at the limit the agent must not
+			// be invoked, cursors still advance past the skipped reviews, and
+			// the counter resets.
+			name: "limit reached pauses reviews",
+			prComments: []ReviewComment{
+				{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+			},
+			claudeResults:     [][]byte{streamResultJSON(AgentResult{Result: "No changes needed"})},
+			maxNoOps:          3,
+			initCommentID:     50,
+			initNoOpCount:     3, // already at limit
+			wantClaudeCalls:   0,
+			wantNoOpCount:     0,
+			wantLastCommentID: 60,
 		},
-		prReviews: []PRReview{
-			{ID: 200, User: "copilot", Body: "Review feedback"},
+		{
+			// The fixup runner simulates a successful autosquash + push, which
+			// resets the counter.
+			name: "successful push resets counter",
+			prComments: []ReviewComment{
+				{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
+			},
+			fixupRunner: true,
+			codeAgent: &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
+			},
+			initCommentID:     50,
+			initNoOpCount:     2, // was approaching limit
+			wantClaudeCalls:   0,
+			wantNoOpCount:     0,
+			wantLastCommentID: 60,
+		},
+		{
+			// The agent runs but produces no changes (no push), so the counter
+			// increments and the cursor advances past the evaluated review.
+			name: "no push increments counter",
+			prReviews: []PRReview{
+				{ID: 200, User: "reviewer", Body: "Please fix the error handling"},
+			},
+			claudeResults:    [][]byte{streamResultJSON(AgentResult{Result: "All reviews are stale"})},
+			initReviewID:     100,
+			initNoOpCount:    1,
+			wantClaudeCalls:  1,
+			wantNoOpCount:    2,
+			wantLastReviewID: 200,
 		},
 	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
 
-	agent := newTestAgent(gh, runner, wt)
-	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
-	}
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-		w.LastReviewID = 100
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{prComments: tt.prComments, prReviews: tt.prReviews}
+			base := &mockCommandRunner{claudeResults: tt.claudeResults}
+			var runner CommandRunner = base
+			if tt.fixupRunner {
+				runner = &reviewFixupRunner{mockCommandRunner: base}
+			}
+			wt := &mockWorktreeManager{}
 
-	agent.ProcessReviewComments(context.Background())
+			agent := newTestAgent(gh, runner, wt)
+			agent.cfg.MaxReviewNoOps = tt.maxNoOps
+			if tt.codeAgent != nil {
+				agent.codeAgent = tt.codeAgent
+			}
+			trackWork(agent, func(w *IssueWork) {
+				w.LastCommentID = tt.initCommentID
+				w.LastReviewID = tt.initReviewID
+				w.ReviewNoOpCount = tt.initNoOpCount
+			})
 
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	// Cursors MUST advance even on agent failure to prevent infinite loops.
-	if work.LastCommentID != 60 {
-		t.Errorf("expected LastCommentID to advance to 60 on agent failure, got %d", work.LastCommentID)
-	}
-	if work.LastReviewID != 200 {
-		t.Errorf("expected LastReviewID to advance to 200 on agent failure, got %d", work.LastReviewID)
-	}
-	// ReviewNoOpCount should increment on failure.
-	if work.ReviewNoOpCount != 1 {
-		t.Errorf("expected ReviewNoOpCount to be 1 after agent failure, got %d", work.ReviewNoOpCount)
-	}
-}
+			agent.ProcessReviewComments(context.Background())
 
-func TestProcessReviewComments_NoOpCountPausesReviews(t *testing.T) {
-	// Issue #164: After N consecutive no-op cycles, review processing should pause.
-	// Simulates the scenario where push keeps failing on the same reviews.
-	result := streamResultJSON(AgentResult{Result: "No changes needed"})
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
-		},
-	}
-	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.cfg.MaxReviewNoOps = 3
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-		w.ReviewNoOpCount = 3 // already at limit
-	})
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Should NOT invoke the agent because no-op limit is reached.
-	claudeCalls := countCalls(runner.calls, "claude")
-	if claudeCalls != 0 {
-		t.Errorf("expected 0 claude calls when no-op limit reached, got %d", claudeCalls)
-	}
-
-	// Cursors should still advance past the skipped reviews.
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastCommentID != 60 {
-		t.Errorf("expected LastCommentID to advance to 60, got %d", work.LastCommentID)
+			if got := countCalls(base.calls, "claude"); got != tt.wantClaudeCalls {
+				t.Errorf("expected %d claude calls, got %d", tt.wantClaudeCalls, got)
+			}
+			work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+			if work.ReviewNoOpCount != tt.wantNoOpCount {
+				t.Errorf("expected ReviewNoOpCount %d, got %d", tt.wantNoOpCount, work.ReviewNoOpCount)
+			}
+			if work.LastCommentID != tt.wantLastCommentID {
+				t.Errorf("expected LastCommentID %d, got %d", tt.wantLastCommentID, work.LastCommentID)
+			}
+			if work.LastReviewID != tt.wantLastReviewID {
+				t.Errorf("expected LastReviewID %d, got %d", tt.wantLastReviewID, work.LastReviewID)
+			}
+		})
 	}
 }
 
@@ -559,66 +629,6 @@ func TestProcessReviewComments_NewReviewAfterNoOpPause(t *testing.T) {
 	}
 }
 
-func TestProcessReviewComments_NoOpCountResetsOnPush(t *testing.T) {
-	// When the agent pushes successfully, the no-op counter should reset to 0.
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Please fix this", Path: "main.go", Line: 10},
-		},
-	}
-	// Use a runner that simulates uncommitted changes (triggers push path)
-	runner := &reviewFixupRunner{
-		mockCommandRunner: &mockCommandRunner{},
-	}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{result: AgentResult{Result: "Done"}}},
-	}
-	trackWork(agent, func(w *IssueWork) {
-		w.LastCommentID = 50
-		w.ReviewNoOpCount = 2 // was approaching limit
-	})
-
-	agent.ProcessReviewComments(context.Background())
-
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	// The fixup runner simulates a successful push, so counter should reset.
-	if work.ReviewNoOpCount != 0 {
-		t.Errorf("expected ReviewNoOpCount to reset to 0 after successful push, got %d", work.ReviewNoOpCount)
-	}
-}
-
-func TestProcessReviewComments_NoOpCountIncrementsOnNoPush(t *testing.T) {
-	// When the agent runs but produces no changes (no push), the counter increments.
-	result := streamResultJSON(AgentResult{Result: "All reviews are stale"})
-	gh := &mockGitHubClient{
-		prReviews: []PRReview{
-			{ID: 200, User: "reviewer", Body: "Please fix the error handling"},
-		},
-	}
-	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent, func(w *IssueWork) {
-		w.LastReviewID = 100
-		w.ReviewNoOpCount = 1
-	})
-
-	agent.ProcessReviewComments(context.Background())
-
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.ReviewNoOpCount != 2 {
-		t.Errorf("expected ReviewNoOpCount to increment to 2, got %d", work.ReviewNoOpCount)
-	}
-	// Cursor should advance since no changes were detected
-	if work.LastReviewID != 200 {
-		t.Errorf("expected LastReviewID to advance to 200, got %d", work.LastReviewID)
-	}
-}
-
 func TestProcessReviewComments_CostGuardSkipsReviews(t *testing.T) {
 	// Issue #164: When a PR exceeds the per-session cost threshold, skip reviews.
 	gh := &mockGitHubClient{
@@ -670,86 +680,141 @@ func TestProcessReviewComments_CostTracking(t *testing.T) {
 	}
 }
 
-func TestProcessReviewComments_OompaCommandProcessed(t *testing.T) {
-	// A PR conversation comment starting with /oompa should be treated as a directive.
-	result := streamResultJSON(AgentResult{Result: "Done"})
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+// TestProcessReviewComments_OompaCommandFiltering covers which PR conversation
+// comments trigger the coding agent: only /oompa-prefixed comments carrying a
+// directive, posted by whitelisted non-bot users, are processed (adding an
+// :eyes: reaction via the issue comment API and combining with any inline
+// review comments into a single agent task). Everything else is filtered out
+// without invoking the agent, with LastIssueCommentID still advancing past
+// filtered comments so they are not re-fetched on every poll cycle. The cursor
+// also advances when the agent errors on a directive.
+func TestProcessReviewComments_OompaCommandFiltering(t *testing.T) {
+	tests := []struct {
+		name                   string
+		issueComments          []ReviewComment
+		prComments             []ReviewComment // optional inline review comments processed alongside
+		reviewers              []string        // cfg.Reviewers whitelist; empty allows all
+		codeAgent              CodeAgent       // nil keeps the default claude agent driven by runner
+		wantClaudeCalls        int
+		wantLastCommentID      int64
+		wantLastIssueCommentID int64
+		wantReactions          []string
+	}{
+		{
+			// A PR conversation comment starting with /oompa is treated as a directive.
+			name: "oompa command processed",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+			},
+			wantClaudeCalls:        1,
+			wantLastIssueCommentID: 70,
+			wantReactions:          []string{"issue:70:eyes"},
+		},
+		{
+			// PR conversation comments without /oompa prefix should be ignored.
+			name: "non-oompa comments ignored",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "reviewer", Body: "This looks good to me"},
+				{ID: 71, User: "reviewer", Body: "I think we should refactor this"},
+			},
+			wantClaudeCalls:        0,
+			wantLastIssueCommentID: 71,
+		},
+		{
+			// /oompa commands from non-whitelisted users should be ignored.
+			name: "oompa command from non-whitelisted user ignored",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "random-user", Body: "/oompa fix the commit message"},
+			},
+			reviewers:              []string{"trusted-reviewer"},
+			wantClaudeCalls:        0,
+			wantLastIssueCommentID: 70,
+		},
+		{
+			// Inline review comments and /oompa PR comments are combined into
+			// one agent task; both cursors advance and both get reactions.
+			name: "oompa command combines with inline review comments",
+			prComments: []ReviewComment{
+				{ID: 60, User: "reviewer", Body: "Fix the typo", Path: "main.go", Line: 10},
+			},
+			issueComments: []ReviewComment{
+				{ID: 70, User: "reviewer", Body: "/oompa rebase on main"},
+			},
+			wantClaudeCalls:        1,
+			wantLastCommentID:      60,
+			wantLastIssueCommentID: 70,
+			wantReactions:          []string{"60:eyes", "issue:70:eyes"},
+		},
+		{
+			// When the agent errors, the issue comment cursor should still
+			// advance. The mocked code agent replaces the claude binary, so
+			// zero claude calls are recorded even though the agent was invoked.
+			name: "cursor advances when agent errors on directive",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
+			},
+			codeAgent: &sequentialMockCodeAgent{
+				results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
+			},
+			wantClaudeCalls:        0,
+			wantLastIssueCommentID: 70,
+			wantReactions:          []string{"issue:70:eyes"},
+		},
+		{
+			// A bare "/oompa" comment with no directive text should be ignored.
+			name: "bare oompa prefix without directive ignored",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "reviewer", Body: "/oompa"},
+				{ID: 71, User: "reviewer", Body: "/oompa   "},
+			},
+			wantClaudeCalls:        0,
+			wantLastIssueCommentID: 71,
+		},
+		{
+			// Bot-posted comments with /oompa prefix should be ignored.
+			name: "bot-posted oompa command ignored",
+			issueComments: []ReviewComment{
+				{ID: 70, User: "some-bot", Body: "/oompa do something " + botMarker},
+			},
+			wantClaudeCalls:        0,
+			wantLastIssueCommentID: 70,
 		},
 	}
-	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
-	wt := &mockWorktreeManager{}
 
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &mockGitHubClient{
+				prComments:    tt.prComments,
+				issueComments: tt.issueComments,
+			}
+			runner := &mockCommandRunner{claudeResults: [][]byte{streamResultJSON(AgentResult{Result: "Done"})}}
+			wt := &mockWorktreeManager{}
 
-	agent.ProcessReviewComments(context.Background())
+			agent := newTestAgent(gh, runner, wt)
+			agent.cfg.Reviewers = tt.reviewers
+			if tt.codeAgent != nil {
+				agent.codeAgent = tt.codeAgent
+			}
+			trackWork(agent)
 
-	// Should have invoked the agent
-	claudeCalls := countCalls(runner.calls, "claude")
-	if claudeCalls != 1 {
-		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
-	}
+			agent.ProcessReviewComments(context.Background())
 
-	// Cursor should advance
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastIssueCommentID != 70 {
-		t.Errorf("expected LastIssueCommentID 70, got %d", work.LastIssueCommentID)
-	}
-
-	// Should have added :eyes: reaction using issue comment API
-	if !slices.Contains(gh.addedReactions, "issue:70:eyes") {
-		t.Errorf("expected issue comment :eyes: reaction, got %v", gh.addedReactions)
-	}
-}
-
-func TestProcessReviewComments_IgnoresNonOompaComments(t *testing.T) {
-	// PR conversation comments without /oompa prefix should be ignored.
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "reviewer", Body: "This looks good to me"},
-			{ID: 71, User: "reviewer", Body: "I think we should refactor this"},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Should NOT invoke the agent
-	if countCalls(runner.calls, "claude") != 0 {
-		t.Error("should not invoke claude for comments without /oompa prefix")
-	}
-
-	// Cursor should still advance past filtered comments
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastIssueCommentID != 71 {
-		t.Errorf("expected LastIssueCommentID to advance to 71, got %d", work.LastIssueCommentID)
-	}
-}
-
-func TestProcessReviewComments_OompaCommandSkipsNonWhitelisted(t *testing.T) {
-	// /oompa commands from non-whitelisted users should be ignored.
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "random-user", Body: "/oompa fix the commit message"},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.cfg.Reviewers = []string{"trusted-reviewer"}
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	if countCalls(runner.calls, "claude") != 0 {
-		t.Error("should not invoke claude for non-whitelisted user's /oompa command")
+			if got := countCalls(runner.calls, "claude"); got != tt.wantClaudeCalls {
+				t.Errorf("expected %d claude calls, got %d", tt.wantClaudeCalls, got)
+			}
+			work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
+			if work.LastCommentID != tt.wantLastCommentID {
+				t.Errorf("expected LastCommentID %d, got %d", tt.wantLastCommentID, work.LastCommentID)
+			}
+			if work.LastIssueCommentID != tt.wantLastIssueCommentID {
+				t.Errorf("expected LastIssueCommentID %d, got %d", tt.wantLastIssueCommentID, work.LastIssueCommentID)
+			}
+			for _, reaction := range tt.wantReactions {
+				if !slices.Contains(gh.addedReactions, reaction) {
+					t.Errorf("expected reaction %q, got %v", reaction, gh.addedReactions)
+				}
+			}
+		})
 	}
 }
 
@@ -792,121 +857,6 @@ func TestProcessReviewComments_OompaCommandIncludedInPrompt(t *testing.T) {
 	// Should NOT contain the /oompa prefix in the directive
 	if strings.Contains(prompt, "/oompa add") {
 		t.Error("prompt should strip the /oompa prefix from directives")
-	}
-}
-
-func TestProcessReviewComments_OompaCommandWithReviewComments(t *testing.T) {
-	// Both inline review comments and /oompa PR comments should be processed together.
-	result := streamResultJSON(AgentResult{Result: "Done"})
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 60, User: "reviewer", Body: "Fix the typo", Path: "main.go", Line: 10},
-		},
-		issueComments: []ReviewComment{
-			{ID: 70, User: "reviewer", Body: "/oompa rebase on main"},
-		},
-	}
-	runner := &mockCommandRunner{claudeResults: [][]byte{result}}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Should have invoked the agent once (both types combined into one task)
-	claudeCalls := countCalls(runner.calls, "claude")
-	if claudeCalls != 1 {
-		t.Fatalf("expected 1 claude call, got %d", claudeCalls)
-	}
-
-	// Both cursors should advance
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastCommentID != 60 {
-		t.Errorf("expected LastCommentID 60, got %d", work.LastCommentID)
-	}
-	if work.LastIssueCommentID != 70 {
-		t.Errorf("expected LastIssueCommentID 70, got %d", work.LastIssueCommentID)
-	}
-
-	// Should have reactions for both comment types
-	if !slices.Contains(gh.addedReactions, "60:eyes") {
-		t.Error("expected :eyes: reaction on review comment")
-	}
-	if !slices.Contains(gh.addedReactions, "issue:70:eyes") {
-		t.Error("expected :eyes: reaction on issue comment")
-	}
-}
-
-func TestProcessReviewComments_OompaCommandCursorAdvancesOnAgentError(t *testing.T) {
-	// When the agent errors, the issue comment cursor should still advance.
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "reviewer", Body: "/oompa fix the commit message"},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	agent.codeAgent = &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{{err: fmt.Errorf("agent crashed")}},
-	}
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastIssueCommentID != 70 {
-		t.Errorf("expected LastIssueCommentID to advance to 70 on agent error, got %d", work.LastIssueCommentID)
-	}
-}
-
-func TestProcessReviewComments_OompaCommandIgnoresBarePrefix(t *testing.T) {
-	// A bare "/oompa" comment with no directive text should be ignored.
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "reviewer", Body: "/oompa"},
-			{ID: 71, User: "reviewer", Body: "/oompa   "},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	// Should NOT invoke the agent for bare /oompa with no directive
-	if countCalls(runner.calls, "claude") != 0 {
-		t.Error("should not invoke claude for bare /oompa comment with no directive")
-	}
-
-	// Cursor should still advance past filtered comments
-	work := agent.state.ActiveIssues[IssueKey("owner", "repo", 42)]
-	if work.LastIssueCommentID != 71 {
-		t.Errorf("expected LastIssueCommentID to advance to 71, got %d", work.LastIssueCommentID)
-	}
-}
-
-func TestProcessReviewComments_OompaCommandIgnoresBotComments(t *testing.T) {
-	// Bot-posted comments with /oompa prefix should be ignored.
-	gh := &mockGitHubClient{
-		issueComments: []ReviewComment{
-			{ID: 70, User: "some-bot", Body: "/oompa do something " + botMarker},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wt := &mockWorktreeManager{}
-
-	agent := newTestAgent(gh, runner, wt)
-	trackWork(agent)
-
-	agent.ProcessReviewComments(context.Background())
-
-	if countCalls(runner.calls, "claude") != 0 {
-		t.Error("should not invoke claude for bot-posted /oompa comment")
 	}
 }
 

--- a/pkg/agent/slack_test.go
+++ b/pkg/agent/slack_test.go
@@ -413,137 +413,213 @@ func TestPostToSlack_HTTPError(t *testing.T) {
 	}
 }
 
-func TestCheckCIStatus_ReportsFailures(t *testing.T) {
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "failure", HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
-			{ID: 2, Name: "unit-test", Status: "completed", Conclusion: "success"},
+// TestCheckFindings covers the Check* finding-collection surface —
+// CheckCIStatus, checkRebaseNeededWithStates, checkConflictsWithStates, and
+// CheckNewReviews — against a slackTestAgent with one open PR (#100),
+// asserting finding count, owner/repo, category, message content, dedup key,
+// and lastReportedAt-based stale filtering.
+func TestCheckFindings(t *testing.T) {
+	checkCI := func(ctx context.Context, a *Agent, last time.Time) []SlackFinding {
+		return a.CheckCIStatus(ctx, last)
+	}
+	checkRebase := func(ctx context.Context, a *Agent, _ time.Time) []SlackFinding {
+		return a.checkRebaseNeededWithStates(ctx, a.fetchMergeableStates(ctx))
+	}
+	checkConflicts := func(ctx context.Context, a *Agent, _ time.Time) []SlackFinding {
+		return a.checkConflictsWithStates(ctx, a.fetchMergeableStates(ctx))
+	}
+	checkReviews := func(ctx context.Context, a *Agent, last time.Time) []SlackFinding {
+		return a.CheckNewReviews(ctx, last)
+	}
+
+	tests := []struct {
+		name              string
+		gh                *mockGitHubClient
+		lastReportedAt    time.Time
+		check             func(context.Context, *Agent, time.Time) []SlackFinding
+		wantCount         int
+		wantCategory      string
+		wantMsgContains   string
+		wantDedupContains string
+	}{
+		{
+			name: "CheckCIStatus reports failures",
+			gh: &mockGitHubClient{
+				checkRuns: []CheckRun{
+					{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "failure", HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
+					{ID: 2, Name: "unit-test", Status: "completed", Conclusion: "success"},
+				},
+				prHeadSHAs: []string{"abc123"},
+			},
+			check:             checkCI,
+			wantCount:         1,
+			wantCategory:      "ci",
+			wantMsgContains:   "e2e-test",
+			wantDedupContains: "abc123",
 		},
-		prHeadSHAs: []string{"abc123"},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckCIStatus(context.Background(), time.Time{})
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
-	}
-	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
-		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
-	}
-	if findings[0].Category != "ci" {
-		t.Errorf("expected category ci, got %s", findings[0].Category)
-	}
-	if !strings.Contains(findings[0].Message, "e2e-test") {
-		t.Errorf("expected message to contain check name, got: %s", findings[0].Message)
-	}
-	if !strings.Contains(findings[0].DedupKey, "abc123") {
-		t.Errorf("expected DedupKey to contain SHA, got: %s", findings[0].DedupKey)
-	}
-}
-
-func TestCheckRebaseNeeded_ReportsBehind(t *testing.T) {
-	gh := &mockGitHubClient{
-		mergeableState: "behind",
-		prBehind:       true,
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
-	}
-	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
-		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
-	}
-	if findings[0].Category != "rebase" {
-		t.Errorf("expected category rebase, got %s", findings[0].Category)
-	}
-	if !strings.Contains(findings[0].Message, "behind main") {
-		t.Errorf("expected message about behind main, got: %s", findings[0].Message)
-	}
-}
-
-func TestCheckConflicts_ReportsDirty(t *testing.T) {
-	gh := &mockGitHubClient{
-		mergeableState: "dirty",
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.checkConflictsWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
-	}
-	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
-		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
-	}
-	if findings[0].Category != "conflict" {
-		t.Errorf("expected category conflict, got %s", findings[0].Category)
-	}
-	if !strings.Contains(findings[0].Message, "merge conflicts") {
-		t.Errorf("expected message about merge conflicts, got: %s", findings[0].Message)
-	}
-}
-
-func TestCheckNewReviews_ReportsComments(t *testing.T) {
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 10, User: "reviewer1", Body: "Please fix this"},
-			{ID: 11, User: "reviewer2", Body: "LGTM"},
+		{
+			name: "CheckCIStatus no failures for passing CI",
+			gh: &mockGitHubClient{
+				checkRuns: []CheckRun{
+					{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "success"},
+				},
+				prHeadSHAs: []string{"abc123"},
+			},
+			check:     checkCI,
+			wantCount: 0,
+		},
+		{
+			name: "CheckCIStatus filters stale failures",
+			gh: &mockGitHubClient{
+				checkRuns: []CheckRun{
+					{ID: 1, Name: "stale-test", Status: "completed", Conclusion: "failure",
+						CompletedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC), // Before lastReportedAt
+						HTMLURL:     "https://github.com/org/repo/actions/runs/1/job/1"},
+					{ID: 2, Name: "new-test", Status: "completed", Conclusion: "failure",
+						CompletedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC), // After lastReportedAt
+						HTMLURL:     "https://github.com/org/repo/actions/runs/2/job/2"},
+				},
+				prHeadSHAs: []string{"abc123"},
+			},
+			lastReportedAt:    time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+			check:             checkCI,
+			wantCount:         1,
+			wantCategory:      "ci",
+			wantMsgContains:   "new-test",
+			wantDedupContains: "abc123",
+		},
+		{
+			// Failures with zero CompletedAt (e.g. commit statuses) should not be filtered.
+			name: "CheckCIStatus includes failures with zero CompletedAt",
+			gh: &mockGitHubClient{
+				checkRuns: []CheckRun{
+					{ID: 1, Name: "no-timestamp", Status: "completed", Conclusion: "failure",
+						HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
+				},
+				prHeadSHAs: []string{"abc123"},
+			},
+			lastReportedAt:    time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+			check:             checkCI,
+			wantCount:         1,
+			wantCategory:      "ci",
+			wantMsgContains:   "no-timestamp",
+			wantDedupContains: "abc123",
+		},
+		{
+			name: "CheckRebaseNeeded reports behind",
+			gh: &mockGitHubClient{
+				mergeableState: "behind",
+				prBehind:       true,
+			},
+			check:             checkRebase,
+			wantCount:         1,
+			wantCategory:      "rebase",
+			wantMsgContains:   "behind main",
+			wantDedupContains: "rebase-needed:100",
+		},
+		{
+			name:      "CheckRebaseNeeded no findings for clean state",
+			gh:        &mockGitHubClient{mergeableState: "clean"},
+			check:     checkRebase,
+			wantCount: 0,
+		},
+		{
+			name:              "CheckConflicts reports dirty",
+			gh:                &mockGitHubClient{mergeableState: "dirty"},
+			check:             checkConflicts,
+			wantCount:         1,
+			wantCategory:      "conflict",
+			wantMsgContains:   "merge conflicts",
+			wantDedupContains: "conflict:100",
+		},
+		{
+			name: "CheckNewReviews reports comments",
+			gh: &mockGitHubClient{
+				prComments: []ReviewComment{
+					{ID: 10, User: "reviewer1", Body: "Please fix this"},
+					{ID: 11, User: "reviewer2", Body: "LGTM"},
+				},
+			},
+			check:             checkReviews,
+			wantCount:         1,
+			wantCategory:      "review",
+			wantMsgContains:   "2 new review",
+			wantDedupContains: "review:100:11",
+		},
+		{
+			name: "CheckNewReviews filters stale comments",
+			gh: &mockGitHubClient{
+				prComments: []ReviewComment{
+					{ID: 10, User: "reviewer1", Body: "Old comment",
+						CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)}, // Before lastReportedAt
+					{ID: 11, User: "reviewer2", Body: "New comment",
+						CreatedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC)}, // After lastReportedAt
+				},
+			},
+			lastReportedAt:    time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+			check:             checkReviews,
+			wantCount:         1,
+			wantCategory:      "review",
+			wantMsgContains:   "1 new review comment",
+			wantDedupContains: "review:100:11",
+		},
+		{
+			// Comments with zero CreatedAt should not be filtered.
+			name: "CheckNewReviews includes comments with zero CreatedAt",
+			gh: &mockGitHubClient{
+				prComments: []ReviewComment{
+					{ID: 10, User: "reviewer1", Body: "No timestamp comment"},
+				},
+			},
+			lastReportedAt:    time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+			check:             checkReviews,
+			wantCount:         1,
+			wantCategory:      "review",
+			wantMsgContains:   "1 new review comment",
+			wantDedupContains: "review:100:10",
+		},
+		{
+			name: "CheckNewReviews all stale no findings",
+			gh: &mockGitHubClient{
+				prComments: []ReviewComment{
+					{ID: 10, User: "reviewer1", Body: "Old comment",
+						CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)},
+					{ID: 11, User: "reviewer2", Body: "Also old",
+						CreatedAt: time.Date(2026, 5, 29, 8, 0, 0, 0, time.UTC)},
+				},
+			},
+			lastReportedAt: time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+			check:          checkReviews,
+			wantCount:      0,
 		},
 	}
 
-	a := slackTestAgent(gh)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := slackTestAgent(tt.gh)
 
-	findings := a.CheckNewReviews(context.Background(), time.Time{})
+			findings := tt.check(context.Background(), a, tt.lastReportedAt)
 
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings))
-	}
-	if findings[0].Owner != "org" || findings[0].Repo != "repo" {
-		t.Errorf("expected Owner/Repo org/repo, got %s/%s", findings[0].Owner, findings[0].Repo)
-	}
-	if findings[0].Category != "review" {
-		t.Errorf("expected category review, got %s", findings[0].Category)
-	}
-	if !strings.Contains(findings[0].Message, "2 new review") {
-		t.Errorf("expected message about 2 new reviews, got: %s", findings[0].Message)
-	}
-}
-
-func TestCheckCIStatus_NoFailures(t *testing.T) {
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "e2e-test", Status: "completed", Conclusion: "success"},
-		},
-		prHeadSHAs: []string{"abc123"},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckCIStatus(context.Background(), time.Time{})
-
-	if len(findings) != 0 {
-		t.Errorf("expected 0 findings for passing CI, got %d", len(findings))
-	}
-}
-
-func TestCheckRebaseNeeded_Clean(t *testing.T) {
-	gh := &mockGitHubClient{
-		mergeableState: "clean",
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.checkRebaseNeededWithStates(context.Background(), a.fetchMergeableStates(context.Background()))
-
-	if len(findings) != 0 {
-		t.Errorf("expected 0 findings for clean state, got %d", len(findings))
+			if len(findings) != tt.wantCount {
+				t.Fatalf("expected %d finding(s), got %d", tt.wantCount, len(findings))
+			}
+			if tt.wantCount == 0 {
+				return
+			}
+			f := findings[0]
+			if f.Owner != "org" || f.Repo != "repo" {
+				t.Errorf("expected Owner/Repo org/repo, got %s/%s", f.Owner, f.Repo)
+			}
+			if f.Category != tt.wantCategory {
+				t.Errorf("expected category %s, got %s", tt.wantCategory, f.Category)
+			}
+			if !strings.Contains(f.Message, tt.wantMsgContains) {
+				t.Errorf("expected message to contain %q, got: %s", tt.wantMsgContains, f.Message)
+			}
+			if !strings.Contains(f.DedupKey, tt.wantDedupContains) {
+				t.Errorf("expected DedupKey to contain %q, got: %s", tt.wantDedupContains, f.DedupKey)
+			}
+		})
 	}
 }
 
@@ -1171,99 +1247,6 @@ func TestSlackReporter_LastReportedAtSurvivesRestart(t *testing.T) {
 	}
 }
 
-// --- Timestamp-based filtering tests ---
-
-func TestCheckCIStatus_FiltersStaleFailures(t *testing.T) {
-	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
-
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "stale-test", Status: "completed", Conclusion: "failure",
-				CompletedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC), // Before lastReportedAt
-				HTMLURL:     "https://github.com/org/repo/actions/runs/1/job/1"},
-			{ID: 2, Name: "new-test", Status: "completed", Conclusion: "failure",
-				CompletedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC), // After lastReportedAt
-				HTMLURL:     "https://github.com/org/repo/actions/runs/2/job/2"},
-		},
-		prHeadSHAs: []string{"abc123"},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding (only new failure), got %d", len(findings))
-	}
-	if !strings.Contains(findings[0].Message, "new-test") {
-		t.Errorf("expected finding for new-test, got: %s", findings[0].Message)
-	}
-}
-
-func TestCheckCIStatus_IncludesFailuresWithZeroCompletedAt(t *testing.T) {
-	// Failures with zero CompletedAt (e.g. commit statuses) should not be filtered
-	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
-
-	gh := &mockGitHubClient{
-		checkRuns: []CheckRun{
-			{ID: 1, Name: "no-timestamp", Status: "completed", Conclusion: "failure",
-				HTMLURL: "https://github.com/org/repo/actions/runs/1/job/1"},
-		},
-		prHeadSHAs: []string{"abc123"},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckCIStatus(context.Background(), lastReportedAt)
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding (zero CompletedAt not filtered), got %d", len(findings))
-	}
-}
-
-func TestCheckNewReviews_FiltersStaleComments(t *testing.T) {
-	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
-
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 10, User: "reviewer1", Body: "Old comment",
-				CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)}, // Before lastReportedAt
-			{ID: 11, User: "reviewer2", Body: "New comment",
-				CreatedAt: time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC)}, // After lastReportedAt
-		},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding (only new comment), got %d", len(findings))
-	}
-	if !strings.Contains(findings[0].Message, "1 new review comment") {
-		t.Errorf("expected message about 1 new review comment, got: %s", findings[0].Message)
-	}
-}
-
-func TestCheckNewReviews_IncludesCommentsWithZeroCreatedAt(t *testing.T) {
-	// Comments with zero CreatedAt should not be filtered
-	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
-
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 10, User: "reviewer1", Body: "No timestamp comment"},
-		},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
-
-	if len(findings) != 1 {
-		t.Fatalf("expected 1 finding (zero CreatedAt not filtered), got %d", len(findings))
-	}
-}
-
 func TestSlackReporter_DedupKeysSurviveRestart(t *testing.T) {
 	var mu sync.Mutex
 	postCount := 0
@@ -1469,26 +1452,5 @@ func TestPersistLastReportedAt_PersistsAllKeys(t *testing.T) {
 	_, loaded := loadLastReportedAt(path, logger)
 	if len(loaded) != 700 {
 		t.Errorf("expected all 700 keys persisted, got %d", len(loaded))
-	}
-}
-
-func TestCheckNewReviews_AllStaleNoFindings(t *testing.T) {
-	lastReportedAt := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
-
-	gh := &mockGitHubClient{
-		prComments: []ReviewComment{
-			{ID: 10, User: "reviewer1", Body: "Old comment",
-				CreatedAt: time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)},
-			{ID: 11, User: "reviewer2", Body: "Also old",
-				CreatedAt: time.Date(2026, 5, 29, 8, 0, 0, 0, time.UTC)},
-		},
-	}
-
-	a := slackTestAgent(gh)
-
-	findings := a.CheckNewReviews(context.Background(), lastReportedAt)
-
-	if len(findings) != 0 {
-		t.Errorf("expected 0 findings when all comments are stale, got %d", len(findings))
 	}
 }

--- a/pkg/agent/triage_test.go
+++ b/pkg/agent/triage_test.go
@@ -694,7 +694,9 @@ func TestMatchExistingTriageIssue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gh := &mockGitHubClient{searchResults: tt.existing}
+			// matchExistingTriageIssue receives the merged issue list
+			// explicitly; it does not search GitHub itself.
+			gh := &mockGitHubClient{}
 			codeAgent := &sequentialMockCodeAgent{results: tt.llm}
 			a := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{},
 				withCfg(func(c *Config) {

--- a/pkg/agent/triage_test.go
+++ b/pkg/agent/triage_test.go
@@ -579,425 +579,146 @@ func TestMergeIssues(t *testing.T) {
 	}
 }
 
-func TestTriageDedup_DifferentFailuresSameJob_MatchesByJobName(t *testing.T) {
-	// Two different failures from the same job should match the existing
-	// issue via same-job prefix match, even when the failure signatures
-	// differ. This prevents duplicate issues when the LLM produces
-	// different summaries for the same job across days (issue #257).
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 1501, Title: "CI Failure: periodic-knmstate-e2e-handler-k8s-latest / VLAN bridge test timeout",
-				Body: "Periodic CI job failed. VLAN configuration test failed with timeout."},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-			c.TriageJobs = []string{}
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	// Different failure signature from the same job
-	title := "CI Failure: periodic-knmstate-e2e-handler-k8s-latest / CRI-O mirror returned HTTP 404"
-	analysis := "## Summary\nCRI-O mirror returned HTTP 404\n\n## Root Cause\nInfrastructure mirror outage"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"periodic-knmstate-e2e-handler-k8s-latest",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, // no cycle issues
-		nil, // no concurrent failures (single job)
-	)
-
-	// Same-job prefix match should find issue #1501
-	if matchedIssue != 1501 {
-		t.Errorf("expected same-job match on issue #1501, got #%d", matchedIssue)
-	}
-
-	// LLM should NOT have been called (same-job match is pre-LLM)
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (same-job match), got %d", codeAgent.callCount)
-	}
-}
-
-func TestFindSameJobIssue_CycleIssues(t *testing.T) {
+// TestMatchExistingTriageIssue covers the dedup ladder in
+// matchExistingTriageIssue: exact title match, same-job prefix match
+// (cross-day dedup, #257), same-job cycle issues (#253), LLM matching for
+// different jobs, and the deterministic fallback to cycle issues when the
+// LLM answers NONE.
+func TestMatchExistingTriageIssue(t *testing.T) {
 	tests := []struct {
 		name        string
 		jobName     string
+		title       string
+		analysis    string
+		existing    []Issue
 		cycleIssues []Issue
-		want        int
+		cycleJobs   []string
+		llm         []mockCodeAgentCall
+		wantIssue   int
+		wantLLM     int
 	}{
 		{
-			name:        "no cycle issues",
-			jobName:     "owner/repo/ci.yml",
-			cycleIssues: nil,
-			want:        0,
-		},
-		{
-			name:    "matching cycle issue",
-			jobName: "owner/repo/ci.yml",
-			cycleIssues: []Issue{
-				{Number: 10, Title: "CI Failure: owner/repo/ci.yml / Compile error in main.go"},
+			name:     "exact title match skips LLM",
+			jobName:  "periodic-e2e-test",
+			title:    "CI Failure: periodic-e2e-test / CRI-O mirror HTTP 404",
+			analysis: "## Summary\nCRI-O mirror HTTP 404\n\n## Root Cause\nMirror outage",
+			existing: []Issue{
+				{Number: 99, Title: "CI Failure: periodic-e2e-test / CRI-O mirror HTTP 404", Body: "CRI-O mirror outage"},
 			},
-			want: 10,
+			wantIssue: 99,
 		},
 		{
-			name:    "no matching cycle issue (different job)",
-			jobName: "owner/repo/ci.yml",
-			cycleIssues: []Issue{
-				{Number: 10, Title: "CI Failure: owner/repo/e2e.yml / Test timeout"},
+			name:     "same job with similar failure matches by prefix",
+			jobName:  "periodic-e2e-test",
+			title:    "CI Failure: periodic-e2e-test / DNS lookup timed out for registry.k8s.io",
+			analysis: "## Summary\nDNS lookup timed out for registry.k8s.io\n\n## Root Cause\nDNS resolution failure",
+			existing: []Issue{
+				{Number: 42, Title: "CI Failure: periodic-e2e-test / DNS resolution failure", Body: "Periodic CI job failed. DNS resolution timed out."},
 			},
-			want: 0,
+			wantIssue: 42,
 		},
 		{
-			name:    "multiple cycle issues returns first match",
-			jobName: "owner/repo/ci.yml",
-			cycleIssues: []Issue{
-				{Number: 10, Title: "CI Failure: owner/repo/ci.yml / Error A"},
-				{Number: 11, Title: "CI Failure: owner/repo/ci.yml / Error B"},
+			name:     "same job with different signature matches by prefix",
+			jobName:  "periodic-knmstate-e2e-handler-k8s-latest",
+			title:    "CI Failure: periodic-knmstate-e2e-handler-k8s-latest / CRI-O mirror returned HTTP 404",
+			analysis: "## Summary\nCRI-O mirror returned HTTP 404\n\n## Root Cause\nInfrastructure mirror outage",
+			existing: []Issue{
+				{Number: 1501, Title: "CI Failure: periodic-knmstate-e2e-handler-k8s-latest / VLAN bridge test timeout", Body: "Periodic CI job failed. VLAN configuration test failed with timeout."},
 			},
-			want: 10,
+			wantIssue: 1501,
 		},
 		{
-			name:    "matches by prefix regardless of failure signature",
-			jobName: "owner/repo/ci.yml",
+			name:     "same job with different signature matches across days",
+			jobName:  "kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml",
+			title:    "CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / IPAM controller pod CrashLoopBackOff",
+			analysis: "## Summary\nIPAM controller pod CrashLoopBackOff\n\n## Root Cause\nMemory limit exceeded",
+			existing: []Issue{
+				{Number: 2835, Title: "CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / DHCP timeout in pod network", Body: "Periodic CI job failed. DHCP timeout during pod network setup."},
+			},
+			wantIssue: 2835,
+		},
+		{
+			name:     "existing issue without signature suffix still matches",
+			jobName:  "owner/repo/ci.yml",
+			title:    "CI Failure: owner/repo/ci.yml / New failure signature",
+			analysis: "## Summary\nNew failure",
+			existing: []Issue{
+				{Number: 100, Title: "CI Failure: owner/repo/ci.yml", Body: "Periodic CI job failed."},
+			},
+			wantIssue: 100,
+		},
+		{
+			name:     "same-job cycle issue matches before LLM",
+			jobName:  "owner/repo/ci.yml",
+			title:    "CI Failure: owner/repo/ci.yml / Compile error in main.go line 99",
+			analysis: "## Summary\nCompile error in main.go line 99",
 			cycleIssues: []Issue{
 				{Number: 10, Title: "CI Failure: owner/repo/ci.yml / Compile error in main.go line 42"},
 			},
-			want: 10,
+			cycleJobs: []string{"owner/repo/ci.yml"},
+			llm:       []mockCodeAgentCall{{result: AgentResult{Result: "NONE"}}},
+			wantIssue: 10,
 		},
 		{
-			name:    "title without failure signature also matches",
-			jobName: "owner/repo/ci.yml",
-			cycleIssues: []Issue{
-				{Number: 10, Title: "CI Failure: owner/repo/ci.yml"},
+			name:     "different job falls through to LLM",
+			jobName:  "owner/repo/ci.yml",
+			title:    "CI Failure: owner/repo/ci.yml / Compile error",
+			analysis: "## Summary\nCompile error",
+			existing: []Issue{
+				{Number: 200, Title: "CI Failure: owner/repo/e2e.yml / DNS timeout", Body: "Periodic CI job failed. DNS timeout."},
 			},
-			want: 10,
+			llm:       []mockCodeAgentCall{{result: AgentResult{Result: "NONE"}}},
+			wantIssue: 0,
+			wantLLM:   1,
 		},
 		{
-			name:    "does not match when job name is prefix of another job",
-			jobName: "owner/repo/ci.yml",
+			name:      "no existing issues returns zero without LLM",
+			jobName:   "periodic-e2e-test",
+			title:     "CI Failure: periodic-e2e-test / some failure",
+			analysis:  "analysis",
+			wantIssue: 0,
+		},
+		{
+			name:     "LLM NONE falls back deterministically to cycle issue",
+			jobName:  "job-b",
+			title:    "CI Failure: job-b / DNS timeout",
+			analysis: "## Summary\nDNS timeout",
 			cycleIssues: []Issue{
-				{Number: 10, Title: "CI Failure: owner/repo/ci.yml-long / Some error"},
+				{Number: 42, Title: "CI Failure: job-a / Infra outage", Body: "Infra outage"},
 			},
-			want: 0,
+			cycleJobs: []string{"job-a", "job-b", "job-c"},
+			llm:       []mockCodeAgentCall{{result: AgentResult{Result: "NONE"}}},
+			wantIssue: 42,
+			wantLLM:   1,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findSameJobIssue(tt.jobName, tt.cycleIssues)
-			if got != tt.want {
-				t.Errorf("findSameJobIssue(%q, ...) = %d, want %d", tt.jobName, got, tt.want)
+			gh := &mockGitHubClient{searchResults: tt.existing}
+			codeAgent := &sequentialMockCodeAgent{results: tt.llm}
+			a := newTestAgent(gh, &mockCommandRunner{}, &mockWorktreeManager{},
+				withCfg(func(c *Config) {
+					c.FlakyLabel = "ci-flake"
+					c.CreateFlakyIssues = true
+				}),
+				withCodeAgent(codeAgent),
+			)
+
+			// Mirror production: investigateTriageRun merges cycle issues into
+			// the search results before matching.
+			existingIssues := mergeIssues(tt.existing, tt.cycleIssues)
+
+			got := a.matchExistingTriageIssue(context.Background(),
+				tt.jobName, tt.title, tt.analysis,
+				existingIssues, "/tmp/worktree", tt.cycleIssues, tt.cycleJobs)
+
+			if got != tt.wantIssue {
+				t.Errorf("matched issue = #%d, want #%d", got, tt.wantIssue)
+			}
+			if codeAgent.callCount != tt.wantLLM {
+				t.Errorf("LLM calls = %d, want %d", codeAgent.callCount, tt.wantLLM)
 			}
 		})
-	}
-}
-
-func TestTriageDedup_SameJobCycleIssue_MatchesBeforeLLM(t *testing.T) {
-	// When a cycle issue exists for the same job, matchExistingTriageIssue
-	// should return it immediately without calling the LLM matcher.
-	// This tests the fix for #253: same workflow, different signatures.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{}, // no existing issues from search
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{
-			// Should NOT be called — same-job cycle dedup fires first
-			{result: AgentResult{Result: "NONE"}},
-		},
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	cycleIssues := []Issue{
-		{Number: 10, Title: "CI Failure: owner/repo/ci.yml / Compile error in main.go line 42"},
-	}
-
-	// Different title (different failure signature) but same job
-	title := "CI Failure: owner/repo/ci.yml / Compile error in main.go line 99"
-	analysis := "## Summary\nCompile error in main.go line 99"
-
-	existingIssues := mergeIssues(gh.searchResults, cycleIssues)
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"owner/repo/ci.yml",
-		title,
-		analysis,
-		existingIssues,
-		"/tmp/worktree",
-		cycleIssues,
-		[]string{"owner/repo/ci.yml"}, // single job
-	)
-
-	// Should match the cycle issue even though titles differ
-	if matchedIssue != 10 {
-		t.Errorf("expected match to cycle issue #10, got %d", matchedIssue)
-	}
-
-	// LLM should NOT have been called (same-job cycle dedup is pre-LLM)
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (same-job cycle dedup), got %d", codeAgent.callCount)
-	}
-}
-
-func TestTriageDedup_SameFailureSameJob_MatchesExistingIssue(t *testing.T) {
-	// Same failure from the same job should match the existing issue via
-	// same-job prefix match (no LLM needed).
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 42, Title: "CI Failure: periodic-e2e-test / DNS resolution failure",
-				Body: "Periodic CI job failed. DNS resolution timed out."},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	// New failure is also a DNS issue, but slightly different title
-	title := "CI Failure: periodic-e2e-test / DNS lookup timed out for registry.k8s.io"
-	analysis := "## Summary\nDNS lookup timed out for registry.k8s.io\n\n## Root Cause\nDNS resolution failure"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"periodic-e2e-test",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, // no cycle issues
-		nil, // no concurrent failures (single job)
-	)
-
-	// Same-job prefix match → should match issue #42
-	if matchedIssue != 42 {
-		t.Errorf("expected match on issue #42, got #%d", matchedIssue)
-	}
-
-	// LLM should NOT have been called
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (same-job match), got %d", codeAgent.callCount)
-	}
-}
-
-func TestTriageDedup_ExactTitleMatch_SkipsLLM(t *testing.T) {
-	// Exact title match should skip LLM invocation entirely.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 99, Title: "CI Failure: periodic-e2e-test / CRI-O mirror HTTP 404",
-				Body: "CRI-O mirror outage"},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{}, // No results — should NOT be called
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	title := "CI Failure: periodic-e2e-test / CRI-O mirror HTTP 404"
-	analysis := "## Summary\nCRI-O mirror HTTP 404\n\n## Root Cause\nMirror outage"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"periodic-e2e-test",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, // no cycle issues
-		nil, // no concurrent failures (single job)
-	)
-
-	// Exact title match — should return issue #99
-	if matchedIssue != 99 {
-		t.Errorf("expected exact title match on issue #99, got #%d", matchedIssue)
-	}
-
-	// LLM should NOT have been called
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (exact title match), got %d", codeAgent.callCount)
-	}
-}
-
-func TestTriageDedup_SameJobDifferentSignature_MatchesAcrossDays(t *testing.T) {
-	// When the same CI job fails on consecutive days, the failure signature
-	// (LLM summary) may differ between runs. The same-job match should find
-	// the existing issue by job name prefix without invoking the LLM.
-	// This is the cross-day dedup scenario from issue #257.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 2835, Title: "CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / DHCP timeout in pod network",
-				Body: "Periodic CI job failed. DHCP timeout during pod network setup."},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{}, // Should NOT be called — same-job match fires first
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	// Next day: same job, different failure signature from LLM
-	title := "CI Failure: kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml / IPAM controller pod CrashLoopBackOff"
-	analysis := "## Summary\nIPAM controller pod CrashLoopBackOff\n\n## Root Cause\nMemory limit exceeded"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"kubevirt/cluster-network-addons-operator/kubevirt-ipam-controller.yaml",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, // no cycle issues (different triage cycle)
-		nil, // no concurrent failures (single job)
-	)
-
-	// Should match issue #2835 via same-job prefix match
-	if matchedIssue != 2835 {
-		t.Errorf("expected same-job match on issue #2835, got #%d", matchedIssue)
-	}
-
-	// LLM should NOT have been called (same-job match is pre-LLM)
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (same-job match), got %d", codeAgent.callCount)
-	}
-}
-
-func TestTriageDedup_SameJobNoSignature_MatchesAcrossDays(t *testing.T) {
-	// Existing issue has no failure signature suffix. Same-job match
-	// should still find it.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 100, Title: "CI Failure: owner/repo/ci.yml",
-				Body: "Periodic CI job failed."},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{},
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	title := "CI Failure: owner/repo/ci.yml / New failure signature"
-	analysis := "## Summary\nNew failure"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"owner/repo/ci.yml",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, nil,
-	)
-
-	if matchedIssue != 100 {
-		t.Errorf("expected same-job match on issue #100, got #%d", matchedIssue)
-	}
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls, got %d", codeAgent.callCount)
-	}
-}
-
-func TestTriageDedup_DifferentJob_DoesNotSameJobMatch(t *testing.T) {
-	// Issues from a DIFFERENT job should NOT be matched by same-job match.
-	// They should fall through to LLM matching.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{
-			{Number: 200, Title: "CI Failure: owner/repo/e2e.yml / DNS timeout",
-				Body: "Periodic CI job failed. DNS timeout."},
-		},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{
-			{result: AgentResult{Result: "NONE"}}, // LLM says no match
-		},
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	// Different job name
-	title := "CI Failure: owner/repo/ci.yml / Compile error"
-	analysis := "## Summary\nCompile error"
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"owner/repo/ci.yml",
-		title,
-		analysis,
-		gh.searchResults,
-		"/tmp/worktree",
-		nil, nil,
-	)
-
-	// Should NOT match — different job
-	if matchedIssue != 0 {
-		t.Errorf("expected no match (different job), got #%d", matchedIssue)
-	}
-
-	// LLM should have been called (same-job match didn't fire)
-	if codeAgent.callCount != 1 {
-		t.Errorf("expected 1 agent call (LLM matching), got %d", codeAgent.callCount)
 	}
 }
 
@@ -1072,44 +793,6 @@ func TestFindSameJobIssue(t *testing.T) {
 				t.Errorf("findSameJobIssue(%q, ...) = %d, want %d", tt.job, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestTriageDedup_NoExistingIssues_ReturnsZero(t *testing.T) {
-	// No existing issues → should return 0 (will create a new issue).
-	gh := &mockGitHubClient{
-		searchResults: []Issue{},
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{},
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"periodic-e2e-test",
-		"CI Failure: periodic-e2e-test / some failure",
-		"analysis",
-		[]Issue{},
-		"/tmp/worktree",
-		nil, // no cycle issues
-		nil, // no concurrent failures (single job)
-	)
-
-	if matchedIssue != 0 {
-		t.Errorf("expected 0 (no existing issues), got #%d", matchedIssue)
-	}
-	if codeAgent.callCount != 0 {
-		t.Errorf("expected 0 agent calls (no existing issues), got %d", codeAgent.callCount)
 	}
 }
 
@@ -1263,64 +946,6 @@ func TestProcessTriageJobs_DeterministicFallbackWhenLLMSaysNone(t *testing.T) {
 	}
 	if runLinkCount != 2 {
 		t.Errorf("expected 2 run-link comments, got %d", runLinkCount)
-	}
-}
-
-func TestTriageDedup_DeterministicFallbackWithCycleIssuesMerged(t *testing.T) {
-	// Mirrors production behavior: investigateTriageRun merges cycleIssues
-	// into existingIssues before calling matchExistingTriageIssue. When the
-	// LLM says NONE, the deterministic fallback should match to the cycle
-	// issue even though it's present in existingIssues.
-	gh := &mockGitHubClient{
-		searchResults: []Issue{}, // GitHub search returns nothing (search lag)
-	}
-	runner := &mockCommandRunner{}
-	wtm := &mockWorktreeManager{}
-
-	// LLM says NONE — deterministic fallback should fire after LLM
-	codeAgent := &sequentialMockCodeAgent{
-		results: []mockCodeAgentCall{
-			{result: AgentResult{Result: "NONE"}},
-		},
-	}
-
-	a := newTestAgent(gh, runner, wtm,
-		withCfg(func(c *Config) {
-			c.FlakyLabel = "ci-flake"
-			c.CreateFlakyIssues = true
-		}),
-		withCodeAgent(codeAgent),
-	)
-
-	title := "CI Failure: job-b / DNS timeout"
-	analysis := "## Summary\nDNS timeout"
-
-	// Simulate 3 failed jobs with 1 cycle issue already created
-	cycleIssues := []Issue{
-		{Number: 42, Title: "CI Failure: job-a / Infra outage", Body: "Infra outage"},
-	}
-	cycleFailedJobs := []string{"job-a", "job-b", "job-c"}
-
-	// Mirror production: merge cycleIssues into existingIssues (as
-	// investigateTriageRun does before calling matchExistingTriageIssue)
-	existingIssues := mergeIssues([]Issue{}, cycleIssues)
-
-	matchedIssue := a.matchExistingTriageIssue(context.Background(),
-		"job-b", title, analysis,
-		existingIssues,
-		"/tmp/worktree",
-		cycleIssues,
-		cycleFailedJobs,
-	)
-
-	// Should match cycle issue #42 via deterministic fallback after LLM NONE
-	if matchedIssue != 42 {
-		t.Errorf("expected deterministic fallback to match cycle issue #42, got #%d", matchedIssue)
-	}
-
-	// LLM should have been called once (title didn't match, so LLM tried)
-	if codeAgent.callCount != 1 {
-		t.Errorf("expected 1 agent call (LLM tried before fallback), got %d", codeAgent.callCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 3b of the unslop series (follow-up to #274): the seven clusters of near-identical one-scenario test functions identified in the test survey become table-driven tests. **89 flat functions collapse into 17 tables** while assertions get *stricter*, not weaker — each table applies the strictest common assertion set to every row, where previously each copy checked whichever subset its author remembered.

## Changes

One commit per cluster; each verified independently with fmt/vet/test:

- **conflicts**: the 8-function ProcessRebase guard matrix (main-branch activity, min interval, fail-open) and the 3 shouldRebaseNow interval tests → 2 tables. Deferred rows now also assert zero git commands.
- **triage**: 9 functions staging one scenario each against `matchExistingTriageIssue` → one table walking the dedup ladder (exact title → same-job prefix → cycle issues → LLM → deterministic NONE fallback). Also deletes `TestFindSameJobIssue_CycleIssues`, whose 7 cases were all duplicates of rows in `TestFindSameJobIssue`.
- **issues**: 6 skip/defer functions → one table (the no-comment assertion now applies to every scenario, not just one); the 3 squash-commit-message tests → a second table.
- **ci**: 27 one-scenario functions over `parseCIStructuredFields`, `writeFenced`, the comment formatters, `resultSummaryLine`, `writeStructuredBody`, and the ProcessCIFailures skip conditions → 8 tables, one per behavioral surface.
- **review**: 14 functions → 3 tables covering the cursor-advancement contract, the no-op counter lifecycle, and /oompa comment filtering. Cursor positions and no-op counts are now checked in every scenario.
- **fileconfig**: 17 validation functions + the pre-existing 10-row table → one 26-row `TestLoadFileConfig_Validation`. Tests asserting on loaded values stay standalone.
- **slack**: 11 Check\* collector functions (incl. stale-filtering variants) → one findings table keyed by a per-row collector closure.

Tests that didn't fit cleanly (multi-cycle flows, prompt-content assertions, bespoke runner scenarios) were deliberately left standalone rather than force-fit.

## Testing

- `go build ./...`
- `go test ./... -count=1 -race` — all packages pass; every table row verified to run via `-v`
- `golangci-lint run` — 0 issues

## Related Issues

Part of the phased unslop series: #269 → #270 → #271 → #272 → #273 → #274 → this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for CI parsing, formatting, configuration validation, rebasing, issue processing, review handling, Slack findings, and triage deduplication.
  - Added scenarios for HTML escaping, stale items, cursor advancement, retry and deferral behavior, configurable intervals, and safe fenced output.
  - Consolidated numerous cases into clearer table-driven test suites, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->