### PR TITLE
fix: paginate gh list endpoints and bound job-log memory

### DIFF
--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -474,6 +474,11 @@ func (g *RESTClient) GetCheckRunLog(ctx context.Context, owner, repo string, che
 	return g.fetchJobLogTail(ctx, owner, repo, checkRunID)
 }
 
+// logDownloadClient fetches log content from pre-signed storage URLs. A
+// dedicated plain client: no API auth header (pre-signed URLs reject it) and
+// an explicit timeout so a stalled storage endpoint cannot hang a poll cycle.
+var logDownloadClient = &http.Client{Timeout: 60 * time.Second}
+
 // fetchJobLogTail downloads the logs for a workflow job and returns the
 // truncated tail.
 //
@@ -492,7 +497,7 @@ func (g *RESTClient) fetchJobLogTail(ctx context.Context, owner, repo string, jo
 	if err != nil {
 		return "", fmt.Errorf("creating log request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := logDownloadClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching log: %w", err)
 	}

--- a/internal/gh/client.go
+++ b/internal/gh/client.go
@@ -93,35 +93,41 @@ func NewRESTClientFromHTTPClient(httpClient *http.Client) (*RESTClient, error) {
 
 func (g *RESTClient) ListLabeledIssues(ctx context.Context, owner, repo, label string) ([]Issue, error) {
 	opts := &github.IssueListByRepoOptions{
-		Labels: []string{label},
-		State:  "open",
-	}
-
-	ghIssues, _, err := g.client.Issues.ListByRepo(ctx, owner, repo, opts)
-	if err != nil {
-		return nil, fmt.Errorf("listing issues: %w", err)
+		Labels:      []string{label},
+		State:       "open",
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
 
 	var issues []Issue
-	for _, gi := range ghIssues {
-		if gi.IsPullRequest() {
-			continue
+	for {
+		ghIssues, resp, err := g.client.Issues.ListByRepo(ctx, owner, repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing issues: %w", err)
 		}
-		var labels []string
-		for _, l := range gi.Labels {
-			labels = append(labels, l.GetName())
+		for _, gi := range ghIssues {
+			if gi.IsPullRequest() {
+				continue
+			}
+			var labels []string
+			for _, l := range gi.Labels {
+				labels = append(labels, l.GetName())
+			}
+			var assignees []string
+			for _, a := range gi.Assignees {
+				assignees = append(assignees, a.GetLogin())
+			}
+			issues = append(issues, Issue{
+				Number:    gi.GetNumber(),
+				Title:     gi.GetTitle(),
+				Body:      gi.GetBody(),
+				Labels:    labels,
+				Assignees: assignees,
+			})
 		}
-		var assignees []string
-		for _, a := range gi.Assignees {
-			assignees = append(assignees, a.GetLogin())
+		if resp.NextPage == 0 {
+			break
 		}
-		issues = append(issues, Issue{
-			Number:    gi.GetNumber(),
-			Title:     gi.GetTitle(),
-			Body:      gi.GetBody(),
-			Labels:    labels,
-			Assignees: assignees,
-		})
+		opts.ListOptions.Page = resp.NextPage
 	}
 	return issues, nil
 }
@@ -333,13 +339,25 @@ func (g *RESTClient) GetCheckRuns(ctx context.Context, owner, repo, ref string) 
 	opts := &github.ListCheckRunsOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	result, _, err := g.client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opts)
-	if err != nil {
-		return nil, fmt.Errorf("listing check runs: %w", err)
-	}
 
 	var runs []CheckRun
-	for _, r := range result.CheckRuns {
+	for {
+		result, resp, err := g.client.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing check runs: %w", err)
+		}
+		runs = appendCheckRuns(runs, result.CheckRuns)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return runs, nil
+}
+
+// appendCheckRuns converts go-github check runs onto the accumulator.
+func appendCheckRuns(runs []CheckRun, ghRuns []*github.CheckRun) []CheckRun {
+	for _, r := range ghRuns {
 		var output string
 		if r.Output != nil {
 			output = r.Output.GetText()
@@ -361,7 +379,7 @@ func (g *RESTClient) GetCheckRuns(ctx context.Context, owner, repo, ref string) 
 			CompletedAt: completedAt,
 		})
 	}
-	return runs, nil
+	return runs
 }
 
 // GetCommitStatuses queries the Combined Status API and returns failures as
@@ -404,19 +422,51 @@ func (g *RESTClient) GetCommitStatuses(ctx context.Context, owner, repo, ref str
 // context for investigation while avoiding excessively large prompts.
 const maxCILogBytes = 50000
 
-// truncateLogTail returns the last maxCILogBytes of a log, with a truncation
-// marker prepended when the log was cut.
-func truncateLogTail(log string) string {
-	if len(log) <= maxCILogBytes {
-		return log
+// tailBuffer is an io.Writer that retains only the last max bytes written,
+// so arbitrarily large streams are consumed with bounded memory. The buffer
+// is allocated once; each overflowing write slides the retained window with
+// copies instead of growing the backing array.
+type tailBuffer struct {
+	buf   []byte // fixed backing array of cap max
+	n     int    // bytes currently retained
+	total int64  // total bytes ever written
+}
+
+func newTailBuffer(maxBytes int) *tailBuffer {
+	return &tailBuffer{buf: make([]byte, maxBytes)}
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	written := len(p)
+	t.total += int64(written)
+	if written >= len(t.buf) {
+		// The chunk alone fills the window: keep only its tail.
+		copy(t.buf, p[written-len(t.buf):])
+		t.n = len(t.buf)
+		return written, nil
 	}
-	// Advance to a rune boundary so the byte cut cannot split a multibyte
-	// character.
-	start := len(log) - maxCILogBytes
-	for start < len(log) && !utf8.RuneStart(log[start]) {
+	if drop := t.n + written - len(t.buf); drop > 0 {
+		copy(t.buf, t.buf[drop:t.n])
+		t.n -= drop
+	}
+	copy(t.buf[t.n:], p)
+	t.n += written
+	return written, nil
+}
+
+// tailString returns the retained tail, prepending a truncation marker when
+// bytes were dropped. The cut is advanced to a rune boundary so it cannot
+// split a multibyte character.
+func (t *tailBuffer) tailString() string {
+	s := string(t.buf[:t.n])
+	if t.total <= int64(t.n) {
+		return s
+	}
+	start := 0
+	for start < len(s) && !utf8.RuneStart(s[start]) {
 		start++
 	}
-	return "...(truncated)...\n" + log[start:]
+	return "...(truncated)...\n" + s[start:]
 }
 
 func (g *RESTClient) GetCheckRunLog(ctx context.Context, owner, repo string, checkRunID int64) (string, error) {
@@ -425,13 +475,26 @@ func (g *RESTClient) GetCheckRunLog(ctx context.Context, owner, repo string, che
 }
 
 // fetchJobLogTail downloads the logs for a workflow job and returns the
-// truncated tail. go-github follows the storage redirects itself (without
-// forwarding the API authorization header), so the returned body is the log
-// content.
+// truncated tail.
+//
+// go-github does not download log content: the API answers with a 302 whose
+// Location is a pre-signed storage URL, and GetWorkflowJobLogs returns that
+// URL (following only intermediate 301s, up to maxRedirects). The content is
+// fetched from the storage URL with a plain client — deliberately without
+// the API authorization header, which pre-signed URLs reject.
 func (g *RESTClient) fetchJobLogTail(ctx context.Context, owner, repo string, jobID int64) (string, error) {
-	_, resp, err := g.client.Actions.GetWorkflowJobLogs(ctx, owner, repo, jobID, 4)
+	logURL, _, err := g.client.Actions.GetWorkflowJobLogs(ctx, owner, repo, jobID, 4)
 	if err != nil {
-		return "", fmt.Errorf("getting job logs: %w", err)
+		return "", fmt.Errorf("getting job logs URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, logURL.String(), http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("creating log request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching log: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -439,25 +502,35 @@ func (g *RESTClient) fetchJobLogTail(ctx context.Context, owner, repo string, jo
 		return "", fmt.Errorf("fetching job logs: unexpected status %s", resp.Status)
 	}
 
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
+	// Stream through a fixed-size tail buffer so memory stays bounded
+	// regardless of log size.
+	tail := newTailBuffer(maxCILogBytes)
+	if _, err := io.Copy(tail, resp.Body); err != nil {
 		return "", fmt.Errorf("reading job logs: %w", err)
 	}
 
-	return truncateLogTail(string(data)), nil
+	return tail.tailString(), nil
 }
 
 func (g *RESTClient) HasPRCommentReaction(ctx context.Context, owner, repo string, commentID int64, reaction, user string) (bool, error) {
-	reactions, _, err := g.client.Reactions.ListPullRequestCommentReactions(ctx, owner, repo, commentID, nil)
-	if err != nil {
-		return false, fmt.Errorf("listing reactions: %w", err)
+	opts := &github.ListReactionOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	for _, r := range reactions {
-		if r.GetContent() == reaction && r.GetUser().GetLogin() == user {
-			return true, nil
+	for {
+		reactions, resp, err := g.client.Reactions.ListPullRequestCommentReactions(ctx, owner, repo, commentID, opts)
+		if err != nil {
+			return false, fmt.Errorf("listing reactions: %w", err)
 		}
+		for _, r := range reactions {
+			if r.GetContent() == reaction && r.GetUser().GetLogin() == user {
+				return true, nil
+			}
+		}
+		if resp.NextPage == 0 {
+			return false, nil
+		}
+		opts.Page = resp.NextPage
 	}
-	return false, nil
 }
 
 func (g *RESTClient) GetPRHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error) {
@@ -493,27 +566,34 @@ func (g *RESTClient) GetPRMergeable(ctx context.Context, owner, repo string, prN
 }
 
 func (g *RESTClient) GetPRReviews(ctx context.Context, owner, repo string, prNumber int, sinceID int64) ([]PRReview, error) {
-	ghReviews, _, err := g.client.PullRequests.ListReviews(ctx, owner, repo, prNumber, nil)
-	if err != nil {
-		return nil, fmt.Errorf("listing PR reviews: %w", err)
-	}
+	opts := &github.ListOptions{PerPage: 100}
 
 	var reviews []PRReview
-	for _, r := range ghReviews {
-		if r.GetID() <= sinceID {
-			continue
+	for {
+		ghReviews, resp, err := g.client.PullRequests.ListReviews(ctx, owner, repo, prNumber, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing PR reviews: %w", err)
 		}
-		body := strings.TrimSpace(r.GetBody())
-		if body == "" {
-			continue
+		for _, r := range ghReviews {
+			if r.GetID() <= sinceID {
+				continue
+			}
+			body := strings.TrimSpace(r.GetBody())
+			if body == "" {
+				continue
+			}
+			reviews = append(reviews, PRReview{
+				ID:          r.GetID(),
+				User:        r.GetUser().GetLogin(),
+				State:       r.GetState(),
+				Body:        body,
+				SubmittedAt: r.GetSubmittedAt().Time,
+			})
 		}
-		reviews = append(reviews, PRReview{
-			ID:          r.GetID(),
-			User:        r.GetUser().GetLogin(),
-			State:       r.GetState(),
-			Body:        body,
-			SubmittedAt: r.GetSubmittedAt().Time,
-		})
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 	return reviews, nil
 }
@@ -749,20 +829,27 @@ func (g *RESTClient) ListWorkflowRuns(ctx context.Context, owner, repo, workflow
 
 // ListWorkflowJobs lists jobs for a specific workflow run.
 func (g *RESTClient) ListWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]WorkflowJob, error) {
-	opts := &github.ListWorkflowJobsOptions{}
-
-	jobs, _, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
-	if err != nil {
-		return nil, fmt.Errorf("listing workflow jobs: %w", err)
+	opts := &github.ListWorkflowJobsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
 
 	var workflowJobs []WorkflowJob
-	for _, job := range jobs.Jobs {
-		workflowJobs = append(workflowJobs, WorkflowJob{
-			ID:         job.GetID(),
-			Name:       job.GetName(),
-			Conclusion: job.GetConclusion(),
-		})
+	for {
+		jobs, resp, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing workflow jobs: %w", err)
+		}
+		for _, job := range jobs.Jobs {
+			workflowJobs = append(workflowJobs, WorkflowJob{
+				ID:         job.GetID(),
+				Name:       job.GetName(),
+				Conclusion: job.GetConclusion(),
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 
 	return workflowJobs, nil

--- a/internal/gh/client_test.go
+++ b/internal/gh/client_test.go
@@ -1069,9 +1069,9 @@ func TestAddIssueCommentReaction(t *testing.T) {
 	}
 }
 
-// TestPagination covers the resp.NextPage loops added for issue #281: every
-// list endpoint the agent reads must aggregate results across pages instead
-// of silently dropping everything after the first.
+// The *_Paginates tests below cover the resp.NextPage loops added for issue
+// #281: every list endpoint the agent reads must aggregate results across
+// pages instead of silently dropping everything after the first.
 func TestListLabeledIssues_Paginates(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v3/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
@@ -1279,8 +1279,9 @@ func TestTailBuffer(t *testing.T) {
 func TestGetCheckRunLog_BoundsLargeLogs(t *testing.T) {
 	// Serve a log much larger than maxCILogBytes in multiple chunks and
 	// verify only the tail is returned, with the truncation marker.
-	// The API endpoint answers with a redirect to blob storage, as GitHub
-	// does; go-github follows it and hands back the storage response.
+	// The API endpoint answers 302 with a pre-signed blob-storage URL, as
+	// GitHub does; the client extracts that URL via go-github and fetches
+	// the content itself.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v3/repos/owner/repo/actions/jobs/7/logs", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "http://"+r.Host+"/blob/logs", http.StatusFound)
@@ -1299,10 +1300,10 @@ func TestGetCheckRunLog_BoundsLargeLogs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.HasPrefix(log, "...(truncated)...\n") {
-		t.Errorf("expected truncation marker prefix, got %q", log[:40])
+		t.Errorf("expected truncation marker prefix, got %q", log[:min(40, len(log))])
 	}
 	if !strings.HasSuffix(log, "THE END") {
-		t.Errorf("expected log to end with the stream tail, got %q", log[len(log)-40:])
+		t.Errorf("expected log to end with the stream tail, got %q", log[max(0, len(log)-40):])
 	}
 	if len(log) > maxCILogBytes+len("...(truncated)...\n") {
 		t.Errorf("log length %d exceeds bound %d", len(log), maxCILogBytes+len("...(truncated)...\n"))

--- a/internal/gh/client_test.go
+++ b/internal/gh/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -1065,5 +1066,267 @@ func TestAddIssueCommentReaction(t *testing.T) {
 	err := gh.AddIssueCommentReaction(context.Background(), "owner", "repo", 42, "eyes")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestPagination covers the resp.NextPage loops added for issue #281: every
+// list endpoint the agent reads must aggregate results across pages instead
+// of silently dropping everything after the first.
+func TestListLabeledIssues_Paginates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("per_page"); got != "100" {
+			t.Fatalf("expected per_page=100, got %q", got)
+		}
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: new(1), Title: new("first"), Labels: []*github.Label{{Name: new("good-for-ai")}}},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode([]*github.Issue{
+				{Number: new(2), Title: new("second"), Labels: []*github.Label{{Name: new("good-for-ai")}}},
+			})
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	issues, err := gh.ListLabeledIssues(context.Background(), "owner", "repo", "good-for-ai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 2 || issues[0].Number != 1 || issues[1].Number != 2 {
+		t.Fatalf("expected issues [1 2] across pages, got %+v", issues)
+	}
+}
+
+func TestGetCheckRuns_Paginates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/commits/abc123/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode(&github.ListCheckRunsResults{
+				Total:     new(int(2)),
+				CheckRuns: []*github.CheckRun{{ID: new(int64(1)), Name: new("test-a"), Status: new("completed"), Conclusion: new("failure")}},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(&github.ListCheckRunsResults{
+				Total:     new(int(2)),
+				CheckRuns: []*github.CheckRun{{ID: new(int64(2)), Name: new("test-b"), Status: new("completed"), Conclusion: new("success")}},
+			})
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	runs, err := gh.GetCheckRuns(context.Background(), "owner", "repo", "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runs) != 2 || runs[0].Name != "test-a" || runs[1].Name != "test-b" {
+		t.Fatalf("expected check runs [test-a test-b] across pages, got %+v", runs)
+	}
+}
+
+func TestGetPRReviews_Paginates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/7/reviews", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequestReview{
+				{ID: new(int64(10)), User: &github.User{Login: new("alice")}, State: new("CHANGES_REQUESTED"), Body: new("fix this")},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode([]*github.PullRequestReview{
+				{ID: new(int64(20)), User: &github.User{Login: new("bob")}, State: new("COMMENTED"), Body: new("and this")},
+			})
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	reviews, err := gh.GetPRReviews(context.Background(), "owner", "repo", 7, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reviews) != 2 || reviews[0].ID != 10 || reviews[1].ID != 20 {
+		t.Fatalf("expected reviews [10 20] across pages, got %+v", reviews)
+	}
+}
+
+func TestListWorkflowJobs_Paginates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/actions/runs/99/jobs", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode(&github.Jobs{
+				TotalCount: new(int(2)),
+				Jobs:       []*github.WorkflowJob{{ID: new(int64(1)), Name: new("build"), Conclusion: new("failure")}},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(&github.Jobs{
+				TotalCount: new(int(2)),
+				Jobs:       []*github.WorkflowJob{{ID: new(int64(2)), Name: new("test"), Conclusion: new("success")}},
+			})
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	jobs, err := gh.ListWorkflowJobs(context.Background(), "owner", "repo", 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(jobs) != 2 || jobs[0].Name != "build" || jobs[1].Name != "test" {
+		t.Fatalf("expected jobs [build test] across pages, got %+v", jobs)
+	}
+}
+
+func TestHasPRCommentReaction_FindsReactionOnLaterPage(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/pulls/comments/55/reactions", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		if page == "" || page == "1" {
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+			_ = json.NewEncoder(w).Encode([]*github.Reaction{
+				{Content: new("+1"), User: &github.User{Login: new("alice")}},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode([]*github.Reaction{
+				{Content: new("eyes"), User: &github.User{Login: new("test-bot")}},
+			})
+		}
+	})
+
+	gh := setupTestClient(t, mux)
+	found, err := gh.HasPRCommentReaction(context.Background(), "owner", "repo", 55, "eyes", "test-bot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected reaction on page 2 to be found")
+	}
+}
+
+// TestTailBuffer covers the bounded log reader added for issue #282: only
+// the last maxBytes of a stream are retained regardless of input size or
+// write chunking, with the truncation marker and rune-boundary handling of
+// the former whole-string truncation preserved.
+func TestTailBuffer(t *testing.T) {
+	tests := []struct {
+		name   string
+		max    int
+		writes []string
+		want   string
+	}{
+		{
+			name:   "under capacity returns input unchanged",
+			max:    10,
+			writes: []string{"hello"},
+			want:   "hello",
+		},
+		{
+			name:   "exactly at capacity returns input unchanged",
+			max:    5,
+			writes: []string{"hello"},
+			want:   "hello",
+		},
+		{
+			name:   "single oversized write keeps the tail",
+			max:    4,
+			writes: []string{"0123456789"},
+			want:   "...(truncated)...\n6789",
+		},
+		{
+			name:   "sliding window across many small writes",
+			max:    6,
+			writes: []string{"aa", "bb", "cc", "dd", "ee"},
+			want:   "...(truncated)...\nccddee",
+		},
+		{
+			name:   "write larger than remaining space slides partially",
+			max:    8,
+			writes: []string{"abcd", "efghij"},
+			want:   "...(truncated)...\ncdefghij",
+		},
+		{
+			name: "cut advances past a split multibyte rune",
+			max:  4,
+			// "xhéllo" ends in é(2 bytes) l l o — keeping the last 4 bytes
+			// cuts é in half; the boundary walk drops the orphaned
+			// continuation byte.
+			writes: []string{"xhéllo"},
+			want:   "...(truncated)...\nllo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tb := newTailBuffer(tt.max)
+			for _, w := range tt.writes {
+				n, err := tb.Write([]byte(w))
+				if err != nil || n != len(w) {
+					t.Fatalf("Write(%q) = (%d, %v), want (%d, nil)", w, n, err, len(w))
+				}
+			}
+			if got := tb.tailString(); got != tt.want {
+				t.Errorf("tailString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCheckRunLog_BoundsLargeLogs(t *testing.T) {
+	// Serve a log much larger than maxCILogBytes in multiple chunks and
+	// verify only the tail is returned, with the truncation marker.
+	// The API endpoint answers with a redirect to blob storage, as GitHub
+	// does; go-github follows it and hands back the storage response.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/actions/jobs/7/logs", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+r.Host+"/blob/logs", http.StatusFound)
+	})
+	mux.HandleFunc("/blob/logs", func(w http.ResponseWriter, r *http.Request) {
+		for i := range 3 {
+			line := strings.Repeat(fmt.Sprintf("chunk%d ", i), maxCILogBytes/7)
+			_, _ = w.Write([]byte(line))
+		}
+		_, _ = w.Write([]byte("THE END"))
+	})
+
+	gh := setupTestClient(t, mux)
+	log, err := gh.GetCheckRunLog(context.Background(), "owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(log, "...(truncated)...\n") {
+		t.Errorf("expected truncation marker prefix, got %q", log[:40])
+	}
+	if !strings.HasSuffix(log, "THE END") {
+		t.Errorf("expected log to end with the stream tail, got %q", log[len(log)-40:])
+	}
+	if len(log) > maxCILogBytes+len("...(truncated)...\n") {
+		t.Errorf("log length %d exceeds bound %d", len(log), maxCILogBytes+len("...(truncated)...\n"))
+	}
+}
+
+func TestGetCheckRunLog_RejectsExpiredStorageURL(t *testing.T) {
+	// A pre-signed storage URL that has expired answers 403 with an XML
+	// error document — that must surface as an error, not as log content.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/owner/repo/actions/jobs/8/logs", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+r.Host+"/blob/expired", http.StatusFound)
+	})
+	mux.HandleFunc("/blob/expired", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<Error><Code>AuthenticationFailed</Code></Error>"))
+	})
+
+	gh := setupTestClient(t, mux)
+	_, err := gh.GetCheckRunLog(context.Background(), "owner", "repo", 8)
+	if err == nil {
+		t.Fatal("expected error for expired storage URL")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected error to mention the status, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements the two follow-ups filed from the #280 review — and fixes a log-fetching regression that writing the new tests exposed.

## Changes

**Pagination (#281)**
- `ListLabeledIssues`, `GetCheckRuns`, `GetPRReviews`, `ListWorkflowJobs`, and `HasPRCommentReaction` now walk `resp.NextPage` with `PerPage: 100`, using the same loop pattern as the already-paginated methods in the file. The reaction scan short-circuits as soon as the reaction is found. Previously each returned only the first page, silently dropping the rest for that cycle.

**Bounded log memory (#282)**
- `fetchJobLogTail` streams the response through a fixed-size `tailBuffer` (an `io.Writer` retaining only the last `maxCILogBytes` via a sliding window over one fixed allocation), so memory stays bounded regardless of log size. The truncation marker and rune-boundary cut are preserved; the whole-string `truncateLogTail` is retired.

**Log-fetch correctness (found by the new tests)**
- The HTTP-level test for the tail path exposed that #280's consolidation misread go-github's semantics: the jobs-logs API answers **302 with a pre-signed storage URL**, and `GetWorkflowJobLogs` returns that URL *without downloading content* (it follows only intermediate 301s; the 302 body is closed and empty). Consequences: `GetCheckRunLog` had been reading an empty body since before the extraction, and the status check added in #280 turned every log fetch into an `unexpected status 302` error. `fetchJobLogTail` now fetches the pre-signed URL with a plain client (deliberately without the API auth header, which pre-signed URLs reject), requires 200, and streams into the tail buffer.

## Testing

- New HTTP-level tests: pagination across `Link` headers for all five endpoints; `tailBuffer` windowing table (under/exact/oversized/sliding/rune-boundary); a multi-chunk oversized log through the 302→storage flow asserting marker, tail content, and size bound; an expired storage URL (403) surfacing as an error instead of log content.
- `go build ./...`, `go test ./... -count=1 -race`, `golangci-lint run` — all green.

## Related Issues

Fixes #281
Fixes #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub issue, check run, review, reaction, and workflow job results now include all available pages.
  * Large CI logs are handled more efficiently while preserving the most recent output and indicating when content was truncated.
  * Expired or inaccessible CI log downloads now return clear errors.
  * Review entries with empty content are excluded, and check run details include available output and completion information.

* **Tests**
  * Added coverage for pagination, large-log handling, Unicode-safe truncation, and expired log URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->